### PR TITLE
fix: populate aud claim on every issued token (JWT-SVID section3)

### DIFF
--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -271,9 +271,14 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 		_ = token.Set("capabilities", req.Identity.Capabilities)
 	}
 
-	if len(req.Audience) > 0 {
-		_ = token.Set(jwt.AudienceKey, req.Audience)
+	// JWT-SVID §3 requires `aud` to be present on every issued token. Default
+	// to the issuer URL when no audience was supplied so tokens remain
+	// interoperable with spec-compliant verifiers (e.g., pkg/authjwt).
+	aud := req.Audience
+	if len(aud) == 0 {
+		aud = []string{s.issuer}
 	}
+	_ = token.Set(jwt.AudienceKey, aud)
 	if len(req.Scopes) > 0 {
 		_ = token.Set("scopes", req.Scopes)
 	}

--- a/tests/integration/jwt_svid_aud_test.go
+++ b/tests/integration/jwt_svid_aud_test.go
@@ -1,12 +1,16 @@
 package integration_test
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
 )
 
 // TestIssuedTokenHasAudClaimDefault verifies that tokens issued without an
@@ -74,4 +78,61 @@ func TestIssuedTokenPreservesExplicitAudience(t *testing.T) {
 
 	assert.Equal(t, explicitAud, parsed.Audience(),
 		"explicit audience must be preserved, not overwritten by the issuer default")
+}
+
+// TestAuthjwtAcceptsDefaultedAudience is the end-to-end proof that the fix
+// restores interop with spec-compliant verifiers: a token issued without an
+// explicit audience must pass validation under an authjwt.Verifier that is
+// configured with Audience = issuer URL. Pre-fix this failed with
+// ErrInvalidAudience because no aud claim was present.
+//
+// Also exercises the negative path (mismatched audience → ErrInvalidAudience)
+// to confirm the verifier is actually enforcing the check, not silently
+// passing every token.
+func TestAuthjwtAcceptsDefaultedAudience(t *testing.T) {
+	agentID := uid("aud-verify-agent")
+	scopes := []string{"data:read"}
+
+	registerIdentity(t, agentID, scopes)
+	client := registerOAuthClient(t, agentID, scopes)
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	accessToken := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	// Positive: verifier configured with Audience = issuer accepts the token.
+	verifier, err := authjwt.NewVerifier(authjwt.VerifierConfig{
+		JWKSURL:  testServer.URL + "/.well-known/jwks.json",
+		Issuer:   testIssuer,
+		Audience: testIssuer,
+	})
+	require.NoError(t, err)
+	defer verifier.Close()
+
+	_, err = verifier.Verify(context.Background(), accessToken)
+	require.NoError(t, err,
+		"token with defaulted aud=issuer must verify under a spec-compliant verifier configured with the same audience")
+
+	// Negative: verifier configured with a different audience rejects the
+	// token — proves the verifier is actually checking aud, not no-opping.
+	strictVerifier, err := authjwt.NewVerifier(authjwt.VerifierConfig{
+		JWKSURL:  testServer.URL + "/.well-known/jwks.json",
+		Issuer:   testIssuer,
+		Audience: "https://different.example.com/api",
+	})
+	require.NoError(t, err)
+	defer strictVerifier.Close()
+
+	_, err = strictVerifier.Verify(context.Background(), accessToken)
+	require.Error(t, err, "mismatched audience must be rejected")
+	assert.True(t, errors.Is(err, authjwt.ErrInvalidAudience),
+		"rejection reason should be ErrInvalidAudience, got: %v", err)
 }

--- a/tests/integration/jwt_svid_aud_test.go
+++ b/tests/integration/jwt_svid_aud_test.go
@@ -1,0 +1,77 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssuedTokenHasAudClaimDefault verifies that tokens issued without an
+// explicit audience still carry the `aud` claim, defaulted to the issuer URL.
+// This satisfies the JWT-SVID §3 MUST requirement and keeps tokens
+// interoperable with spec-compliant verifiers (e.g., pkg/authjwt with a
+// configured audience).
+//
+// Pre-fix behavior: any grant that did not set Audience on the IssueRequest
+// produced a token with no aud claim at all — breaking JWT-SVID outright and
+// RFC 7519 §4.1.3 guidance.
+func TestIssuedTokenHasAudClaimDefault(t *testing.T) {
+	agentID := uid("aud-default-agent")
+	scopes := []string{"data:read"}
+
+	registerIdentity(t, agentID, scopes)
+	client := registerOAuthClient(t, agentID, scopes)
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	accessToken := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	parsed, err := jwt.ParseInsecure([]byte(accessToken))
+	require.NoError(t, err)
+
+	aud := parsed.Audience()
+	require.NotEmpty(t, aud, "aud claim MUST be present on issued tokens (JWT-SVID §3)")
+	assert.Equal(t, []string{testIssuer}, aud,
+		"aud must default to the issuer URL when no audience was requested")
+}
+
+// TestIssuedTokenPreservesExplicitAudience verifies that an explicit audience
+// passed via the admin /credentials/issue path is preserved on the issued
+// token (not clobbered by the default-to-issuer logic).
+func TestIssuedTokenPreservesExplicitAudience(t *testing.T) {
+	agentID := uid("aud-explicit-agent")
+	scopes := []string{"data:read"}
+	identity := registerIdentity(t, agentID, scopes)
+
+	explicitAud := []string{"https://target.example.com/api"}
+
+	resp := post(t, adminPath("/credentials/issue"), map[string]any{
+		"identity_id": identity.ID,
+		"scopes":      scopes,
+		"audience":    explicitAud,
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	body := decode(t, resp)
+	tok := body["token"].(map[string]any)
+	accessToken := tok["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	parsed, err := jwt.ParseInsecure([]byte(accessToken))
+	require.NoError(t, err)
+
+	assert.Equal(t, explicitAud, parsed.Audience(),
+		"explicit audience must be preserved, not overwritten by the issuer default")
+}


### PR DESCRIPTION
 ## Problem                                                                                                
  Tokens issued without an explicit audience had **no `aud` claim** at all. `internal/service/credential.go`
   only set the claim inside `if len(req.Audience) > 0`. This:                                              
                                                                                                            
  - Violates JWT-SVID Section3 (which requires `aud` on every issued token)                                       
  - Violates RFC 7519 Section4.1.3 guidance                                                                       
  - Breaks interop with spec-compliant verifiers — including ZeroID's own `pkg/authjwt` client when         
  configured with an expected audience                                                                      
   
  ## Fix                                                                                                    
  Default `aud` to the issuer URL when the caller does not supply one. Every grant routes through `CredentialService.IssueCredential`, so a single change covers all paths (`client_credentials`, `jwt_bearer`, `token_exchange`, `api_key`, `authorization_code`, `refresh_token`).
                                                                                                            
  ```go                                                     
  aud := req.Audience
  if len(aud) == 0 {
      aud = []string{s.issuer}
  }                                                                                                         
  _ = token.Set(jwt.AudienceKey, aud)
  ```                                                                                                          
  Explicit audiences (set via the admin /credentials/issue endpoint) are preserved; the default only fills the empty case.                                                                                           
                                                                                                            
  ## Tests                                                     

  New file tests/integration/jwt_svid_aud_test.go:                                                          
   
  - TestIssuedTokenHasAudClaimDefault: client_credentials with no audience → aud = [issuer]                
  - TestIssuedTokenPreservesExplicitAudience:  admin /credentials/issue with explicit audience → preserved, not clobbered                                                                                             
  - TestAuthjwtAcceptsDefaultedAudience: end-to-end proof that a defaulted token verifies under an authjwt.Verifier configured with Audience: issuer (positive path), and that the verifier correctly rejects a mismatched audience with ErrInvalidAudience (negative null-test)
                                                                                                            
  ## Test plan                                                 

  - go build ./... clean                                                                                    
  - go vet ./... clean
  - gofmt -l clean for modified files                                                                       
  - Full integration suite passes                                                                           
  - Three new tests pass
  - golangci-lint (ci-lint PR config) clean for modified files  