### PR TITLE
ci: add golangci-lint job with govet, staticcheck, gofmt

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -59,6 +59,38 @@ jobs:
           go vet
           go build
 
+  highflame-lint-check:
+    permissions:
+      contents: 'read'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Golang Version
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VER }}
+          cache: false
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ runner.os }}-${{ env.GO_VER }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-${{ runner.os }}-${{ env.GO_VER }}-
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.7.2
+          args: --timeout=5m
+
   highflame-sast-check:
     permissions:
       contents: read

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - govet
+    - staticcheck
+
+formatters:
+  enable:
+    - gofmt

--- a/domain/credential.go
+++ b/domain/credential.go
@@ -30,7 +30,7 @@ const (
 // urnToShortGrantType maps OAuth2 URN grant type identifiers to their canonical short forms.
 var urnToShortGrantType = map[string]GrantType{
 	"urn:ietf:params:oauth:grant-type:jwt-bearer":     GrantTypeJWTBearer,
-	"urn:ietf:params:oauth:grant-type:token-exchange":  GrantTypeTokenExchange,
+	"urn:ietf:params:oauth:grant-type:token-exchange": GrantTypeTokenExchange,
 }
 
 // allValidGrantTypes is the set of all recognised canonical short forms.

--- a/domain/refresh_token.go
+++ b/domain/refresh_token.go
@@ -8,9 +8,9 @@ import (
 
 // Refresh token constants.
 const (
-	RefreshTokenPrefix     = "zid_rt"
-	RefreshTokenByteLength = 32
-	RefreshTokenTTLDays    = 90
+	RefreshTokenPrefix       = "zid_rt"
+	RefreshTokenByteLength   = 32
+	RefreshTokenTTLDays      = 90
 	RefreshTokenStateActive  = "active"
 	RefreshTokenStateRevoked = "revoked"
 )

--- a/internal/handler/helper.go
+++ b/internal/handler/helper.go
@@ -24,4 +24,3 @@ func respondWithError(w http.ResponseWriter, status int, internalCode, message s
 	errResp := domain.NewErrorResponse(status, internalCode, message)
 	respondWithJSON(w, status, errResp)
 }
-

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -18,20 +18,20 @@ import (
 
 type CreateIdentityInput struct {
 	Body struct {
-		ExternalID         string          `json:"external_id" required:"true" minLength:"1" doc:"Unique identifier within this project"`
-		Name               string          `json:"name,omitempty" doc:"Human-readable identity name"`
-		TrustLevel         string          `json:"trust_level,omitempty" enum:"unverified,verified_third_party,first_party" doc:"Trust level"`
-		IdentityType       string          `json:"identity_type,omitempty" enum:"agent,application,mcp_server,service" doc:"Identity type"`
-		SubType            string          `json:"sub_type,omitempty" enum:"orchestrator,autonomous,tool_agent,human_proxy,evaluator,chatbot,assistant,api_service,custom,code_agent" doc:"Sub-type within identity type"`
-		OwnerUserID        string          `json:"owner_user_id" required:"true" minLength:"1" doc:"User ID of the identity owner"`
-		AllowedScopes      []string        `json:"allowed_scopes,omitempty" doc:"OAuth scopes this identity may request"`
-		PublicKeyPEM       string          `json:"public_key_pem,omitempty" doc:"ECDSA P-256 public key in PEM format for jwt_bearer grant"`
-		Framework          string          `json:"framework,omitempty" doc:"Agent framework (e.g. langchain, autogen, crewai)"`
-		Version            string          `json:"version,omitempty" doc:"Agent version string"`
-		Publisher          string          `json:"publisher,omitempty" doc:"Agent publisher or organization"`
-		Description        string          `json:"description,omitempty" doc:"Human-readable description of the identity"`
-		Capabilities       json.RawMessage `json:"capabilities,omitempty" doc:"JSON array of capabilities"`
-		Labels             json.RawMessage `json:"labels,omitempty" doc:"JSON object of key-value labels"`
+		ExternalID    string          `json:"external_id" required:"true" minLength:"1" doc:"Unique identifier within this project"`
+		Name          string          `json:"name,omitempty" doc:"Human-readable identity name"`
+		TrustLevel    string          `json:"trust_level,omitempty" enum:"unverified,verified_third_party,first_party" doc:"Trust level"`
+		IdentityType  string          `json:"identity_type,omitempty" enum:"agent,application,mcp_server,service" doc:"Identity type"`
+		SubType       string          `json:"sub_type,omitempty" enum:"orchestrator,autonomous,tool_agent,human_proxy,evaluator,chatbot,assistant,api_service,custom,code_agent" doc:"Sub-type within identity type"`
+		OwnerUserID   string          `json:"owner_user_id" required:"true" minLength:"1" doc:"User ID of the identity owner"`
+		AllowedScopes []string        `json:"allowed_scopes,omitempty" doc:"OAuth scopes this identity may request"`
+		PublicKeyPEM  string          `json:"public_key_pem,omitempty" doc:"ECDSA P-256 public key in PEM format for jwt_bearer grant"`
+		Framework     string          `json:"framework,omitempty" doc:"Agent framework (e.g. langchain, autogen, crewai)"`
+		Version       string          `json:"version,omitempty" doc:"Agent version string"`
+		Publisher     string          `json:"publisher,omitempty" doc:"Agent publisher or organization"`
+		Description   string          `json:"description,omitempty" doc:"Human-readable description of the identity"`
+		Capabilities  json.RawMessage `json:"capabilities,omitempty" doc:"JSON array of capabilities"`
+		Labels        json.RawMessage `json:"labels,omitempty" doc:"JSON object of key-value labels"`
 	}
 }
 
@@ -65,21 +65,21 @@ type IdentityListOutput struct {
 type UpdateIdentityInput struct {
 	ID   string `path:"id" doc:"Identity UUID"`
 	Body struct {
-		Name               string          `json:"name,omitempty" doc:"Human-readable identity name"`
-		TrustLevel         string          `json:"trust_level,omitempty" enum:"unverified,verified_third_party,first_party" doc:"Trust level"`
-		IdentityType       string          `json:"identity_type,omitempty" enum:"agent,application,mcp_server,service" doc:"Identity type"`
-		SubType            string          `json:"sub_type,omitempty" enum:"orchestrator,autonomous,tool_agent,human_proxy,evaluator,chatbot,assistant,api_service,custom,code_agent" doc:"Sub-type"`
-		OwnerUserID        string          `json:"owner_user_id,omitempty" doc:"Owner user ID"`
-		AllowedScopes      []string        `json:"allowed_scopes,omitempty" doc:"OAuth scopes"`
-		PublicKeyPEM       string          `json:"public_key_pem,omitempty" doc:"ECDSA public key PEM"`
-		Framework          *string         `json:"framework,omitempty" doc:"Agent framework"`
-		Version            *string         `json:"version,omitempty" doc:"Agent version"`
-		Publisher          *string         `json:"publisher,omitempty" doc:"Agent publisher"`
-		Description        *string         `json:"description,omitempty" doc:"Agent description"`
-		Capabilities       json.RawMessage `json:"capabilities,omitempty" doc:"Capabilities"`
-		Labels             json.RawMessage `json:"labels,omitempty" doc:"Key-value labels"`
-		Metadata           json.RawMessage `json:"metadata,omitempty" doc:"Product-specific metadata"`
-		Status             *string         `json:"status,omitempty" enum:"active,suspended,deactivated" doc:"Identity status"`
+		Name          string          `json:"name,omitempty" doc:"Human-readable identity name"`
+		TrustLevel    string          `json:"trust_level,omitempty" enum:"unverified,verified_third_party,first_party" doc:"Trust level"`
+		IdentityType  string          `json:"identity_type,omitempty" enum:"agent,application,mcp_server,service" doc:"Identity type"`
+		SubType       string          `json:"sub_type,omitempty" enum:"orchestrator,autonomous,tool_agent,human_proxy,evaluator,chatbot,assistant,api_service,custom,code_agent" doc:"Sub-type"`
+		OwnerUserID   string          `json:"owner_user_id,omitempty" doc:"Owner user ID"`
+		AllowedScopes []string        `json:"allowed_scopes,omitempty" doc:"OAuth scopes"`
+		PublicKeyPEM  string          `json:"public_key_pem,omitempty" doc:"ECDSA public key PEM"`
+		Framework     *string         `json:"framework,omitempty" doc:"Agent framework"`
+		Version       *string         `json:"version,omitempty" doc:"Agent version"`
+		Publisher     *string         `json:"publisher,omitempty" doc:"Agent publisher"`
+		Description   *string         `json:"description,omitempty" doc:"Agent description"`
+		Capabilities  json.RawMessage `json:"capabilities,omitempty" doc:"Capabilities"`
+		Labels        json.RawMessage `json:"labels,omitempty" doc:"Key-value labels"`
+		Metadata      json.RawMessage `json:"metadata,omitempty" doc:"Product-specific metadata"`
+		Status        *string         `json:"status,omitempty" enum:"active,suspended,deactivated" doc:"Identity status"`
 	}
 }
 

--- a/internal/handler/wellknown.go
+++ b/internal/handler/wellknown.go
@@ -53,10 +53,10 @@ func (a *API) oauthMetadataOp(_ context.Context, _ *struct{}) (*OAuthMetadataOut
 			"urn:ietf:params:oauth:grant-type:token-exchange",
 			"api_key",
 		},
-		"jwks_uri":                                         a.baseURL + "/.well-known/jwks.json",
-		"introspection_endpoint":                           a.baseURL + "/oauth2/token/introspect",
-		"revocation_endpoint":                              a.baseURL + "/oauth2/token/revoke",
-		"response_types_supported":                         []string{"token"},
+		"jwks_uri":                 a.baseURL + "/.well-known/jwks.json",
+		"introspection_endpoint":   a.baseURL + "/oauth2/token/introspect",
+		"revocation_endpoint":      a.baseURL + "/oauth2/token/revoke",
+		"response_types_supported": []string{"token"},
 		"token_endpoint_auth_signing_alg_values_supported": []string{"ES256", "RS256"},
 	}}, nil
 }

--- a/internal/middleware/agent_auth.go
+++ b/internal/middleware/agent_auth.go
@@ -15,7 +15,7 @@ import (
 // AgentClaims holds the agent identity claims extracted from a validated ES256 JWT.
 // It is populated by AgentAuthMiddleware and available via GetAgentClaims.
 type AgentClaims struct {
-	Subject    string   // WIMSE URI
+	Subject    string // WIMSE URI
 	AccountID  string
 	ProjectID  string
 	AgentID    string

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -156,7 +156,7 @@ func (s *AgentService) RegisterAgent(ctx context.Context, req RegisterAgentReque
 
 	return &AgentRegistrationResponse{
 		Identity: identityToAgentResponse(identity, skResp.KeyPrefix),
-		APIKey: skResp.FullKey,
+		APIKey:   skResp.FullKey,
 	}, nil
 }
 
@@ -314,7 +314,7 @@ func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID s
 
 	return &AgentRegistrationResponse{
 		Identity: identityToAgentResponse(identity, skResp.KeyPrefix),
-		APIKey: skResp.FullKey,
+		APIKey:   skResp.FullKey,
 	}, nil
 }
 

--- a/internal/service/authcode.go
+++ b/internal/service/authcode.go
@@ -14,16 +14,16 @@ import (
 
 // AuthCodeClaims holds the decoded claims from an authorization code JWT.
 type AuthCodeClaims struct {
-	JTI           string   // JWT ID (jti claim or derived hash)
+	JTI           string    // JWT ID (jti claim or derived hash)
 	ExpiresAt     time.Time // Token expiration
-	ClientID      string   // "cid" — Client application ID
-	CodeChallenge string   // "cc"  — PKCE code challenge (S256)
-	RedirectURI   string   // "ruri" — OAuth redirect URI
-	Scopes        []string // "scp" — Granted scopes
-	UserID        string   // "uid" — User ID
-	OrgID         string   // "oid" — Organization ID
-	AccountID     string   // "aid" — Account ID
-	ProjectID     string   // "pid" — Project ID (optional)
+	ClientID      string    // "cid" — Client application ID
+	CodeChallenge string    // "cc"  — PKCE code challenge (S256)
+	RedirectURI   string    // "ruri" — OAuth redirect URI
+	Scopes        []string  // "scp" — Granted scopes
+	UserID        string    // "uid" — User ID
+	OrgID         string    // "oid" — Organization ID
+	AccountID     string    // "aid" — Account ID
+	ProjectID     string    // "pid" — Project ID (optional)
 }
 
 // decodeAuthCodeJWT verifies and decodes a stateless auth code JWT (HS256).

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -33,8 +33,8 @@ type OAuthService struct {
 	refreshTokenSvc *RefreshTokenService
 	issuer          string
 	wimseDomain     string // configurable WIMSE URI domain (e.g. "zeroid.dev")
-	hmacSecret     string // HS256 shared secret for auth code JWT verification
-	authCodeIssuer string // expected issuer in auth code JWTs
+	hmacSecret      string // HS256 shared secret for auth code JWT verification
+	authCodeIssuer  string // expected issuer in auth code JWTs
 	// trustedServiceValidator checks if the caller is a trusted service for external principal exchange.
 	trustedServiceValidator trustedServiceValidatorFunc
 	// customGrants holds registered custom grant type handlers.
@@ -46,7 +46,7 @@ type CustomGrantHandler func(ctx context.Context, req TokenRequest) (*domain.Acc
 
 // Default token TTLs (used when per-client TTL is not configured).
 const (
-	defaultAccessTokenTTLWithRefresh = 3600          // 1 hour when refresh tokens provide continuity
+	defaultAccessTokenTTLWithRefresh = 3600           // 1 hour when refresh tokens provide continuity
 	defaultAccessTokenTTLNoRefresh   = 90 * 24 * 3600 // 90 days for clients without refresh_token grant
 )
 
@@ -71,10 +71,10 @@ type trustedServiceValidatorFunc func(ctx context.Context) (serviceName string, 
 
 // OAuthServiceConfig holds configuration for the OAuthService.
 type OAuthServiceConfig struct {
-	Issuer          string
-	WIMSEDomain     string
-	HMACSecret      string
-	AuthCodeIssuer  string
+	Issuer         string
+	WIMSEDomain    string
+	HMACSecret     string
+	AuthCodeIssuer string
 	// TrustedServiceValidator is called during external principal token exchange
 	// to verify the caller is a trusted internal service. If nil, external
 	// principal exchange is disabled.
@@ -93,15 +93,15 @@ func NewOAuthService(
 	cfg OAuthServiceConfig,
 ) *OAuthService {
 	return &OAuthService{
-		credentialSvc:    credentialSvc,
-		identitySvc:      identitySvc,
-		oauthClientSvc:   oauthClientSvc,
-		apiKeyRepo:       apiKeyRepo,
-		authCodeRepo:     authCodeRepo,
-		jwksSvc:          jwksSvc,
-		refreshTokenSvc:  refreshTokenSvc,
-		issuer:           cfg.Issuer,
-		wimseDomain:      cfg.WIMSEDomain,
+		credentialSvc:           credentialSvc,
+		identitySvc:             identitySvc,
+		oauthClientSvc:          oauthClientSvc,
+		apiKeyRepo:              apiKeyRepo,
+		authCodeRepo:            authCodeRepo,
+		jwksSvc:                 jwksSvc,
+		refreshTokenSvc:         refreshTokenSvc,
+		issuer:                  cfg.Issuer,
+		wimseDomain:             cfg.WIMSEDomain,
 		hmacSecret:              cfg.HMACSecret,
 		authCodeIssuer:          cfg.AuthCodeIssuer,
 		trustedServiceValidator: cfg.TrustedServiceValidator,
@@ -141,9 +141,9 @@ type TokenRequest struct {
 	ActorToken       string // the sub-agent's JWT assertion (NHI delegation only)
 	// External principal exchange fields (RFC 8693 with subject_token_type=jwt):
 	// Populated by the trusted service (e.g. admin) that already authenticated the user.
-	UserID        string // external user ID (e.g. Clerk user ID)
-	UserEmail     string // user email
-	UserName      string // user display name
+	UserID           string         // external user ID (e.g. Clerk user ID)
+	UserEmail        string         // user email
+	UserName         string         // user display name
 	ApplicationID    string         // optional application scope
 	AdditionalClaims map[string]any // arbitrary claims to inject into the issued JWT
 	// authorization_code grant fields:
@@ -1000,7 +1000,6 @@ func (s *OAuthService) parseWIMSEURI(wimseURI string) (accountID, projectID stri
 	}
 	return parts[0], parts[1], nil
 }
-
 
 // parseScopeString splits a space-delimited scope string into a slice.
 func parseScopeString(scope string) []string {

--- a/internal/service/refresh_token.go
+++ b/internal/service/refresh_token.go
@@ -41,8 +41,8 @@ type RefreshTokenParams struct {
 
 // RefreshTokenResult contains both the raw token (returned to client) and stored metadata.
 type RefreshTokenResult struct {
-	RawToken  string    // Returned to client once — never stored.
-	FamilyID  string    // For audit/debugging.
+	RawToken  string // Returned to client once — never stored.
+	FamilyID  string // For audit/debugging.
 	ExpiresAt time.Time
 }
 

--- a/internal/store/postgres/auth_code.go
+++ b/internal/store/postgres/auth_code.go
@@ -72,4 +72,3 @@ func (r *AuthCodeRepository) UpdateTokenInfo(ctx context.Context, jti, credentia
 	}
 	return nil
 }
-

--- a/pkg/authjwt/claims.go
+++ b/pkg/authjwt/claims.go
@@ -125,7 +125,7 @@ func (c *Claims) Agent() *AgentIdentity {
 		TrustLevel:      c.TrustLevel,
 		Name:            c.Name,
 		Framework:       c.Framework,
-		Publisher:        c.Publisher,
+		Publisher:       c.Publisher,
 		Capabilities:    c.Capabilities,
 		Scopes:          c.Scopes,
 		DelegationDepth: c.DelegationDepth,
@@ -254,7 +254,7 @@ func extractClaims(token jwt.Token) *Claims {
 		"external_id": {}, "identity_type": {}, "sub_type": {}, "trust_level": {},
 		"status": {}, "name": {}, "framework": {}, "version": {}, "publisher": {},
 		"capabilities": {},
-		"grant_type": {}, "scopes": {}, "delegation_depth": {},
+		"grant_type":   {}, "scopes": {}, "delegation_depth": {},
 		"act": {},
 	}
 

--- a/pkg/authjwt/middleware.go
+++ b/pkg/authjwt/middleware.go
@@ -117,9 +117,9 @@ func extractBearerToken(r *http.Request) string {
 	return strings.TrimSpace(parts[1])
 }
 
-func isExpired(err error) bool          { return errors.Is(err, ErrExpiredToken) }
-func isInvalidIssuer(err error) bool    { return errors.Is(err, ErrInvalidIssuer) }
-func isInvalidAudience(err error) bool  { return errors.Is(err, ErrInvalidAudience) }
-func isUnsupportedAlg(err error) bool   { return errors.Is(err, ErrUnsupportedAlg) }
-func isTokenRevoked(err error) bool     { return errors.Is(err, ErrTokenRevoked) }
+func isExpired(err error) bool           { return errors.Is(err, ErrExpiredToken) }
+func isInvalidIssuer(err error) bool     { return errors.Is(err, ErrInvalidIssuer) }
+func isInvalidAudience(err error) bool   { return errors.Is(err, ErrInvalidAudience) }
+func isUnsupportedAlg(err error) bool    { return errors.Is(err, ErrUnsupportedAlg) }
+func isTokenRevoked(err error) bool      { return errors.Is(err, ErrTokenRevoked) }
 func isInsufficientScope(err error) bool { return errors.Is(err, ErrInsufficientScope) }

--- a/pkg/authjwt/verifier.go
+++ b/pkg/authjwt/verifier.go
@@ -16,16 +16,16 @@ import (
 )
 
 var (
-	ErrNoToken          = errors.New("authjwt: no token provided")
-	ErrInvalidToken     = errors.New("authjwt: invalid token")
-	ErrExpiredToken     = errors.New("authjwt: token expired")
-	ErrInvalidIssuer    = errors.New("authjwt: invalid issuer")
-	ErrInvalidAudience  = errors.New("authjwt: invalid audience")
-	ErrUnsupportedAlg   = errors.New("authjwt: unsupported signing algorithm")
-	ErrNoKeySet         = errors.New("authjwt: no JWKS available")
+	ErrNoToken           = errors.New("authjwt: no token provided")
+	ErrInvalidToken      = errors.New("authjwt: invalid token")
+	ErrExpiredToken      = errors.New("authjwt: token expired")
+	ErrInvalidIssuer     = errors.New("authjwt: invalid issuer")
+	ErrInvalidAudience   = errors.New("authjwt: invalid audience")
+	ErrUnsupportedAlg    = errors.New("authjwt: unsupported signing algorithm")
+	ErrNoKeySet          = errors.New("authjwt: no JWKS available")
 	ErrInsufficientScope = errors.New("authjwt: insufficient scope")
-	ErrTokenRevoked     = errors.New("authjwt: token revoked or inactive")
-	ErrIntrospectFailed = errors.New("authjwt: introspection request failed")
+	ErrTokenRevoked      = errors.New("authjwt: token revoked or inactive")
+	ErrIntrospectFailed  = errors.New("authjwt: introspection request failed")
 )
 
 // allowedAlgorithms restricts which signing algorithms are accepted.

--- a/tests/integration/authorization_code_test.go
+++ b/tests/integration/authorization_code_test.go
@@ -169,8 +169,8 @@ func TestAuthorizationCodeExpired(t *testing.T) {
 	tok, err := jwt.NewBuilder().
 		Issuer(testIssuer).
 		Subject("auth-code").
-		IssuedAt(now.Add(-10 * time.Minute)).
-		Expiration(now.Add(-1 * time.Second)).
+		IssuedAt(now.Add(-10*time.Minute)).
+		Expiration(now.Add(-1*time.Second)).
 		Claim("cid", testCLIClientID).
 		Claim("uid", "user-expired-001").
 		Claim("aid", testAccountID).

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -18,10 +18,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"strings"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 


### PR DESCRIPTION
  Commit 9e4af97 — chore: normalize gofmt across the repo (16 files, whitespace-only).
  Commit c9dbd58 — ci: add golangci-lint job with govet, staticcheck, gofmt:
  - .golangci.yml — v2 config, only three linters enabled (no noise).
  - highflame-lint-check job in pr-check.yml, matching the existing job layout (same Go setup, same cache key).
  - Uses golangci/golangci-lint-action@v8 pinned to v2.7.2