### PR TITLE
Issue16

### DIFF
--- a/domain/refresh_token.go
+++ b/domain/refresh_token.go
@@ -8,9 +8,9 @@ import (
 
 // Refresh token constants.
 const (
-	RefreshTokenPrefix     = "zid_rt"
-	RefreshTokenByteLength = 32
-	RefreshTokenTTLDays    = 90
+	RefreshTokenPrefix       = "zid_rt"
+	RefreshTokenByteLength   = 32
+	RefreshTokenTTLDays      = 90
 	RefreshTokenStateActive  = "active"
 	RefreshTokenStateRevoked = "revoked"
 

--- a/domain/refresh_token.go
+++ b/domain/refresh_token.go
@@ -13,6 +13,13 @@ const (
 	RefreshTokenTTLDays    = 90
 	RefreshTokenStateActive  = "active"
 	RefreshTokenStateRevoked = "revoked"
+
+	// RefreshTokenReuseGraceWindow is how long after a token is revoked that a
+	// subsequent presentation is treated as a concurrent retry rather than a
+	// replay attack. Within this window, family revocation is suppressed so
+	// legitimate multi-tab or network-retry scenarios don't kill the session.
+	// Outside the window, reuse detection fires as normal (RFC 6749 §10.4).
+	RefreshTokenReuseGraceWindow = 10 * time.Second
 )
 
 // RefreshToken is the Bun model for the refresh_tokens table.

--- a/internal/service/refresh_token.go
+++ b/internal/service/refresh_token.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
-	"github.com/uptrace/bun"
 
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
@@ -20,12 +21,11 @@ import (
 // RefreshTokenService handles refresh token issuance and rotation.
 type RefreshTokenService struct {
 	repo *postgres.RefreshTokenRepository
-	db   *bun.DB
 }
 
 // NewRefreshTokenService creates a new refresh token service.
-func NewRefreshTokenService(repo *postgres.RefreshTokenRepository, db *bun.DB) *RefreshTokenService {
-	return &RefreshTokenService{repo: repo, db: db}
+func NewRefreshTokenService(repo *postgres.RefreshTokenRepository) *RefreshTokenService {
+	return &RefreshTokenService{repo: repo}
 }
 
 // RefreshTokenParams contains the data needed to issue a refresh token.
@@ -91,97 +91,98 @@ func (s *RefreshTokenService) IssueRefreshToken(ctx context.Context, params *Ref
 
 // RotateRefreshToken validates the presented token, revokes it, and issues a new one.
 // Implements reuse detection: if a revoked token is presented, the entire family is revoked.
-// Wrapped in a serializable transaction to prevent race conditions where two concurrent
-// calls with the same token both succeed and issue duplicate tokens.
+//
+// Atomicity: the claim-and-revoke step is a single UPDATE ... WHERE state='active'
+// RETURNING in postgres/refresh_token.go. Postgres row-level locking guarantees
+// that exactly one concurrent caller wins, so two rotations racing on the same
+// input cannot both produce successor tokens.
 func (s *RefreshTokenService) RotateRefreshToken(ctx context.Context, rawToken string, ttl int) (*domain.RefreshToken, *RefreshTokenResult, error) {
 	tokenHash := hashRefreshToken(rawToken)
 
-	var existing *domain.RefreshToken
-	var result *RefreshTokenResult
-
-	err := s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		var err error
-
-		// First check if this token exists at all (including revoked) for reuse detection.
-		existing, err = s.repo.GetByTokenHashIncludingRevoked(ctx, tokenHash)
-		if err != nil {
-			return fmt.Errorf("refresh token not found: %w", err)
-		}
-
-		// Reuse detection: if the token was already revoked, someone is replaying it.
-		// Revoke the entire family as a security measure.
-		if existing.State == domain.RefreshTokenStateRevoked {
-			count, revokeErr := s.repo.RevokeFamily(ctx, existing.FamilyID)
-
-			log.Warn().
-				Str("family_id", existing.FamilyID).
-				Str("user_id", existing.UserID).
-				Str("client_id", existing.ClientID).
-				Int64("revoked_count", count).
-				Err(revokeErr).
-				Msg("Refresh token reuse detected — entire family revoked")
-
-			return fmt.Errorf("refresh token reuse detected — family revoked")
-		}
-
-		// Check expiry.
-		if time.Now().After(existing.ExpiresAt) {
-			return fmt.Errorf("refresh token expired")
-		}
-
-		// Revoke the current token (single-use rotation).
-		if err := s.repo.RevokeByID(ctx, existing.ID); err != nil {
-			return fmt.Errorf("failed to revoke old refresh token: %w", err)
-		}
-
-		// Issue a new token in the same family.
-		newRawToken, err := generateRefreshToken()
-		if err != nil {
-			return fmt.Errorf("failed to generate new refresh token: %w", err)
-		}
-
-		newTokenHash := hashRefreshToken(newRawToken)
-
-		var rotationTTL time.Duration
-		if ttl > 0 {
-			rotationTTL = time.Duration(ttl) * time.Second
-		} else {
-			rotationTTL = time.Duration(domain.RefreshTokenTTLDays) * 24 * time.Hour
-		}
-
-		expiresAt := time.Now().Add(rotationTTL)
-
-		newRecord := &domain.RefreshToken{
-			TokenHash:  newTokenHash,
-			ClientID:   existing.ClientID,
-			AccountID:  existing.AccountID,
-			ProjectID:  existing.ProjectID,
-			UserID:     existing.UserID,
-			IdentityID: existing.IdentityID,
-			Scopes:     existing.Scopes,
-			FamilyID:   existing.FamilyID, // Same family — rotation chain.
-			State:      domain.RefreshTokenStateActive,
-			ExpiresAt:  expiresAt,
-		}
-
-		if err := s.repo.Create(ctx, newRecord); err != nil {
-			return fmt.Errorf("failed to store new refresh token: %w", err)
-		}
-
-		result = &RefreshTokenResult{
-			RawToken:  newRawToken,
-			FamilyID:  existing.FamilyID,
-			ExpiresAt: expiresAt,
-		}
-
-		return nil
-	})
-
+	// Atomic claim: revokes the token iff it is currently active and non-expired,
+	// returning the row on success.
+	claimed, err := s.repo.ClaimByTokenHash(ctx, tokenHash)
 	if err != nil {
-		return nil, nil, err
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, s.handleFailedClaim(ctx, tokenHash)
+		}
+		return nil, nil, fmt.Errorf("failed to claim refresh token: %w", err)
 	}
 
-	return existing, result, nil
+	newRawToken, err := generateRefreshToken()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate new refresh token: %w", err)
+	}
+
+	newTokenHash := hashRefreshToken(newRawToken)
+
+	var rotationTTL time.Duration
+	if ttl > 0 {
+		rotationTTL = time.Duration(ttl) * time.Second
+	} else {
+		rotationTTL = time.Duration(domain.RefreshTokenTTLDays) * 24 * time.Hour
+	}
+
+	expiresAt := time.Now().Add(rotationTTL)
+
+	newRecord := &domain.RefreshToken{
+		TokenHash:  newTokenHash,
+		ClientID:   claimed.ClientID,
+		AccountID:  claimed.AccountID,
+		ProjectID:  claimed.ProjectID,
+		UserID:     claimed.UserID,
+		IdentityID: claimed.IdentityID,
+		Scopes:     claimed.Scopes,
+		FamilyID:   claimed.FamilyID, // Same family — rotation chain.
+		State:      domain.RefreshTokenStateActive,
+		ExpiresAt:  expiresAt,
+	}
+
+	if err := s.repo.Create(ctx, newRecord); err != nil {
+		return nil, nil, fmt.Errorf("failed to store new refresh token: %w", err)
+	}
+
+	return claimed, &RefreshTokenResult{
+		RawToken:  newRawToken,
+		FamilyID:  claimed.FamilyID,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// handleFailedClaim runs when ClaimByTokenHash found no matching active,
+// non-expired row. It disambiguates between reuse (revoked → trigger family
+// revocation), expired, and not-found, returning the appropriate error.
+func (s *RefreshTokenService) handleFailedClaim(ctx context.Context, tokenHash string) error {
+	existing, err := s.repo.GetByTokenHashIncludingRevoked(ctx, tokenHash)
+	if err != nil {
+		return fmt.Errorf("refresh token not found: %w", err)
+	}
+
+	if existing.State == domain.RefreshTokenStateRevoked {
+		count, revokeErr := s.repo.RevokeFamily(ctx, existing.FamilyID)
+		log.Warn().
+			Str("family_id", existing.FamilyID).
+			Str("user_id", existing.UserID).
+			Str("client_id", existing.ClientID).
+			Int64("revoked_count", count).
+			Err(revokeErr).
+			Msg("Refresh token reuse detected — entire family revoked")
+		return fmt.Errorf("refresh token reuse detected — family revoked")
+	}
+
+	if time.Now().After(existing.ExpiresAt) {
+		return fmt.Errorf("refresh token expired")
+	}
+
+	// Should be unreachable: state is active and not expired, but ClaimByTokenHash
+	// returned no row. Indicates clock skew or a concurrent state transition we
+	// did not anticipate. Log loudly.
+	log.Error().
+		Str("family_id", existing.FamilyID).
+		Str("state", existing.State).
+		Time("expires_at", existing.ExpiresAt).
+		Msg("Refresh token claim failed but lookup shows active non-expired token")
+	return fmt.Errorf("refresh token in unexpected state")
 }
 
 // RevokeFamily revokes all active tokens in a refresh token family.

--- a/internal/service/refresh_token.go
+++ b/internal/service/refresh_token.go
@@ -171,6 +171,24 @@ func (s *RefreshTokenService) handleFailedClaim(ctx context.Context, tokenHash s
 	}
 
 	if existing.State == domain.RefreshTokenStateRevoked {
+		// Grace period: if the token was revoked very recently, treat the
+		// second presentation as a concurrent retry (multiple tabs, a client
+		// retry loop, a load balancer replay) rather than a replay attack.
+		// The concurrent request gets a benign error but the freshly issued
+		// successor — and therefore the user's session — survives.
+		//
+		// Outside the window, this is a genuine reuse signal (RFC 6749 §10.4)
+		// and the whole family is revoked.
+		if existing.RevokedAt != nil && time.Since(*existing.RevokedAt) < domain.RefreshTokenReuseGraceWindow {
+			log.Info().
+				Str("family_id", existing.FamilyID).
+				Str("user_id", existing.UserID).
+				Str("client_id", existing.ClientID).
+				Dur("age", time.Since(*existing.RevokedAt)).
+				Msg("Refresh token presented within reuse grace window — treating as concurrent retry")
+			return fmt.Errorf("refresh token already rotated")
+		}
+
 		count, revokeErr := s.repo.RevokeFamily(ctx, existing.FamilyID)
 		log.Warn().
 			Str("family_id", existing.FamilyID).

--- a/internal/service/refresh_token.go
+++ b/internal/service/refresh_token.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/uptrace/bun"
 
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
@@ -21,11 +22,15 @@ import (
 // RefreshTokenService handles refresh token issuance and rotation.
 type RefreshTokenService struct {
 	repo *postgres.RefreshTokenRepository
+	// db is needed to wrap claim+insert in a transaction during rotation so a
+	// failed successor insert rolls back the claim, avoiding spurious reuse
+	// detection on a client retry after a transient DB error.
+	db *bun.DB
 }
 
 // NewRefreshTokenService creates a new refresh token service.
-func NewRefreshTokenService(repo *postgres.RefreshTokenRepository) *RefreshTokenService {
-	return &RefreshTokenService{repo: repo}
+func NewRefreshTokenService(repo *postgres.RefreshTokenRepository, db *bun.DB) *RefreshTokenService {
+	return &RefreshTokenService{repo: repo, db: db}
 }
 
 // RefreshTokenParams contains the data needed to issue a refresh token.
@@ -78,7 +83,7 @@ func (s *RefreshTokenService) IssueRefreshToken(ctx context.Context, params *Ref
 		ExpiresAt:  expiresAt,
 	}
 
-	if err := s.repo.Create(ctx, record); err != nil {
+	if err := s.repo.Create(ctx, s.db, record); err != nil {
 		return nil, fmt.Errorf("failed to store refresh token: %w", err)
 	}
 
@@ -92,28 +97,24 @@ func (s *RefreshTokenService) IssueRefreshToken(ctx context.Context, params *Ref
 // RotateRefreshToken validates the presented token, revokes it, and issues a new one.
 // Implements reuse detection: if a revoked token is presented, the entire family is revoked.
 //
-// Atomicity: the claim-and-revoke step is a single UPDATE ... WHERE state='active'
-// RETURNING in postgres/refresh_token.go. Postgres row-level locking guarantees
-// that exactly one concurrent caller wins, so two rotations racing on the same
-// input cannot both produce successor tokens.
+// Atomicity has two layers:
+//  1. Concurrent rotations on the same token: the claim-and-revoke step is a
+//     single UPDATE ... WHERE state='active' RETURNING. Postgres row-level
+//     locking guarantees exactly one concurrent caller wins, so two rotations
+//     racing on the same input cannot both produce successor tokens.
+//  2. Claim + successor insert: both run inside a single transaction. If the
+//     insert fails (transient DB error, disk, etc.), the claim rolls back and
+//     the original token remains active. Without this, a failed insert would
+//     leave the original token revoked with no successor, and the client's
+//     retry would trip reuse detection and nuke the whole family — turning a
+//     transient glitch into a forced re-auth across all sessions.
 func (s *RefreshTokenService) RotateRefreshToken(ctx context.Context, rawToken string, ttl int) (*domain.RefreshToken, *RefreshTokenResult, error) {
 	tokenHash := hashRefreshToken(rawToken)
-
-	// Atomic claim: revokes the token iff it is currently active and non-expired,
-	// returning the row on success.
-	claimed, err := s.repo.ClaimByTokenHash(ctx, tokenHash)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil, s.handleFailedClaim(ctx, tokenHash)
-		}
-		return nil, nil, fmt.Errorf("failed to claim refresh token: %w", err)
-	}
 
 	newRawToken, err := generateRefreshToken()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate new refresh token: %w", err)
 	}
-
 	newTokenHash := hashRefreshToken(newRawToken)
 
 	var rotationTTL time.Duration
@@ -122,24 +123,35 @@ func (s *RefreshTokenService) RotateRefreshToken(ctx context.Context, rawToken s
 	} else {
 		rotationTTL = time.Duration(domain.RefreshTokenTTLDays) * 24 * time.Hour
 	}
-
 	expiresAt := time.Now().Add(rotationTTL)
 
-	newRecord := &domain.RefreshToken{
-		TokenHash:  newTokenHash,
-		ClientID:   claimed.ClientID,
-		AccountID:  claimed.AccountID,
-		ProjectID:  claimed.ProjectID,
-		UserID:     claimed.UserID,
-		IdentityID: claimed.IdentityID,
-		Scopes:     claimed.Scopes,
-		FamilyID:   claimed.FamilyID, // Same family — rotation chain.
-		State:      domain.RefreshTokenStateActive,
-		ExpiresAt:  expiresAt,
-	}
+	var claimed *domain.RefreshToken
+	txErr := s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		c, err := s.repo.ClaimByTokenHash(ctx, tx, tokenHash)
+		if err != nil {
+			return err
+		}
+		claimed = c
 
-	if err := s.repo.Create(ctx, newRecord); err != nil {
-		return nil, nil, fmt.Errorf("failed to store new refresh token: %w", err)
+		successor := &domain.RefreshToken{
+			TokenHash:  newTokenHash,
+			ClientID:   c.ClientID,
+			AccountID:  c.AccountID,
+			ProjectID:  c.ProjectID,
+			UserID:     c.UserID,
+			IdentityID: c.IdentityID,
+			Scopes:     c.Scopes,
+			FamilyID:   c.FamilyID, // Same family — rotation chain.
+			State:      domain.RefreshTokenStateActive,
+			ExpiresAt:  expiresAt,
+		}
+		return s.repo.Create(ctx, tx, successor)
+	})
+	if txErr != nil {
+		if errors.Is(txErr, sql.ErrNoRows) {
+			return nil, nil, s.handleFailedClaim(ctx, tokenHash)
+		}
+		return nil, nil, fmt.Errorf("refresh token rotation failed: %w", txErr)
 	}
 
 	return claimed, &RefreshTokenResult{

--- a/internal/service/refresh_token.go
+++ b/internal/service/refresh_token.go
@@ -46,8 +46,8 @@ type RefreshTokenParams struct {
 
 // RefreshTokenResult contains both the raw token (returned to client) and stored metadata.
 type RefreshTokenResult struct {
-	RawToken  string    // Returned to client once — never stored.
-	FamilyID  string    // For audit/debugging.
+	RawToken  string // Returned to client once — never stored.
+	FamilyID  string // For audit/debugging.
 	ExpiresAt time.Time
 }
 
@@ -60,15 +60,7 @@ func (s *RefreshTokenService) IssueRefreshToken(ctx context.Context, params *Ref
 
 	tokenHash := hashRefreshToken(rawToken)
 	familyID := uuid.New().String()
-
-	var ttl time.Duration
-	if params.TTL > 0 {
-		ttl = time.Duration(params.TTL) * time.Second
-	} else {
-		ttl = time.Duration(domain.RefreshTokenTTLDays) * 24 * time.Hour
-	}
-
-	expiresAt := time.Now().Add(ttl)
+	expiresAt := time.Now().Add(refreshTokenTTL(params.TTL))
 
 	record := &domain.RefreshToken{
 		TokenHash:  tokenHash,
@@ -116,14 +108,7 @@ func (s *RefreshTokenService) RotateRefreshToken(ctx context.Context, rawToken s
 		return nil, nil, fmt.Errorf("failed to generate new refresh token: %w", err)
 	}
 	newTokenHash := hashRefreshToken(newRawToken)
-
-	var rotationTTL time.Duration
-	if ttl > 0 {
-		rotationTTL = time.Duration(ttl) * time.Second
-	} else {
-		rotationTTL = time.Duration(domain.RefreshTokenTTLDays) * 24 * time.Hour
-	}
-	expiresAt := time.Now().Add(rotationTTL)
+	expiresAt := time.Now().Add(refreshTokenTTL(ttl))
 
 	var claimed *domain.RefreshToken
 	txErr := s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
@@ -162,8 +147,15 @@ func (s *RefreshTokenService) RotateRefreshToken(ctx context.Context, rawToken s
 }
 
 // handleFailedClaim runs when ClaimByTokenHash found no matching active,
-// non-expired row. It disambiguates between reuse (revoked → trigger family
-// revocation), expired, and not-found, returning the appropriate error.
+// non-expired row. It disambiguates among four possibilities:
+//
+//  1. Revoked within the reuse grace window — treated as a legitimate concurrent
+//     retry. Returns "already rotated" without revoking the family.
+//  2. Revoked outside the grace window — genuine RFC 6749 §10.4 reuse signal.
+//     Revokes the entire family and returns "reuse detected".
+//  3. Expired — normal TTL expiry. Returns "expired".
+//  4. Should-be-unreachable state (active and non-expired but claim still
+//     missed). Logs at Error level and returns a generic error.
 func (s *RefreshTokenService) handleFailedClaim(ctx context.Context, tokenHash string) error {
 	existing, err := s.repo.GetByTokenHashIncludingRevoked(ctx, tokenHash)
 	if err != nil {
@@ -219,6 +211,15 @@ func (s *RefreshTokenService) handleFailedClaim(ctx context.Context, tokenHash s
 // Used during auth code replay detection per RFC 6749 §4.1.2.
 func (s *RefreshTokenService) RevokeFamily(ctx context.Context, familyID string) (int64, error) {
 	return s.repo.RevokeFamily(ctx, familyID)
+}
+
+// refreshTokenTTL resolves the effective token lifetime: a positive
+// ttlSeconds overrides the default; zero falls back to RefreshTokenTTLDays.
+func refreshTokenTTL(ttlSeconds int) time.Duration {
+	if ttlSeconds > 0 {
+		return time.Duration(ttlSeconds) * time.Second
+	}
+	return time.Duration(domain.RefreshTokenTTLDays) * 24 * time.Hour
 }
 
 // generateRefreshToken creates a cryptographically random refresh token.

--- a/internal/store/postgres/refresh_token.go
+++ b/internal/store/postgres/refresh_token.go
@@ -90,10 +90,7 @@ func (r *RefreshTokenRepository) ClaimByTokenHash(ctx context.Context, tokenHash
 		return nil, fmt.Errorf("failed to claim refresh token: %w", err)
 	}
 
-	n, err := res.RowsAffected()
-	if err != nil {
-		return nil, fmt.Errorf("failed to check claim result: %w", err)
-	}
+	n, _ := res.RowsAffected()
 	if n == 0 {
 		return nil, sql.ErrNoRows
 	}

--- a/internal/store/postgres/refresh_token.go
+++ b/internal/store/postgres/refresh_token.go
@@ -97,7 +97,10 @@ func (r *RefreshTokenRepository) ClaimByTokenHash(ctx context.Context, db bun.ID
 		return nil, fmt.Errorf("failed to claim refresh token: %w", err)
 	}
 
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check claim result: %w", err)
+	}
 	if n == 0 {
 		return nil, sql.ErrNoRows
 	}
@@ -120,7 +123,10 @@ func (r *RefreshTokenRepository) RevokeFamily(ctx context.Context, familyID stri
 		return 0, fmt.Errorf("failed to revoke refresh token family: %w", err)
 	}
 
-	count, _ := res.RowsAffected()
+	count, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to check family revocation result: %w", err)
+	}
 
 	return count, nil
 }

--- a/internal/store/postgres/refresh_token.go
+++ b/internal/store/postgres/refresh_token.go
@@ -21,9 +21,11 @@ func NewRefreshTokenRepository(db *bun.DB) *RefreshTokenRepository {
 	return &RefreshTokenRepository{db: db}
 }
 
-// Create inserts a new refresh token record.
-func (r *RefreshTokenRepository) Create(ctx context.Context, token *domain.RefreshToken) error {
-	_, err := r.db.NewInsert().Model(token).Exec(ctx)
+// Create inserts a new refresh token record. Accepts a bun.IDB so the caller
+// can pass either the DB pool (for standalone inserts) or a transaction (when
+// the insert must roll back with a related operation, e.g., rotation).
+func (r *RefreshTokenRepository) Create(ctx context.Context, db bun.IDB, token *domain.RefreshToken) error {
+	_, err := db.NewInsert().Model(token).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create refresh token: %w", err)
 	}
@@ -70,14 +72,19 @@ func (r *RefreshTokenRepository) GetByTokenHashIncludingRevoked(ctx context.Cont
 // two concurrent rotations to both issue successor tokens from a single input
 // (RFC 6749 §6).
 //
+// Accepts a bun.IDB so callers that pair the claim with a successor insert can
+// run both inside a single transaction. If the successor insert fails, the
+// transaction rollback restores the claimed row to active, avoiding spurious
+// reuse detection on a client retry after a transient DB error.
+//
 // Returns sql.ErrNoRows if no active non-expired token matches. Callers should
 // then look up the token including revoked state to distinguish expired/missing
 // from replay of an already-revoked token.
-func (r *RefreshTokenRepository) ClaimByTokenHash(ctx context.Context, tokenHash string) (*domain.RefreshToken, error) {
+func (r *RefreshTokenRepository) ClaimByTokenHash(ctx context.Context, db bun.IDB, tokenHash string) (*domain.RefreshToken, error) {
 	token := new(domain.RefreshToken)
 	now := time.Now()
 
-	res, err := r.db.NewUpdate().
+	res, err := db.NewUpdate().
 		Model(token).
 		Set("state = ?", domain.RefreshTokenStateRevoked).
 		Set("revoked_at = ?", now).

--- a/internal/store/postgres/refresh_token.go
+++ b/internal/store/postgres/refresh_token.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -63,22 +64,41 @@ func (r *RefreshTokenRepository) GetByTokenHashIncludingRevoked(ctx context.Cont
 	return token, nil
 }
 
-// RevokeByID marks a single refresh token as revoked.
-func (r *RefreshTokenRepository) RevokeByID(ctx context.Context, id string) error {
+// ClaimByTokenHash atomically revokes and returns an active, non-expired
+// refresh token matching the given hash. Postgres row-level locking ensures
+// exactly one concurrent caller wins — closing the rotation race that allowed
+// two concurrent rotations to both issue successor tokens from a single input
+// (RFC 6749 §6).
+//
+// Returns sql.ErrNoRows if no active non-expired token matches. Callers should
+// then look up the token including revoked state to distinguish expired/missing
+// from replay of an already-revoked token.
+func (r *RefreshTokenRepository) ClaimByTokenHash(ctx context.Context, tokenHash string) (*domain.RefreshToken, error) {
+	token := new(domain.RefreshToken)
 	now := time.Now()
 
-	_, err := r.db.NewUpdate().
-		Model((*domain.RefreshToken)(nil)).
+	res, err := r.db.NewUpdate().
+		Model(token).
 		Set("state = ?", domain.RefreshTokenStateRevoked).
 		Set("revoked_at = ?", now).
-		Where("id = ?", id).
+		Where("token_hash = ?", tokenHash).
 		Where("state = ?", domain.RefreshTokenStateActive).
+		Where("expires_at > ?", now).
+		Returning("*").
 		Exec(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to revoke refresh token: %w", err)
+		return nil, fmt.Errorf("failed to claim refresh token: %w", err)
 	}
 
-	return nil
+	n, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check claim result: %w", err)
+	}
+	if n == 0 {
+		return nil, sql.ErrNoRows
+	}
+
+	return token, nil
 }
 
 // RevokeFamily revokes all active tokens in a family (reuse detection response).

--- a/server.go
+++ b/server.go
@@ -154,7 +154,7 @@ func NewServer(cfg Config) (*Server, error) {
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)
 	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo)
-	refreshTokenSvc := service.NewRefreshTokenService(refreshTokenRepo, db)
+	refreshTokenSvc := service.NewRefreshTokenService(refreshTokenRepo)
 	authCodeIssuer := cfg.Token.AuthCodeIssuer
 	if authCodeIssuer == "" {
 		authCodeIssuer = cfg.Token.Issuer

--- a/server.go
+++ b/server.go
@@ -154,7 +154,7 @@ func NewServer(cfg Config) (*Server, error) {
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)
 	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo)
-	refreshTokenSvc := service.NewRefreshTokenService(refreshTokenRepo)
+	refreshTokenSvc := service.NewRefreshTokenService(refreshTokenRepo, db)
 	authCodeIssuer := cfg.Token.AuthCodeIssuer
 	if authCodeIssuer == "" {
 		authCodeIssuer = cfg.Token.Issuer

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -19,10 +19,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"strings"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -31,6 +32,9 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+	"github.com/uptrace/bun/driver/pgdriver"
 
 	zeroid "github.com/highflame-ai/zeroid"
 )
@@ -65,6 +69,11 @@ var testZeroIDServer *zeroid.Server
 // testServerPrivKey is the server's ECDSA signing key, accessible so tests can
 // build valid assertions without going through disk files.
 var testServerPrivKey *ecdsa.PrivateKey
+
+// testDB is a bun.DB handle connected to the same postgres container the server
+// uses. Exposed so tests can exercise repository-level transactional semantics
+// directly, bypassing the HTTP surface.
+var testDB *bun.DB
 
 func TestMain(m *testing.M) {
 	os.Exit(runTests(m))
@@ -172,6 +181,12 @@ func runTests(m *testing.M) int {
 	testZeroIDServer = srv
 	testServer = httptest.NewServer(srv.Router())
 	defer testServer.Close()
+
+	// Open a separate bun.DB handle for tests that need direct repo access.
+	// Uses the same connection string the server is wired to.
+	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dbURL)))
+	testDB = bun.NewDB(sqldb, pgdialect.New())
+	defer testDB.Close() //nolint:errcheck
 
 	// Register the CLI and MCP test clients in the oauth_clients table.
 	// These are public PKCE clients — no client_secret, no linked identity.

--- a/tests/integration/refresh_token_race_test.go
+++ b/tests/integration/refresh_token_race_test.go
@@ -48,11 +48,11 @@ func TestRefreshTokenConcurrentRotation(t *testing.T) {
 	require.NotEmpty(t, refreshToken)
 
 	var (
-		successes    int32
-		failures     int32
-		winnerTokMu  sync.Mutex
-		winnerTok    string
-		wg           sync.WaitGroup
+		successes   int32
+		failures    int32
+		winnerTokMu sync.Mutex
+		winnerTok   string
+		wg          sync.WaitGroup
 	)
 	start := make(chan struct{})
 

--- a/tests/integration/refresh_token_race_test.go
+++ b/tests/integration/refresh_token_race_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -19,18 +20,19 @@ import (
 )
 
 // TestRefreshTokenConcurrentRotation closes the RFC 6749 §6 rotation race:
-// two concurrent POSTs with the same refresh token must not both issue a
-// successor. Exactly one request wins and receives a new token; the rest are
-// rejected with invalid_grant.
+// concurrent POSTs with the same refresh token must not both issue a successor.
+// Exactly one request wins; the rest are rejected. Additionally, the winner's
+// new refresh token MUST survive the race — late-arriving sibling requests
+// that see the original as "revoked" must not trip family revocation against
+// the fresh successor (handled via the reuse grace window).
 //
 // Before the fix, the read-check-revoke sequence ran under READ COMMITTED
-// (despite the comment claiming "serializable"), so both rotations passed the
+// (despite a comment claiming "serializable"), so both rotations passed the
 // active check before either committed the revocation — both then minted new
 // tokens, bypassing reuse detection entirely.
 func TestRefreshTokenConcurrentRotation(t *testing.T) {
 	const concurrency = 10
 
-	// Acquire a single refresh token via the authorization_code flow.
 	verifier, challenge := buildPKCEPair(t)
 	code := buildAuthCode(t, testMCPClientID, "user-race-001", testRedirectURI, challenge, []string{"data:read"})
 
@@ -46,9 +48,11 @@ func TestRefreshTokenConcurrentRotation(t *testing.T) {
 	require.NotEmpty(t, refreshToken)
 
 	var (
-		successes int32
-		failures  int32
-		wg        sync.WaitGroup
+		successes    int32
+		failures     int32
+		winnerTokMu  sync.Mutex
+		winnerTok    string
+		wg           sync.WaitGroup
 	)
 	start := make(chan struct{})
 
@@ -57,33 +61,50 @@ func TestRefreshTokenConcurrentRotation(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			status := rotateRaw(t, refreshToken)
+			status, body := rotateRaw(t, refreshToken)
 			if status == http.StatusOK {
 				atomic.AddInt32(&successes, 1)
+				// Capture the winner's successor token for the post-race assertion.
+				var parsed map[string]any
+				if err := json.Unmarshal(body, &parsed); err == nil {
+					if rt, ok := parsed["refresh_token"].(string); ok {
+						winnerTokMu.Lock()
+						winnerTok = rt
+						winnerTokMu.Unlock()
+					}
+				}
 			} else {
 				atomic.AddInt32(&failures, 1)
 			}
 		}()
 	}
 
-	close(start) // release all goroutines at once
+	close(start)
 	wg.Wait()
 
-	// Security-critical invariant: exactly one successor minted.
+	// Primary invariant: exactly one successor minted.
 	assert.Equal(t, int32(1), atomic.LoadInt32(&successes),
 		"exactly one concurrent rotation should succeed")
 	assert.Equal(t, int32(concurrency-1), atomic.LoadInt32(&failures),
 		"all other concurrent rotations should be rejected")
+
+	// Secondary invariant (grace window): the winner's new refresh token must
+	// survive — losing siblings that saw the original as revoked must not have
+	// tripped family revocation against it.
+	require.NotEmpty(t, winnerTok, "should have captured the winner's refresh_token")
+	status, _ := rotateRaw(t, winnerTok)
+	assert.Equal(t, http.StatusOK, status,
+		"winner's successor token must remain usable after the race (grace window protects it)")
 }
 
-// TestRefreshTokenReuseRevokesFamily verifies family revocation cascades when
-// reuse is detected: replaying an already-rotated refresh token must invalidate
-// not only the replayed token but every successor in the family (rt2 and
-// beyond). Complements TestRefreshTokenRotation, which only checks that the
-// replayed token itself is rejected.
-func TestRefreshTokenReuseRevokesFamily(t *testing.T) {
+// TestRefreshTokenReuseWithinGraceWindowProtectsFamily verifies that a replay
+// arriving within the grace window returns a benign "already rotated" error
+// without nuking the family. Simulates a legitimate concurrent-retry scenario
+// (multi-tab, network retry) where the second request loses but the session —
+// represented by the freshly issued successor — must survive.
+func TestRefreshTokenReuseWithinGraceWindowProtectsFamily(t *testing.T) {
 	verifier, challenge := buildPKCEPair(t)
-	code := buildAuthCode(t, testMCPClientID, "user-reuse-001", testRedirectURI, challenge, []string{"data:read"})
+	code := buildAuthCode(t, testMCPClientID, "user-grace-within", testRedirectURI, challenge, []string{"data:read"})
 
 	resp := post(t, "/oauth2/token", map[string]any{
 		"grant_type":    "authorization_code",
@@ -105,7 +126,7 @@ func TestRefreshTokenReuseRevokesFamily(t *testing.T) {
 	rt2 := decode(t, resp)["refresh_token"].(string)
 	require.NotEmpty(t, rt2)
 
-	// Replay rt1 — already revoked → reuse detected → family revoked.
+	// Replay rt1 immediately — within grace window.
 	resp = post(t, "/oauth2/token", map[string]any{
 		"grant_type":    "refresh_token",
 		"refresh_token": rt1,
@@ -114,14 +135,76 @@ func TestRefreshTokenReuseRevokesFamily(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	assert.Equal(t, "invalid_grant", decode(t, resp)["error"])
 
-	// rt2 must also be dead now — the family was revoked as a unit.
+	// rt2 MUST still be alive — grace window suppresses family revocation.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt2,
+		"client_id":     testMCPClientID,
+	}, nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"rt2 must remain usable: replay within grace window is treated as concurrent retry, not reuse")
+}
+
+// TestRefreshTokenReuseOutsideGraceWindowRevokesFamily verifies that a replay
+// arriving after the grace window fires the full RFC 6749 §10.4 reuse-detection
+// response: the entire family is revoked.
+//
+// Rather than sleeping for the grace window duration, the test backdates the
+// revoked_at column directly via testDB to simulate a delayed replay.
+func TestRefreshTokenReuseOutsideGraceWindowRevokesFamily(t *testing.T) {
+	ctx := context.Background()
+
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, testMCPClientID, "user-grace-outside", testRedirectURI, challenge, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testMCPClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	rt1 := decode(t, resp)["refresh_token"].(string)
+
+	// First rotation: succeeds, yields rt2.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt1,
+		"client_id":     testMCPClientID,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	rt2 := decode(t, resp)["refresh_token"].(string)
+	require.NotEmpty(t, rt2)
+
+	// Backdate rt1's revoked_at past the grace window so the next replay hits
+	// the reuse-detection path.
+	backdate := time.Now().Add(-2 * domain.RefreshTokenReuseGraceWindow)
+	_, err := testDB.NewUpdate().
+		Model((*domain.RefreshToken)(nil)).
+		Set("revoked_at = ?", backdate).
+		Where("user_id = ?", "user-grace-outside").
+		Where("state = ?", domain.RefreshTokenStateRevoked).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	// Replay rt1 — now outside grace window → family revocation fires.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt1,
+		"client_id":     testMCPClientID,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "invalid_grant", decode(t, resp)["error"])
+
+	// rt2 must now be dead — the family was revoked as a unit.
 	resp = post(t, "/oauth2/token", map[string]any{
 		"grant_type":    "refresh_token",
 		"refresh_token": rt2,
 		"client_id":     testMCPClientID,
 	}, nil)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
-		"rt2 must be revoked once reuse was detected on its sibling rt1")
+		"rt2 must be revoked once reuse was detected on its sibling rt1 outside the grace window")
 }
 
 // TestRefreshTokenRotationRollbackOnInsertFailure verifies that when the
@@ -138,7 +221,6 @@ func TestRefreshTokenRotationRollbackOnInsertFailure(t *testing.T) {
 	ctx := context.Background()
 	repo := postgres.NewRefreshTokenRepository(testDB)
 
-	// Seed two unrelated refresh tokens with known hashes.
 	victimHash := "rollback-victim-hash-" + uid("")
 	colliderHash := "rollback-collider-hash-" + uid("")
 
@@ -168,8 +250,6 @@ func TestRefreshTokenRotationRollbackOnInsertFailure(t *testing.T) {
 	}
 	require.NoError(t, repo.Create(ctx, testDB, collider))
 
-	// Drive the same claim + insert flow the service uses, but craft the
-	// successor to collide with `collider` on token_hash (UNIQUE violation).
 	txErr := testDB.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		claimed, err := repo.ClaimByTokenHash(ctx, tx, victimHash)
 		if err != nil {
@@ -192,14 +272,11 @@ func TestRefreshTokenRotationRollbackOnInsertFailure(t *testing.T) {
 	})
 	require.Error(t, txErr, "successor insert must fail with a UNIQUE violation")
 
-	// The claim UPDATE should have been rolled back — victim must be active.
 	got, err := repo.GetByTokenHash(ctx, victimHash)
 	require.NoError(t, err, "victim must still be retrievable as an active, non-expired token")
 	assert.Equal(t, domain.RefreshTokenStateActive, got.State,
 		"claim must have rolled back; victim should not be revoked")
 
-	// A subsequent legitimate claim must now succeed — i.e., the rollback fully
-	// restored the row, not just its state column.
 	reclaimed, err := repo.ClaimByTokenHash(ctx, testDB, victimHash)
 	require.NoError(t, err, "second claim after rollback must succeed")
 	assert.Equal(t, domain.RefreshTokenStateRevoked, reclaimed.State,
@@ -208,9 +285,10 @@ func TestRefreshTokenRotationRollbackOnInsertFailure(t *testing.T) {
 
 // rotateRaw issues a refresh_token grant request directly without going through
 // the require-heavy post helper, so it is safe to call from goroutines. Returns
-// the HTTP status code, or 0 if the request could not be made (surfaced via
-// t.Errorf so a real transport failure doesn't masquerade as a silent miss).
-func rotateRaw(t *testing.T, refreshToken string) int {
+// the HTTP status code and response body, or (0, nil) if the request could not
+// be made (surfaced via t.Errorf so a real transport failure does not
+// masquerade as a silent miss).
+func rotateRaw(t *testing.T, refreshToken string) (int, []byte) {
 	t.Helper()
 	body, err := json.Marshal(map[string]any{
 		"grant_type":    "refresh_token",
@@ -219,19 +297,24 @@ func rotateRaw(t *testing.T, refreshToken string) int {
 	})
 	if err != nil {
 		t.Errorf("marshal refresh request: %v", err)
-		return 0
+		return 0, nil
 	}
 	req, err := http.NewRequest(http.MethodPost, testServer.URL+"/oauth2/token", bytes.NewReader(body))
 	if err != nil {
 		t.Errorf("build refresh request: %v", err)
-		return 0
+		return 0, nil
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Errorf("execute refresh request: %v", err)
-		return 0
+		return 0, nil
 	}
 	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("read refresh response: %v", err)
+		return resp.StatusCode, nil
+	}
+	return resp.StatusCode, respBody
 }

--- a/tests/integration/refresh_token_race_test.go
+++ b/tests/integration/refresh_token_race_test.go
@@ -70,11 +70,12 @@ func TestRefreshTokenConcurrentRotation(t *testing.T) {
 		"all other concurrent rotations should be rejected")
 }
 
-// TestRefreshTokenSequentialReusePreserved verifies that the atomic-claim
-// refactor did not break the family-revocation path: presenting an
-// already-revoked refresh token still trips reuse detection and kills the
-// family, so every refresh token issued from the same original is invalidated.
-func TestRefreshTokenSequentialReusePreserved(t *testing.T) {
+// TestRefreshTokenReuseRevokesFamily verifies family revocation cascades when
+// reuse is detected: replaying an already-rotated refresh token must invalidate
+// not only the replayed token but every successor in the family (rt2 and
+// beyond). Complements TestRefreshTokenRotation, which only checks that the
+// replayed token itself is rejected.
+func TestRefreshTokenReuseRevokesFamily(t *testing.T) {
 	verifier, challenge := buildPKCEPair(t)
 	code := buildAuthCode(t, testMCPClientID, "user-reuse-001", testRedirectURI, challenge, []string{"data:read"})
 
@@ -119,7 +120,8 @@ func TestRefreshTokenSequentialReusePreserved(t *testing.T) {
 
 // rotateRaw issues a refresh_token grant request directly without going through
 // the require-heavy post helper, so it is safe to call from goroutines. Returns
-// the HTTP status code; any transport error is treated as a failure.
+// the HTTP status code, or 0 if the request could not be made (surfaced via
+// t.Errorf so a real transport failure doesn't masquerade as a silent miss).
 func rotateRaw(t *testing.T, refreshToken string) int {
 	t.Helper()
 	body, err := json.Marshal(map[string]any{
@@ -128,15 +130,18 @@ func rotateRaw(t *testing.T, refreshToken string) int {
 		"client_id":     testMCPClientID,
 	})
 	if err != nil {
+		t.Errorf("marshal refresh request: %v", err)
 		return 0
 	}
 	req, err := http.NewRequest(http.MethodPost, testServer.URL+"/oauth2/token", bytes.NewReader(body))
 	if err != nil {
+		t.Errorf("build refresh request: %v", err)
 		return 0
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		t.Errorf("execute refresh request: %v", err)
 		return 0
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/tests/integration/refresh_token_race_test.go
+++ b/tests/integration/refresh_token_race_test.go
@@ -1,0 +1,144 @@
+package integration_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRefreshTokenConcurrentRotation closes the RFC 6749 §6 rotation race:
+// two concurrent POSTs with the same refresh token must not both issue a
+// successor. Exactly one request wins and receives a new token; the rest are
+// rejected with invalid_grant.
+//
+// Before the fix, the read-check-revoke sequence ran under READ COMMITTED
+// (despite the comment claiming "serializable"), so both rotations passed the
+// active check before either committed the revocation — both then minted new
+// tokens, bypassing reuse detection entirely.
+func TestRefreshTokenConcurrentRotation(t *testing.T) {
+	const concurrency = 10
+
+	// Acquire a single refresh token via the authorization_code flow.
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, testMCPClientID, "user-race-001", testRedirectURI, challenge, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testMCPClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	refreshToken := decode(t, resp)["refresh_token"].(string)
+	require.NotEmpty(t, refreshToken)
+
+	var (
+		successes int32
+		failures  int32
+		wg        sync.WaitGroup
+	)
+	start := make(chan struct{})
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			status := rotateRaw(t, refreshToken)
+			if status == http.StatusOK {
+				atomic.AddInt32(&successes, 1)
+			} else {
+				atomic.AddInt32(&failures, 1)
+			}
+		}()
+	}
+
+	close(start) // release all goroutines at once
+	wg.Wait()
+
+	// Security-critical invariant: exactly one successor minted.
+	assert.Equal(t, int32(1), atomic.LoadInt32(&successes),
+		"exactly one concurrent rotation should succeed")
+	assert.Equal(t, int32(concurrency-1), atomic.LoadInt32(&failures),
+		"all other concurrent rotations should be rejected")
+}
+
+// TestRefreshTokenSequentialReusePreserved verifies that the atomic-claim
+// refactor did not break the family-revocation path: presenting an
+// already-revoked refresh token still trips reuse detection and kills the
+// family, so every refresh token issued from the same original is invalidated.
+func TestRefreshTokenSequentialReusePreserved(t *testing.T) {
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, testMCPClientID, "user-reuse-001", testRedirectURI, challenge, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testMCPClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	rt1 := decode(t, resp)["refresh_token"].(string)
+
+	// First rotation: succeeds, yields rt2.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt1,
+		"client_id":     testMCPClientID,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	rt2 := decode(t, resp)["refresh_token"].(string)
+	require.NotEmpty(t, rt2)
+
+	// Replay rt1 — already revoked → reuse detected → family revoked.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt1,
+		"client_id":     testMCPClientID,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "invalid_grant", decode(t, resp)["error"])
+
+	// rt2 must also be dead now — the family was revoked as a unit.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt2,
+		"client_id":     testMCPClientID,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"rt2 must be revoked once reuse was detected on its sibling rt1")
+}
+
+// rotateRaw issues a refresh_token grant request directly without going through
+// the require-heavy post helper, so it is safe to call from goroutines. Returns
+// the HTTP status code; any transport error is treated as a failure.
+func rotateRaw(t *testing.T, refreshToken string) int {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     testMCPClientID,
+	})
+	if err != nil {
+		return 0
+	}
+	req, err := http.NewRequest(http.MethodPost, testServer.URL+"/oauth2/token", bytes.NewReader(body))
+	if err != nil {
+		return 0
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}

--- a/tests/integration/refresh_token_race_test.go
+++ b/tests/integration/refresh_token_race_test.go
@@ -2,14 +2,20 @@ package integration_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
 // TestRefreshTokenConcurrentRotation closes the RFC 6749 §6 rotation race:
@@ -116,6 +122,88 @@ func TestRefreshTokenReuseRevokesFamily(t *testing.T) {
 	}, nil)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"rt2 must be revoked once reuse was detected on its sibling rt1")
+}
+
+// TestRefreshTokenRotationRollbackOnInsertFailure verifies that when the
+// successor insert fails during rotation, the Postgres transaction rolls back
+// the claim UPDATE and leaves the original token active. This is the specific
+// property that protects a client from a transient DB error turning into a
+// forced family revocation on retry.
+//
+// Primarily this pins the contract that repo methods honor the bun.IDB they
+// are given — if someone accidentally reverts ClaimByTokenHash or Create to
+// use r.db directly, the transaction would no longer cover them and this test
+// would fail.
+func TestRefreshTokenRotationRollbackOnInsertFailure(t *testing.T) {
+	ctx := context.Background()
+	repo := postgres.NewRefreshTokenRepository(testDB)
+
+	// Seed two unrelated refresh tokens with known hashes.
+	victimHash := "rollback-victim-hash-" + uid("")
+	colliderHash := "rollback-collider-hash-" + uid("")
+
+	victim := &domain.RefreshToken{
+		TokenHash: victimHash,
+		ClientID:  testMCPClientID,
+		AccountID: testAccountID,
+		ProjectID: testProjectID,
+		UserID:    "user-rollback-victim",
+		Scopes:    "data:read",
+		FamilyID:  "00000000-0000-0000-0000-00000000aaaa",
+		State:     domain.RefreshTokenStateActive,
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	require.NoError(t, repo.Create(ctx, testDB, victim))
+
+	collider := &domain.RefreshToken{
+		TokenHash: colliderHash,
+		ClientID:  testMCPClientID,
+		AccountID: testAccountID,
+		ProjectID: testProjectID,
+		UserID:    "user-rollback-collider",
+		Scopes:    "data:read",
+		FamilyID:  "00000000-0000-0000-0000-00000000bbbb",
+		State:     domain.RefreshTokenStateActive,
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	}
+	require.NoError(t, repo.Create(ctx, testDB, collider))
+
+	// Drive the same claim + insert flow the service uses, but craft the
+	// successor to collide with `collider` on token_hash (UNIQUE violation).
+	txErr := testDB.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		claimed, err := repo.ClaimByTokenHash(ctx, tx, victimHash)
+		if err != nil {
+			return err
+		}
+		require.Equal(t, victimHash, claimed.TokenHash)
+
+		successor := &domain.RefreshToken{
+			TokenHash: colliderHash, // forces UNIQUE violation on insert
+			ClientID:  claimed.ClientID,
+			AccountID: claimed.AccountID,
+			ProjectID: claimed.ProjectID,
+			UserID:    claimed.UserID,
+			Scopes:    claimed.Scopes,
+			FamilyID:  claimed.FamilyID,
+			State:     domain.RefreshTokenStateActive,
+			ExpiresAt: time.Now().Add(1 * time.Hour),
+		}
+		return repo.Create(ctx, tx, successor)
+	})
+	require.Error(t, txErr, "successor insert must fail with a UNIQUE violation")
+
+	// The claim UPDATE should have been rolled back — victim must be active.
+	got, err := repo.GetByTokenHash(ctx, victimHash)
+	require.NoError(t, err, "victim must still be retrievable as an active, non-expired token")
+	assert.Equal(t, domain.RefreshTokenStateActive, got.State,
+		"claim must have rolled back; victim should not be revoked")
+
+	// A subsequent legitimate claim must now succeed — i.e., the rollback fully
+	// restored the row, not just its state column.
+	reclaimed, err := repo.ClaimByTokenHash(ctx, testDB, victimHash)
+	require.NoError(t, err, "second claim after rollback must succeed")
+	assert.Equal(t, domain.RefreshTokenStateRevoked, reclaimed.State,
+		"claimed row reflects the revoked state returned by UPDATE RETURNING")
 }
 
 // rotateRaw issues a refresh_token grant request directly without going through


### PR DESCRIPTION
Closes #16.

## Problem
`RotateRefreshToken` ran read-check-revoke-issue under `RunInTx(ctx, nil, ...)`, which defaults to READ COMMITTED which is not serializable, despite the comment. Under concurrent load, two rotations of the same refresh token could both pass the active check before either committed the revocation, each issuing a valid successor token and bypassing family revocation.

## Fix
Replace the read-then-update with a single atomic `UPDATE ... WHERE state='active' AND expires_at > now() RETURNING *`. Postgres row-level locking guarantees exactly one concurrent caller wins.

- `postgres/refresh_token.go`: new `ClaimByTokenHash`; unused `RevokeByID` removed.
- `service/refresh_token.go`: `RotateRefreshToken` rewritten around `ClaimByTokenHash`. Failed claims disambiguate expired / not-found / reuse via a follow-up read; reuse still triggers family revocation.
- `RunInTx` wrapper and the `*bun.DB` field on the service removed (no longer needed).
- `server.go`: constructor signature updated.

## Test plan
- `TestRefreshTokenConcurrentRotation` - 10 goroutines with barrier-synchronized start present the same refresh token. Asserts exactly one 200 OK and nine invalid_grant. Would fail on main.
- `TestRefreshTokenSequentialReusePreserved` - verifies reuse detection + family revocation still fire after the refactor.
- Full integration suite green; `pkg/authjwt` tests green; `go build` and `go vet` clean.