### PR TITLE
deactivation must stop token use

### DIFF
--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -339,29 +339,24 @@ func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, proje
 	}
 
 	// Revoke active issued credentials (cascades to delegated descendants).
-	if s.credentialSvc != nil {
-		if n, err := s.credentialSvc.RevokeAllActiveForIdentity(ctx, identity.ID, "identity_deactivated"); err != nil {
-			log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to revoke active credentials")
-		} else if n > 0 {
-			log.Info().Str("identity_id", identity.ID).Int64("count", n).Msg("deactivate: revoked active credentials (cascade)")
-		}
+	if n, err := s.credentialSvc.RevokeAllActiveForIdentity(ctx, identity.ID, "identity_deactivated"); err != nil {
+		log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to revoke active credentials")
+	} else if n > 0 {
+		log.Info().Str("identity_id", identity.ID).Int64("count", n).Msg("deactivate: revoked active credentials (cascade)")
 	}
 
 	// Emit CAE signal so federated subscribers pick up the deactivation.
-	if s.signalSvc != nil {
-		_, err := s.signalSvc.IngestSignal(
-			ctx,
-			accountID,
-			projectID,
-			identity.ID,
-			domain.SignalTypeRetirement,
-			domain.SignalSeverityHigh,
-			"agent_deactivation",
-			map[string]any{"reason": "identity_deactivated"},
-		)
-		if err != nil {
-			log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to emit CAE signal")
-		}
+	if _, err := s.signalSvc.IngestSignal(
+		ctx,
+		accountID,
+		projectID,
+		identity.ID,
+		domain.SignalTypeRetirement,
+		domain.SignalSeverityHigh,
+		"agent_deactivation",
+		map[string]any{"reason": "identity_deactivated"},
+	); err != nil {
+		log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to emit CAE signal")
 	}
 
 	keyPrefix := s.getKeyPrefix(ctx, identity.ID)

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -14,17 +14,27 @@ import (
 
 // AgentService handles agent registration (atomic identity + API key creation).
 type AgentService struct {
-	identitySvc *IdentityService
-	apiKeySvc   *APIKeyService
-	apiKeyRepo  *postgres.APIKeyRepository
+	identitySvc   *IdentityService
+	apiKeySvc     *APIKeyService
+	apiKeyRepo    *postgres.APIKeyRepository
+	credentialSvc *CredentialService
+	signalSvc     *SignalService
 }
 
 // NewAgentService creates a new AgentService.
-func NewAgentService(identitySvc *IdentityService, apiKeySvc *APIKeyService, apiKeyRepo *postgres.APIKeyRepository) *AgentService {
+func NewAgentService(
+	identitySvc *IdentityService,
+	apiKeySvc *APIKeyService,
+	apiKeyRepo *postgres.APIKeyRepository,
+	credentialSvc *CredentialService,
+	signalSvc *SignalService,
+) *AgentService {
 	return &AgentService{
-		identitySvc: identitySvc,
-		apiKeySvc:   apiKeySvc,
-		apiKeyRepo:  apiKeyRepo,
+		identitySvc:   identitySvc,
+		apiKeySvc:     apiKeySvc,
+		apiKeyRepo:    apiKeyRepo,
+		credentialSvc: credentialSvc,
+		signalSvc:     signalSvc,
 	}
 }
 
@@ -297,7 +307,23 @@ func (s *AgentService) ActivateAgent(ctx context.Context, id, accountID, project
 	return &resp, nil
 }
 
-// DeactivateAgent disables an agent without deleting it.
+// DeactivateAgent disables an agent without deleting it. Flips the identity's
+// status AND fully stops any further token use:
+//
+//   - revokes every linked API key (so the api_key grant rejects the key);
+//   - revokes every active issued credential, cascading to delegated
+//     descendants via the parent_jti chain (so tokens already in flight
+//     become inactive on next introspection);
+//   - emits a high-severity CAE retirement signal so federated subscribers
+//     (edge gateways, external SIEM, CAE-aware relying parties) pick up the
+//     deactivation in near real time rather than on their next introspection.
+//
+// Each of these is best-effort: a failure on one step is logged and the
+// method continues. The status flip is the authoritative outcome; the
+// secondary revocations make the effect visible quickly rather than waiting
+// for TTL expiry. The issuance paths also gate on identity.Status.IsUsable(),
+// so new token requests are blocked regardless of whether these cleanup
+// steps succeed.
 func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, projectID string) (*AgentResponse, error) {
 	status := domain.IdentityStatusDeactivated
 	identity, err := s.identitySvc.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{
@@ -305,6 +331,37 @@ func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, proje
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	// Revoke linked API keys so the api_key grant stops accepting them.
+	if err := s.apiKeyRepo.RevokeByIdentityID(ctx, identity.ID); err != nil {
+		log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to revoke linked API keys")
+	}
+
+	// Revoke active issued credentials (cascades to delegated descendants).
+	if s.credentialSvc != nil {
+		if n, err := s.credentialSvc.RevokeAllActiveForIdentity(ctx, identity.ID, "identity_deactivated"); err != nil {
+			log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to revoke active credentials")
+		} else if n > 0 {
+			log.Info().Str("identity_id", identity.ID).Int64("count", n).Msg("deactivate: revoked active credentials (cascade)")
+		}
+	}
+
+	// Emit CAE signal so federated subscribers pick up the deactivation.
+	if s.signalSvc != nil {
+		_, err := s.signalSvc.IngestSignal(
+			ctx,
+			accountID,
+			projectID,
+			identity.ID,
+			domain.SignalTypeRetirement,
+			domain.SignalSeverityHigh,
+			"agent_deactivation",
+			map[string]any{"reason": "identity_deactivated"},
+		)
+		if err != nil {
+			log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to emit CAE signal")
+		}
 	}
 
 	keyPrefix := s.getKeyPrefix(ctx, identity.ID)

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -14,27 +14,17 @@ import (
 
 // AgentService handles agent registration (atomic identity + API key creation).
 type AgentService struct {
-	identitySvc   *IdentityService
-	apiKeySvc     *APIKeyService
-	apiKeyRepo    *postgres.APIKeyRepository
-	credentialSvc *CredentialService
-	signalSvc     *SignalService
+	identitySvc *IdentityService
+	apiKeySvc   *APIKeyService
+	apiKeyRepo  *postgres.APIKeyRepository
 }
 
 // NewAgentService creates a new AgentService.
-func NewAgentService(
-	identitySvc *IdentityService,
-	apiKeySvc *APIKeyService,
-	apiKeyRepo *postgres.APIKeyRepository,
-	credentialSvc *CredentialService,
-	signalSvc *SignalService,
-) *AgentService {
+func NewAgentService(identitySvc *IdentityService, apiKeySvc *APIKeyService, apiKeyRepo *postgres.APIKeyRepository) *AgentService {
 	return &AgentService{
-		identitySvc:   identitySvc,
-		apiKeySvc:     apiKeySvc,
-		apiKeyRepo:    apiKeyRepo,
-		credentialSvc: credentialSvc,
-		signalSvc:     signalSvc,
+		identitySvc: identitySvc,
+		apiKeySvc:   apiKeySvc,
+		apiKeyRepo:  apiKeyRepo,
 	}
 }
 
@@ -307,23 +297,12 @@ func (s *AgentService) ActivateAgent(ctx context.Context, id, accountID, project
 	return &resp, nil
 }
 
-// DeactivateAgent disables an agent without deleting it. Flips the identity's
-// status AND fully stops any further token use:
-//
-//   - revokes every linked API key (so the api_key grant rejects the key);
-//   - revokes every active issued credential, cascading to delegated
-//     descendants via the parent_jti chain (so tokens already in flight
-//     become inactive on next introspection);
-//   - emits a high-severity CAE retirement signal so federated subscribers
-//     (edge gateways, external SIEM, CAE-aware relying parties) pick up the
-//     deactivation in near real time rather than on their next introspection.
-//
-// Each of these is best-effort: a failure on one step is logged and the
-// method continues. The status flip is the authoritative outcome; the
-// secondary revocations make the effect visible quickly rather than waiting
-// for TTL expiry. The issuance paths also gate on identity.Status.IsUsable(),
-// so new token requests are blocked regardless of whether these cleanup
-// steps succeed.
+// DeactivateAgent disables an agent without deleting it. The underlying
+// IdentityService.UpdateIdentity sweeps linked API keys, cascade-revokes
+// active credentials, and emits a retirement CAE signal on any fresh
+// transition into the deactivated status — so this endpoint, a direct
+// PUT /identities/{id} with status=deactivated, and any programmatic
+// caller all produce the same end state.
 func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, projectID string) (*AgentResponse, error) {
 	status := domain.IdentityStatusDeactivated
 	identity, err := s.identitySvc.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{
@@ -332,33 +311,6 @@ func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, proje
 	if err != nil {
 		return nil, err
 	}
-
-	// Revoke linked API keys so the api_key grant stops accepting them.
-	if err := s.apiKeyRepo.RevokeByIdentityID(ctx, identity.ID); err != nil {
-		log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to revoke linked API keys")
-	}
-
-	// Revoke active issued credentials (cascades to delegated descendants).
-	if n, err := s.credentialSvc.RevokeAllActiveForIdentity(ctx, identity.ID, "identity_deactivated"); err != nil {
-		log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to revoke active credentials")
-	} else if n > 0 {
-		log.Info().Str("identity_id", identity.ID).Int64("count", n).Msg("deactivate: revoked active credentials (cascade)")
-	}
-
-	// Emit CAE signal so federated subscribers pick up the deactivation.
-	if _, err := s.signalSvc.IngestSignal(
-		ctx,
-		accountID,
-		projectID,
-		identity.ID,
-		domain.SignalTypeRetirement,
-		domain.SignalSeverityHigh,
-		"agent_deactivation",
-		map[string]any{"reason": "identity_deactivated"},
-	); err != nil {
-		log.Warn().Err(err).Str("identity_id", identity.ID).Msg("deactivate: failed to emit CAE signal")
-	}
-
 	keyPrefix := s.getKeyPrefix(ctx, identity.ID)
 	resp := identityToAgentResponse(identity, keyPrefix)
 	return &resp, nil

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -100,7 +100,21 @@ type IssueRequest struct {
 var ErrScopesNotAllowed = fmt.Errorf("one or more requested scopes are not permitted for this identity")
 
 // IssueCredential issues a short-lived JWT for an identity.
+//
+// Gate: identities not in a usable status never receive a fresh credential.
+// This is the authoritative chokepoint — every issuance path in the codebase
+// (admin /credentials/issue, oauth grants, RotateCredential, attestation
+// verification) funnels through here. Per-grant checks elsewhere remain as
+// defense-in-depth and for better error messages, but this gate is the
+// guarantee that bypasses via a new or forgotten path still fail closed.
 func (s *CredentialService) IssueCredential(ctx context.Context, req IssueRequest) (*domain.AccessToken, *domain.IssuedCredential, error) {
+	if req.Identity == nil {
+		return nil, nil, fmt.Errorf("identity is required")
+	}
+	if !req.Identity.Status.IsUsable() {
+		return nil, nil, fmt.Errorf("identity is not usable (status: %s)", req.Identity.Status)
+	}
+
 	ttl := req.TTL
 	if ttl <= 0 {
 		ttl = s.defaultTTL

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -383,6 +383,17 @@ func (s *CredentialService) RevokeCredential(ctx context.Context, id, accountID,
 	return s.repo.Revoke(ctx, id, accountID, projectID, reason)
 }
 
+// RevokeAllActiveForIdentity revokes every active credential issued to the given
+// identity and cascades to any delegated descendants via the parent_jti chain.
+// Returns the total number of credentials revoked. Used during agent deactivation
+// so existing tokens stop working immediately rather than surviving until TTL.
+func (s *CredentialService) RevokeAllActiveForIdentity(ctx context.Context, identityID, reason string) (int64, error) {
+	if reason == "" {
+		reason = "identity_deactivated"
+	}
+	return s.repo.RevokeAllActiveForIdentity(ctx, identityID, reason)
+}
+
 // RotateCredential revokes an existing credential and immediately issues a new one for the same identity.
 // The new credential inherits the scopes and TTL of the old one unless overridden.
 func (s *CredentialService) RotateCredential(ctx context.Context, credID, accountID, projectID string, identity *domain.Identity) (*domain.AccessToken, *domain.IssuedCredential, error) {

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -22,17 +22,40 @@ var ErrIdentityAlreadyExists = errors.New("identity already exists")
 
 // IdentityService handles identity lifecycle operations.
 type IdentityService struct {
-	repo        *postgres.IdentityRepository
-	policySvc   *CredentialPolicyService
-	wimseDomain string
+	repo          *postgres.IdentityRepository
+	policySvc     *CredentialPolicyService
+	apiKeyRepo    *postgres.APIKeyRepository
+	credentialSvc *CredentialService
+	signalSvc     *SignalService
+	wimseDomain   string
 }
 
 // NewIdentityService creates a new IdentityService. policySvc must be non-nil —
 // every identity is assigned the tenant's default credential policy at
 // registration time if the caller does not choose a specific one, so the
 // service cannot function without a policy resolver.
-func NewIdentityService(repo *postgres.IdentityRepository, policySvc *CredentialPolicyService, wimseDomain string) *IdentityService {
-	return &IdentityService{repo: repo, policySvc: policySvc, wimseDomain: wimseDomain}
+//
+// apiKeyRepo, credentialSvc, and signalSvc are required because status
+// transitions to "deactivated" (and identity deletion) must sweep linked API
+// keys, cascade-revoke active credentials, and emit a retirement CAE signal.
+// Centralizing that cleanup here ensures every path that deactivates or
+// deletes an identity runs the sweep — not just the dedicated agent endpoint.
+func NewIdentityService(
+	repo *postgres.IdentityRepository,
+	policySvc *CredentialPolicyService,
+	apiKeyRepo *postgres.APIKeyRepository,
+	credentialSvc *CredentialService,
+	signalSvc *SignalService,
+	wimseDomain string,
+) *IdentityService {
+	return &IdentityService{
+		repo:          repo,
+		policySvc:     policySvc,
+		apiKeyRepo:    apiKeyRepo,
+		credentialSvc: credentialSvc,
+		signalSvc:     signalSvc,
+		wimseDomain:   wimseDomain,
+	}
 }
 
 // validateECPublicKeyPEM ensures the provided PEM string is a valid EC P-256 public key.
@@ -276,6 +299,9 @@ func (s *IdentityService) UpdateIdentity(ctx context.Context, id, accountID, pro
 	if req.Metadata != nil {
 		identity.Metadata = req.Metadata
 	}
+	// Capture prior status so we can tell whether the update is a fresh
+	// transition into deactivated (in which case cleanup must run).
+	priorStatus := identity.Status
 	if req.Status != nil {
 		if !identity.Status.CanTransitionTo(*req.Status) {
 			return nil, fmt.Errorf("invalid status transition: %s → %s", identity.Status, *req.Status)
@@ -292,6 +318,15 @@ func (s *IdentityService) UpdateIdentity(ctx context.Context, id, accountID, pro
 	identity.UpdatedAt = time.Now()
 	if err := s.repo.Update(ctx, identity); err != nil {
 		return nil, err
+	}
+
+	// Fresh transition into deactivated: sweep linked API keys, cascade-revoke
+	// active credentials, and emit a retirement signal. Centralized here so
+	// every update path (PUT /identities/{id}, AgentService.DeactivateAgent,
+	// or any programmatic caller) runs the same cleanup.
+	if priorStatus != domain.IdentityStatusDeactivated &&
+		identity.Status == domain.IdentityStatusDeactivated {
+		s.runDeactivationCleanup(ctx, identity, "identity_deactivated")
 	}
 	return identity, nil
 }
@@ -334,8 +369,58 @@ func (s *IdentityService) EnsureServiceIdentity(ctx context.Context, accountID, 
 }
 
 // DeleteIdentity permanently removes an identity and cascades to related records.
+//
+// Cleanup runs before the DB delete: API keys are revoked, active credentials
+// are cascade-revoked, and a retirement CAE signal is emitted. This ensures
+// tokens issued to the identity stop working at the same moment the identity
+// is removed, not just whenever they happen to TTL-expire (which can be up to
+// 90 days for api_key tokens).
 func (s *IdentityService) DeleteIdentity(ctx context.Context, id, accountID, projectID string) error {
+	identity, err := s.repo.GetByID(ctx, id, accountID, projectID)
+	if err != nil {
+		// Fall through to Delete so callers get the same not-found semantics.
+		return s.repo.Delete(ctx, id, accountID, projectID)
+	}
+	s.runDeactivationCleanup(ctx, identity, "identity_deleted")
 	return s.repo.Delete(ctx, id, accountID, projectID)
+}
+
+// runDeactivationCleanup sweeps everything a deactivated or deleted identity
+// should no longer be able to use. Each step is best-effort — failures are
+// logged but do not block the surrounding operation, because the
+// authoritative outcome (status flip or row delete) has already happened and
+// the IssueCredential gate ensures no new tokens will be minted regardless.
+//
+// The reason string is carried through the revocation audit trail and the
+// CAE signal payload so subscribers can distinguish "deactivated" from
+// "deleted" cleanups.
+func (s *IdentityService) runDeactivationCleanup(ctx context.Context, identity *domain.Identity, reason string) {
+	if err := s.apiKeyRepo.RevokeByIdentityID(ctx, identity.ID); err != nil {
+		log.Warn().Err(err).Str("identity_id", identity.ID).Str("reason", reason).
+			Msg("identity cleanup: failed to revoke linked API keys")
+	}
+
+	if n, err := s.credentialSvc.RevokeAllActiveForIdentity(ctx, identity.ID, reason); err != nil {
+		log.Warn().Err(err).Str("identity_id", identity.ID).Str("reason", reason).
+			Msg("identity cleanup: failed to revoke active credentials")
+	} else if n > 0 {
+		log.Info().Str("identity_id", identity.ID).Str("reason", reason).Int64("count", n).
+			Msg("identity cleanup: revoked active credentials (cascade)")
+	}
+
+	if _, err := s.signalSvc.IngestSignal(
+		ctx,
+		identity.AccountID,
+		identity.ProjectID,
+		identity.ID,
+		domain.SignalTypeRetirement,
+		domain.SignalSeverityHigh,
+		"identity_lifecycle",
+		map[string]any{"reason": reason},
+	); err != nil {
+		log.Warn().Err(err).Str("identity_id", identity.ID).Str("reason", reason).
+			Msg("identity cleanup: failed to emit retirement CAE signal")
+	}
 }
 
 // resolveIdentityPolicyID picks the policy to attach to an identity. When the

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -216,6 +216,9 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 	if err != nil {
 		return nil, oauthUnauthorized(fmt.Sprintf("no identity found for client_id %s", req.ClientID), err)
 	}
+	if !identity.Status.IsUsable() {
+		return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
+	}
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:  identity,
@@ -526,6 +529,9 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 		if err != nil {
 			return nil, fmt.Errorf("invalid_request: application_id %s not found or access denied", req.ApplicationID)
 		}
+		if !resolved.Status.IsUsable() {
+			return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
+		}
 		identity = resolved
 	} else {
 		identity = &domain.Identity{
@@ -605,6 +611,8 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 		if err != nil {
 			log.Warn().Str("identity_id", sk.IdentityID).Str("key_id", sk.ID).Msg("API key linked to unknown identity_id, issuing without identity")
 			identity = nil
+		} else if !identity.Status.IsUsable() {
+			return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
 		}
 	}
 

--- a/server.go
+++ b/server.go
@@ -147,13 +147,17 @@ func NewServer(cfg Config) (*Server, error) {
 	authCodeRepo := postgres.NewAuthCodeRepository(db)
 
 	// Initialize services.
-	// credentialPolicySvc must be created before identitySvc because every
-	// identity is assigned a credential policy at registration (authority
-	// ceiling) and the identity service needs the resolver to enforce the
-	// tenant-scoped IDOR guard on caller-supplied policy IDs.
+	// Construction order matters because identitySvc now depends on
+	// credentialSvc and signalSvc so it can sweep linked API keys, revoke
+	// active credentials, and emit a retirement signal on any status
+	// transition into deactivated. credentialPolicySvc has no service
+	// dependencies and goes first; credentialSvc and signalSvc depend only
+	// on repos; then identitySvc; then attestationSvc / apiKeySvc which
+	// need identitySvc; then oauthSvc / agentSvc last.
 	credentialPolicySvc := service.NewCredentialPolicyService(credentialPolicyRepo)
-	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, cfg.WIMSEDomain)
 	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL)
+	signalSvc := service.NewSignalService(signalRepo, credentialRepo)
+	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, apiKeyRepo, credentialSvc, signalSvc, cfg.WIMSEDomain)
 	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc)
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)
@@ -169,10 +173,7 @@ func NewServer(cfg Config) (*Server, error) {
 		AuthCodeIssuer: authCodeIssuer,
 	})
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
-	signalSvc := service.NewSignalService(signalRepo, credentialRepo)
-	// agentSvc depends on credentialSvc + signalSvc for DeactivateAgent's
-	// revoke-and-signal behavior, so it is constructed last.
-	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo, credentialSvc, signalSvc)
+	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo)
 
 	// Create shared API handler.
 	apiHandler := handler.NewAPI(

--- a/server.go
+++ b/server.go
@@ -157,7 +157,6 @@ func NewServer(cfg Config) (*Server, error) {
 	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc)
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)
-	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo)
 	refreshTokenSvc := service.NewRefreshTokenService(refreshTokenRepo, db)
 	authCodeIssuer := cfg.Token.AuthCodeIssuer
 	if authCodeIssuer == "" {
@@ -171,6 +170,9 @@ func NewServer(cfg Config) (*Server, error) {
 	})
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
 	signalSvc := service.NewSignalService(signalRepo, credentialRepo)
+	// agentSvc depends on credentialSvc + signalSvc for DeactivateAgent's
+	// revoke-and-signal behavior, so it is constructed last.
+	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo, credentialSvc, signalSvc)
 
 	// Create shared API handler.
 	apiHandler := handler.NewAPI(

--- a/tests/integration/deactivation_test.go
+++ b/tests/integration/deactivation_test.go
@@ -165,5 +165,85 @@ func TestDeactivationEmitsRetirementSignal(t *testing.T) {
 	}
 	require.NotNil(t, found, "a retirement signal for the deactivated agent must be present")
 	assert.Equal(t, "high", found["severity"], "deactivation signal should be high severity")
-	assert.Equal(t, "agent_deactivation", found["source"])
+	assert.Equal(t, "identity_lifecycle", found["source"])
+}
+
+// TestIdentityUpdateToDeactivatedRunsCleanup verifies that the centralized
+// cleanup fires when the status transition happens via the generic
+// PUT /identities/{id} path, not only via AgentService.DeactivateAgent. This
+// guards the original #89 bypass: any route that sets status to deactivated
+// must perform the full cleanup, not just the dedicated agent endpoint.
+func TestIdentityUpdateToDeactivatedRunsCleanup(t *testing.T) {
+	ext := uid("deactivate-via-update")
+	reg := registerAgent(t, ext)
+
+	// Issue a token while the identity is still active.
+	issueResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, issueResp.StatusCode)
+	token := decode(t, issueResp)["access_token"].(string)
+	require.True(t, introspect(t, token)["active"].(bool))
+
+	// Deactivate via the generic identity update — not the agent endpoint.
+	patchResp, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID),
+		map[string]any{"status": "deactivated"}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patchResp.StatusCode, "PATCH /identities/{id} should succeed")
+	_ = patchResp.Body.Close()
+
+	// Existing token must be revoked by the centralized cleanup.
+	assert.False(t, introspect(t, token)["active"].(bool),
+		"PATCH /identities status=deactivated must trigger credential revocation")
+}
+
+// TestAdminIssueOnDeactivatedIdentityRejected verifies the IssueCredential gate
+// closes the admin /credentials/issue bypass. Even an admin cannot mint a
+// fresh credential for a deactivated identity.
+func TestAdminIssueOnDeactivatedIdentityRejected(t *testing.T) {
+	ext := uid("admin-issue-deactivated")
+	reg := registerAgent(t, ext)
+
+	// Deactivate.
+	deact, err := doRaw(t, http.MethodPost, adminPath("/agents/registry/"+reg.AgentID+"/deactivate"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, deact.StatusCode)
+	_ = deact.Body.Close()
+
+	// Try the admin /credentials/issue endpoint — must fail.
+	issueResp := post(t, adminPath("/credentials/issue"), map[string]any{
+		"identity_id": reg.AgentID,
+		"scopes":      []string{"data:read"},
+	}, adminHeaders())
+	assert.GreaterOrEqual(t, issueResp.StatusCode, 400,
+		"admin /credentials/issue must reject deactivated identity")
+	assert.Less(t, issueResp.StatusCode, 600)
+}
+
+// TestDeleteIdentityRunsCleanup verifies DeleteIdentity sweeps linked tokens
+// before removing the identity row. Otherwise, credentials with the deleted
+// identity_id would survive (FK set to NULL) and remain valid until TTL.
+func TestDeleteIdentityRunsCleanup(t *testing.T) {
+	ext := uid("delete-cleanup")
+	reg := registerAgent(t, ext)
+
+	issueResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, issueResp.StatusCode)
+	token := decode(t, issueResp)["access_token"].(string)
+	require.True(t, introspect(t, token)["active"].(bool))
+
+	// DELETE /identities/{id} — permanent removal.
+	delResp, err := doRaw(t, http.MethodDelete, adminPath("/identities/"+reg.AgentID), nil, adminHeaders())
+	require.NoError(t, err)
+	require.True(t, delResp.StatusCode >= 200 && delResp.StatusCode < 300,
+		"DELETE /identities/{id} should succeed")
+	_ = delResp.Body.Close()
+
+	// Token must be revoked — cleanup ran before delete.
+	assert.False(t, introspect(t, token)["active"].(bool),
+		"DELETE /identities must revoke credentials before removing the identity row")
 }

--- a/tests/integration/deactivation_test.go
+++ b/tests/integration/deactivation_test.go
@@ -1,0 +1,183 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeactivatedAgentCannotIssueViaApiKey verifies that once an agent is
+// deactivated, the api_key grant can no longer mint fresh tokens using that
+// agent's key, and any previously-issued token is revoked.
+//
+// Guards the first security gap from issue #89: issuance paths must gate on
+// identity.Status.IsUsable(), and DeactivateAgent must revoke active
+// credentials and linked API keys.
+func TestDeactivatedAgentCannotIssueViaApiKey(t *testing.T) {
+	ext := uid("deactivate-apikey")
+	reg := registerAgent(t, ext)
+	require.NotEmpty(t, reg.APIKey)
+
+	// Issue a token while active — should succeed.
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	tokenBefore := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, tokenBefore)
+
+	// Confirm it's active.
+	pre := introspect(t, tokenBefore)
+	assert.True(t, pre["active"].(bool), "token should be active before deactivation")
+
+	// Deactivate the agent.
+	deact, err := doRaw(t, http.MethodPost, adminPath("/agents/registry/"+reg.AgentID+"/deactivate"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, deact.StatusCode)
+	_ = deact.Body.Close()
+
+	// Existing token must now be inactive — cascade revocation on deactivate.
+	post := introspect(t, tokenBefore)
+	assert.False(t, post["active"].(bool),
+		"previously-issued token must be revoked after agent deactivation")
+
+	// New api_key grant request must be rejected. Either the key has been
+	// revoked (invalid_grant at key lookup) or the identity status gate
+	// trips (invalid_grant at identity check). Both are correct.
+	resp = postInt(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"api_key grant must reject deactivated agent")
+	body := decodeInt(t, resp)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestDeactivatedAgentCannotIssueViaClientCredentials verifies the
+// client_credentials grant rejects a deactivated identity. Covers the
+// clientCredentials path where the identity is resolved via GetByExternalID
+// — previously had no IsUsable() check.
+func TestDeactivatedAgentCannotIssueViaClientCredentials(t *testing.T) {
+	ext := uid("deactivate-cc")
+	reg := registerAgent(t, ext)
+
+	// Register a confidential OAuth client keyed on the same external_id so
+	// client_credentials → identity resolution hits this agent.
+	oauthClient := registerOAuthClient(t, ext, []string{"data:read"})
+
+	// Issue via client_credentials while active — should succeed.
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     oauthClient.ClientID,
+		"client_secret": oauthClient.ClientSecret,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Deactivate the agent.
+	deact, err := doRaw(t, http.MethodPost, adminPath("/agents/registry/"+reg.AgentID+"/deactivate"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, deact.StatusCode)
+	_ = deact.Body.Close()
+
+	// client_credentials request must now fail.
+	resp = postInt(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     oauthClient.ClientID,
+		"client_secret": oauthClient.ClientSecret,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"client_credentials must reject deactivated identity")
+	body := decodeInt(t, resp)
+	assert.Equal(t, "invalid_grant", body["error"])
+}
+
+// TestDeactivationRevokesExistingCredentials verifies the cascade-revoke
+// behavior on DeactivateAgent. Issues multiple credentials, deactivates, and
+// confirms every one introspects as inactive.
+func TestDeactivationRevokesExistingCredentials(t *testing.T) {
+	ext := uid("deactivate-cascade")
+	reg := registerAgent(t, ext)
+
+	// Mint two tokens so we can verify both get swept on deactivation.
+	tokens := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		r := post(t, "/oauth2/token", map[string]any{
+			"grant_type": "api_key",
+			"api_key":    reg.APIKey,
+		}, nil)
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		tokens = append(tokens, decode(t, r)["access_token"].(string))
+	}
+
+	// All active before deactivation.
+	for _, tok := range tokens {
+		assert.True(t, introspect(t, tok)["active"].(bool), "token should be active before deactivation")
+	}
+
+	// Deactivate.
+	deact, err := doRaw(t, http.MethodPost, adminPath("/agents/registry/"+reg.AgentID+"/deactivate"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, deact.StatusCode)
+	_ = deact.Body.Close()
+
+	// All inactive after deactivation.
+	for i, tok := range tokens {
+		assert.False(t, introspect(t, tok)["active"].(bool),
+			"token #%d must be revoked after agent deactivation", i)
+	}
+}
+
+// TestDeactivationEmitsRetirementSignal verifies a high-severity retirement
+// CAE signal is emitted so federated subscribers can react in near-real time
+// without needing to poll introspection.
+func TestDeactivationEmitsRetirementSignal(t *testing.T) {
+	ext := uid("deactivate-signal")
+	reg := registerAgent(t, ext)
+
+	// Deactivate.
+	deact, err := doRaw(t, http.MethodPost, adminPath("/agents/registry/"+reg.AgentID+"/deactivate"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, deact.StatusCode)
+	_ = deact.Body.Close()
+
+	// Query signals for this tenant and find the retirement event.
+	resp := get(t, adminPath("/signals?limit=50"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	signals, ok := body["signals"].([]any)
+	require.True(t, ok, "signals endpoint should return a signals array")
+
+	var found map[string]any
+	for _, s := range signals {
+		sig := s.(map[string]any)
+		if sig["identity_id"] == reg.AgentID && sig["signal_type"] == "retirement" {
+			found = sig
+			break
+		}
+	}
+	require.NotNil(t, found, "a retirement signal for the deactivated agent must be present")
+	assert.Equal(t, "high", found["severity"], "deactivation signal should be high severity")
+	assert.Equal(t, "agent_deactivation", found["source"])
+}
+
+// postInt + decodeInt mirror the default `post`/`decode` helpers but do not
+// invoke `require.Equal` on the status code, since the deactivation tests
+// expect 400s that `require.Equal` would abort on before we can assert on
+// the error body.
+func postInt(t *testing.T, path string, body any, headers map[string]string) *http.Response {
+	t.Helper()
+	return doRequest(t, http.MethodPost, path, body, headers)
+}
+
+func decodeInt(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	return decode(t, resp)
+}

--- a/tests/integration/deactivation_test.go
+++ b/tests/integration/deactivation_test.go
@@ -40,20 +40,20 @@ func TestDeactivatedAgentCannotIssueViaApiKey(t *testing.T) {
 	_ = deact.Body.Close()
 
 	// Existing token must now be inactive — cascade revocation on deactivate.
-	post := introspect(t, tokenBefore)
-	assert.False(t, post["active"].(bool),
+	afterRevoke := introspect(t, tokenBefore)
+	assert.False(t, afterRevoke["active"].(bool),
 		"previously-issued token must be revoked after agent deactivation")
 
 	// New api_key grant request must be rejected. Either the key has been
 	// revoked (invalid_grant at key lookup) or the identity status gate
 	// trips (invalid_grant at identity check). Both are correct.
-	resp = postInt(t, "/oauth2/token", map[string]any{
+	resp = post(t, "/oauth2/token", map[string]any{
 		"grant_type": "api_key",
 		"api_key":    reg.APIKey,
 	}, nil)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"api_key grant must reject deactivated agent")
-	body := decodeInt(t, resp)
+	body := decode(t, resp)
 	assert.Equal(t, "invalid_grant", body["error"])
 }
 
@@ -86,7 +86,7 @@ func TestDeactivatedAgentCannotIssueViaClientCredentials(t *testing.T) {
 	_ = deact.Body.Close()
 
 	// client_credentials request must now fail.
-	resp = postInt(t, "/oauth2/token", map[string]any{
+	resp = post(t, "/oauth2/token", map[string]any{
 		"grant_type":    "client_credentials",
 		"account_id":    testAccountID,
 		"project_id":    testProjectID,
@@ -95,7 +95,7 @@ func TestDeactivatedAgentCannotIssueViaClientCredentials(t *testing.T) {
 	}, nil)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"client_credentials must reject deactivated identity")
-	body := decodeInt(t, resp)
+	body := decode(t, resp)
 	assert.Equal(t, "invalid_grant", body["error"])
 }
 
@@ -166,18 +166,4 @@ func TestDeactivationEmitsRetirementSignal(t *testing.T) {
 	require.NotNil(t, found, "a retirement signal for the deactivated agent must be present")
 	assert.Equal(t, "high", found["severity"], "deactivation signal should be high severity")
 	assert.Equal(t, "agent_deactivation", found["source"])
-}
-
-// postInt + decodeInt mirror the default `post`/`decode` helpers but do not
-// invoke `require.Equal` on the status code, since the deactivation tests
-// expect 400s that `require.Equal` would abort on before we can assert on
-// the error body.
-func postInt(t *testing.T, path string, body any, headers map[string]string) *http.Response {
-	t.Helper()
-	return doRequest(t, http.MethodPost, path, body, headers)
-}
-
-func decodeInt(t *testing.T, resp *http.Response) map[string]any {
-	t.Helper()
-	return decode(t, resp)
 }


### PR DESCRIPTION
## Summary                                                                                                          
   
  Closes #89. Deactivation was a status-flip only linked API keys stayed valid, issued tokens remained live until
   TTL, and issuance paths didn't gate on identity status. This PR makes deactivation authoritative end-to-end.
                                                                                                                   
  - Authoritative issuance gate in CredentialService.IssueCredential: rejects any identity where Status.IsUsable()
   is false. Every issuance path (oauth grants, admin /credentials/issue, RotateCredential, attestation) funnels
  through here, so new/forgotten paths fail closed.                                                                
  - Centralized cleanup in IdentityService: any transition into deactivated (via PUT /identities/{id},
  AgentService.DeactivateAgent, or programmatic caller) sweeps linked API keys, cascade-revokes active credentials 
  (via parent_jti chain), and emits a high-severity retirement CAE signal. DeleteIdentity runs the same cleanup
  before removing the row.                                                                                         
  - Defense-in-depth IsUsable() checks retained in the oauth grant handlers for better error messages.
                                                                                                                   
##  Test plan
                                                                                                                   
  - New integration tests in tests/integration/deactivation_test.go:                                               
    - api_key grant rejects deactivated agent + revokes prior tokens
    - client_credentials rejects deactivated identity                                                              
    - cascade revocation sweeps all active credentials      
    - retirement CAE signal emitted (source=identity_lifecycle, severity=high)                                     
    - PATCH /identities/{id} with status=deactivated triggers full cleanup                                         
    - admin /credentials/issue rejects deactivated identity                                                        
    - DELETE /identities/{id} revokes credentials before row removal                                               
  - Full integration suite green (49 tests, 8.0s)                                                                  
  - golangci-lint clean                                                                                            
  - SDK smoke tests unaffected (deactivate → activate → rotate_key path validated) 