### PR TITLE
fix: accept form-encoded OAuth requests (RFC 6749/7662/7009)

### DIFF
--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -132,6 +132,45 @@ func (a *API) registerOAuthRoutes(api huma.API) {
 		Tags:          []string{"OAuth"},
 		DefaultStatus: http.StatusNotImplemented,
 	}, a.bcAuthorizeOp)
+
+	advertiseFormContentType(api, "/oauth2/token", "/oauth2/token/introspect", "/oauth2/token/revoke")
+}
+
+// advertiseFormContentType mirrors the JSON request-body schema Huma generated
+// for each given path into an additional application/x-www-form-urlencoded
+// entry. Generated OpenAPI clients then know these endpoints accept form
+// encoding (as RFC 6749/7662/7009 require) in addition to the JSON shape the
+// input struct declares.
+//
+// Safe because oauthFormCompatMiddleware rewrites form bodies to JSON before
+// the handler runs, so the JSON-generated schema is the effective schema for
+// both content types.
+func advertiseFormContentType(api huma.API, paths ...string) {
+	oapi := api.OpenAPI()
+	if oapi == nil || oapi.Paths == nil {
+		return
+	}
+	for _, p := range paths {
+		item, ok := oapi.Paths[p]
+		if !ok || item == nil || item.Post == nil || item.Post.RequestBody == nil {
+			continue
+		}
+		content := item.Post.RequestBody.Content
+		if content == nil {
+			continue
+		}
+		jsonMT, ok := content["application/json"]
+		if !ok || jsonMT == nil {
+			continue
+		}
+		// Shallow-copy the MediaType so the JSON and form entries stay
+		// decoupled. Future spec-post-processing (adding an example, a
+		// content-type-specific encoding hint) must not cross-contaminate.
+		// Nested pointers (Schema, Examples, Encoding) are shared — safe
+		// because those structures are not mutated after registration.
+		formMT := *jsonMT
+		content["application/x-www-form-urlencoded"] = &formMT
+	}
 }
 
 func (a *API) tokenOp(ctx context.Context, input *TokenInput) (*TokenOutput, error) {

--- a/server.go
+++ b/server.go
@@ -687,9 +687,17 @@ func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		// ParseForm reads and consumes r.Body for urlencoded POSTs and caps
-		// the read at Go's defaultMaxFormSize (10 MiB), matching the blanket
-		// 10 MiB body cap applied by requestValidationMiddleware elsewhere.
+		// Apply the same 10 MiB body cap that requestValidationMiddleware
+		// enforces on JSON bodies. Go's ParseForm already imposes an internal
+		// 10 MiB defaultMaxFormSize, but wiring MaxBytesReader here makes the
+		// limit explicit in our own code — a reader who later raises the
+		// JSON cap will see the form cap in the same spot, and ParseForm
+		// short-circuits to MaxBytesError (with limit info) instead of the
+		// opaque "http: POST too large" string.
+		const maxBodySize = 10 * 1024 * 1024
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
+		// ParseForm reads and consumes r.Body for urlencoded POSTs.
 		if err := r.ParseForm(); err != nil {
 			writeValidationError(w, r, "malformed form body: "+err.Error())
 			return

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -639,39 +640,56 @@ func errorRecoveryMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// oauthFormEndpoints lists paths that MUST accept application/x-www-form-urlencoded
+// OAuthFormEndpoints lists paths that MUST accept application/x-www-form-urlencoded
 // per RFC 6749 §4, RFC 7662 §2.1, and RFC 7009 §2.1. Clients built to the
 // RFCs (e.g. pkg/authjwt real-time introspection) post form-encoded bodies,
 // so any mismatch between the spec and our JSON-only validation gate breaks
-// interoperability silently.
-var oauthFormEndpoints = map[string]struct{}{
+// interoperability silently. Exported so the handler layer can mirror the
+// list when advertising the alternate content type in the OpenAPI spec.
+var OAuthFormEndpoints = map[string]struct{}{
 	"/oauth2/token":            {},
 	"/oauth2/token/introspect": {},
 	"/oauth2/token/revoke":     {},
+}
+
+// mediaTypeEquals parses a Content-Type header and reports whether the media
+// type portion matches want (case-insensitive per RFC 7231 §3.1.1.1).
+// Parameters like charset are ignored for the comparison.
+func mediaTypeEquals(headerValue, want string) bool {
+	if headerValue == "" {
+		return false
+	}
+	mt, _, err := mime.ParseMediaType(headerValue)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(mt, want)
 }
 
 // oauthFormCompatMiddleware rewrites application/x-www-form-urlencoded bodies
 // on RFC OAuth endpoints into application/json so downstream Huma handlers
 // (which bind from JSON) and the JSON-only requestValidationMiddleware both
 // see a uniform shape. The target schemas for these endpoints are flat maps
-// of string fields, so form → JSON is a lossless flatten.
+// of string fields, so form → JSON is a lossless flatten when each parameter
+// appears at most once (RFC 6749 §3.1) and has a non-empty value (§3.2).
 func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if _, ok := oauthFormEndpoints[r.URL.Path]; !ok {
+		if _, ok := OAuthFormEndpoints[r.URL.Path]; !ok {
 			next.ServeHTTP(w, r)
 			return
 		}
-		ct := r.Header.Get("Content-Type")
-		if !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
+		if !mediaTypeEquals(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		// ParseForm reads and consumes r.Body for urlencoded POSTs.
+		// ParseForm reads and consumes r.Body for urlencoded POSTs and caps
+		// the read at Go's defaultMaxFormSize (10 MiB), matching the blanket
+		// 10 MiB body cap applied by requestValidationMiddleware elsewhere.
 		if err := r.ParseForm(); err != nil {
 			writeValidationError(w, r, "malformed form body: "+err.Error())
 			return
@@ -679,9 +697,23 @@ func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 
 		flat := make(map[string]string, len(r.PostForm))
 		for k, vs := range r.PostForm {
-			if len(vs) > 0 {
-				flat[k] = vs[0]
+			// RFC 6749 §3.1: request parameters MUST NOT be included more
+			// than once. Duplicate keys are rejected rather than silently
+			// collapsed to vs[0].
+			if len(vs) > 1 {
+				writeValidationError(w, r, "duplicate OAuth parameter: "+k)
+				return
 			}
+			if len(vs) == 0 {
+				continue
+			}
+			// RFC 6749 §3.2: parameters sent without a value MUST be treated
+			// as if they were omitted. Drop so downstream handlers see a
+			// missing field, not a bound empty string.
+			if vs[0] == "" {
+				continue
+			}
+			flat[k] = vs[0]
 		}
 
 		b, err := gojson.Marshal(flat)
@@ -693,8 +725,6 @@ func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 		r.Body = io.NopCloser(bytes.NewReader(b))
 		r.ContentLength = int64(len(b))
 		r.Header.Set("Content-Type", "application/json")
-		// Drop the legacy Content-Length-by-form signal; the ParseForm cache
-		// stays on the request for any downstream that wants it.
 		next.ServeHTTP(w, r)
 	})
 }
@@ -712,7 +742,7 @@ func requestValidationMiddleware(next http.Handler) http.Handler {
 				writeValidationError(w, r, "Content-Type header is required for "+r.Method+" requests")
 				return
 			}
-			if ct != "" && !strings.HasPrefix(ct, "application/json") {
+			if !mediaTypeEquals(ct, "application/json") {
 				writeValidationError(w, r, "Content-Type must be application/json, got: "+ct)
 				return
 			}
@@ -723,6 +753,19 @@ func requestValidationMiddleware(next http.Handler) http.Handler {
 }
 
 func writeValidationError(w http.ResponseWriter, r *http.Request, msg string) {
+	// Emit a log line here because the validation middlewares run before
+	// structuredLoggingMiddleware — without this, rejected requests leave no
+	// trace for operators. Use Info (not Warn/Error) because these are client
+	// mistakes, not server faults.
+	reqID := chimiddleware.GetReqID(r.Context())
+	log.Info().
+		Str("request_id", reqID).
+		Str("method", r.Method).
+		Str("path", r.RequestURI).
+		Str("content_type", r.Header.Get("Content-Type")).
+		Str("reason", msg).
+		Msg("request validation rejected")
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	errResp := map[string]any{
@@ -734,7 +777,7 @@ func writeValidationError(w http.ResponseWriter, r *http.Request, msg string) {
 			"timestamp":    time.Now().UTC().Format(time.RFC3339),
 		},
 	}
-	if reqID := chimiddleware.GetReqID(r.Context()); reqID != "" {
+	if reqID != "" {
 		errResp["error"].(map[string]any)["requestId"] = reqID
 	}
 	_ = gojson.NewEncoder(w).Encode(errResp)

--- a/server.go
+++ b/server.go
@@ -1,9 +1,11 @@
 package zeroid
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -191,6 +193,10 @@ func NewServer(cfg Config) (*Server, error) {
 	// Global middleware.
 	r.Use(chimiddleware.RequestID)
 	r.Use(chimiddleware.RealIP)
+	// oauthFormCompat must run before requestValidationMiddleware so that
+	// RFC-mandated form-encoded bodies on /oauth2/* endpoints are rewritten
+	// to JSON before the JSON-only Content-Type gate runs.
+	r.Use(oauthFormCompatMiddleware)
 	r.Use(requestValidationMiddleware)
 	r.Use(errorRecoveryMiddleware)
 	r.Use(structuredLoggingMiddleware)
@@ -629,6 +635,66 @@ func errorRecoveryMiddleware(next http.Handler) http.Handler {
 				_ = gojson.NewEncoder(w).Encode(errResp)
 			}
 		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// oauthFormEndpoints lists paths that MUST accept application/x-www-form-urlencoded
+// per RFC 6749 §4, RFC 7662 §2.1, and RFC 7009 §2.1. Clients built to the
+// RFCs (e.g. pkg/authjwt real-time introspection) post form-encoded bodies,
+// so any mismatch between the spec and our JSON-only validation gate breaks
+// interoperability silently.
+var oauthFormEndpoints = map[string]struct{}{
+	"/oauth2/token":            {},
+	"/oauth2/token/introspect": {},
+	"/oauth2/token/revoke":     {},
+}
+
+// oauthFormCompatMiddleware rewrites application/x-www-form-urlencoded bodies
+// on RFC OAuth endpoints into application/json so downstream Huma handlers
+// (which bind from JSON) and the JSON-only requestValidationMiddleware both
+// see a uniform shape. The target schemas for these endpoints are flat maps
+// of string fields, so form → JSON is a lossless flatten.
+func oauthFormCompatMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if _, ok := oauthFormEndpoints[r.URL.Path]; !ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		ct := r.Header.Get("Content-Type")
+		if !strings.HasPrefix(ct, "application/x-www-form-urlencoded") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// ParseForm reads and consumes r.Body for urlencoded POSTs.
+		if err := r.ParseForm(); err != nil {
+			writeValidationError(w, r, "malformed form body: "+err.Error())
+			return
+		}
+
+		flat := make(map[string]string, len(r.PostForm))
+		for k, vs := range r.PostForm {
+			if len(vs) > 0 {
+				flat[k] = vs[0]
+			}
+		}
+
+		b, err := gojson.Marshal(flat)
+		if err != nil {
+			writeValidationError(w, r, "failed to re-encode form body: "+err.Error())
+			return
+		}
+
+		r.Body = io.NopCloser(bytes.NewReader(b))
+		r.ContentLength = int64(len(b))
+		r.Header.Set("Content-Type", "application/json")
+		// Drop the legacy Content-Length-by-form signal; the ParseForm cache
+		// stays on the request for any downstream that wants it.
 		next.ServeHTTP(w, r)
 	})
 }

--- a/tests/integration/oauth_form_compat_test.go
+++ b/tests/integration/oauth_form_compat_test.go
@@ -88,3 +88,109 @@ func TestOAuthFormCompatDoesNotLeakToOtherEndpoints(t *testing.T) {
 		"non-OAuth endpoints must still reject form-encoded bodies")
 	_ = resp.Body.Close()
 }
+
+// TestOAuthFormCompatContentTypeCaseInsensitive verifies RFC 7231 §3.1.1.1
+// case-insensitive media-type matching: a mixed-case Content-Type value and
+// a charset parameter must still be accepted.
+func TestOAuthFormCompatContentTypeCaseInsensitive(t *testing.T) {
+	agentID := uid("form-compat-case")
+	scopes := []string{"data:read"}
+	registerIdentity(t, agentID, scopes)
+	client := registerOAuthClient(t, agentID, scopes)
+
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"account_id":    {testAccountID},
+		"project_id":    {testProjectID},
+		"client_id":     {client.ClientID},
+		"client_secret": {client.ClientSecret},
+		"scope":         {"data:read"},
+	}
+	req, err := http.NewRequest(http.MethodPost, testServer.URL+"/oauth2/token", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "Application/X-WWW-Form-Urlencoded; charset=UTF-8")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"mixed-case Content-Type with charset param must be accepted")
+}
+
+// TestOAuthFormCompatRejectsDuplicateParams enforces RFC 6749 §3.1: request
+// parameters MUST NOT be included more than once. Duplicates must be
+// rejected, not silently collapsed to the first value.
+func TestOAuthFormCompatRejectsDuplicateParams(t *testing.T) {
+	// Handcraft a body with a repeated parameter.
+	body := "grant_type=client_credentials&scope=a&scope=b"
+	req, err := http.NewRequest(http.MethodPost, testServer.URL+"/oauth2/token", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"duplicate OAuth parameters must be rejected (RFC 6749 §3.1)")
+	var body400 map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body400))
+	errObj, ok := body400["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, errObj["message"], "duplicate OAuth parameter")
+}
+
+// TestOAuthFormCompatEmptyParamsOmitted enforces RFC 6749 §3.2: parameters
+// sent without a value MUST be treated as if they were omitted. Verified by
+// sending an empty scope param — the request should still succeed and the
+// missing-scope semantics should apply (no mandatory-field failure because
+// of the empty value, no bound empty-string on the server side).
+func TestOAuthFormCompatEmptyParamsOmitted(t *testing.T) {
+	agentID := uid("form-compat-empty")
+	scopes := []string{"data:read"}
+	registerIdentity(t, agentID, scopes)
+	client := registerOAuthClient(t, agentID, scopes)
+
+	resp := postForm(t, "/oauth2/token", url.Values{
+		"grant_type":    {"client_credentials"},
+		"account_id":    {testAccountID},
+		"project_id":    {testProjectID},
+		"client_id":     {client.ClientID},
+		"client_secret": {client.ClientSecret},
+		// scope intentionally empty — must be treated as omitted.
+		"scope": {""},
+	})
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"empty-value params must be treated as omitted, not a bind error")
+}
+
+// TestOAuthFormCompatOpenAPIAdvertisesFormContentType confirms that the
+// OpenAPI specification exposes application/x-www-form-urlencoded alongside
+// application/json for each OAuth endpoint so generated clients and docs
+// know which wire shapes the server accepts.
+func TestOAuthFormCompatOpenAPIAdvertisesFormContentType(t *testing.T) {
+	resp, err := http.Get(testServer.URL + "/openapi.json")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var spec map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&spec))
+
+	paths, _ := spec["paths"].(map[string]any)
+	require.NotNil(t, paths)
+
+	for _, p := range []string{"/oauth2/token", "/oauth2/token/introspect", "/oauth2/token/revoke"} {
+		pathItem, _ := paths[p].(map[string]any)
+		require.NotNil(t, pathItem, "path %s missing from OpenAPI spec", p)
+		op, _ := pathItem["post"].(map[string]any)
+		require.NotNil(t, op, "post op missing for %s", p)
+		reqBody, _ := op["requestBody"].(map[string]any)
+		require.NotNil(t, reqBody, "requestBody missing for %s", p)
+		content, _ := reqBody["content"].(map[string]any)
+		require.NotNil(t, content, "content missing for %s", p)
+		assert.Contains(t, content, "application/json", "%s must advertise JSON", p)
+		assert.Contains(t, content, "application/x-www-form-urlencoded",
+			"%s must advertise form encoding per RFC 6749/7662/7009", p)
+	}
+}

--- a/tests/integration/oauth_form_compat_test.go
+++ b/tests/integration/oauth_form_compat_test.go
@@ -1,0 +1,90 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// postForm posts an application/x-www-form-urlencoded body to the test server
+// and returns the response. Mirrors the request shape the SDK's
+// pkg/authjwt.Verifier produces for real-time introspection and the shape
+// every RFC 6749/7662/7009 client produces by default.
+func postForm(t *testing.T, path string, form url.Values) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, testServer.URL+path, strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestOAuthFormCompatTokenIntrospectRevoke exercises the full RFC 6749/7662/7009
+// form-encoded happy path. Guards against regressions of the incompatibility
+// where the global JSON-only Content-Type gate rejected spec-compliant clients
+// (notably pkg/authjwt.VerifyRealTime) with a 400 before the OAuth handlers
+// ever saw the request.
+func TestOAuthFormCompatTokenIntrospectRevoke(t *testing.T) {
+	agentID := uid("form-compat")
+	scopes := []string{"data:read"}
+	registerIdentity(t, agentID, scopes)
+	client := registerOAuthClient(t, agentID, scopes)
+
+	// 1. Token endpoint — form-encoded client_credentials grant.
+	tokenResp := postForm(t, "/oauth2/token", url.Values{
+		"grant_type":    {"client_credentials"},
+		"account_id":    {testAccountID},
+		"project_id":    {testProjectID},
+		"client_id":     {client.ClientID},
+		"client_secret": {client.ClientSecret},
+		"scope":         {"data:read"},
+	})
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode,
+		"form-encoded token request must be accepted (RFC 6749 §4.4.2)")
+	var tokBody map[string]any
+	require.NoError(t, json.NewDecoder(tokenResp.Body).Decode(&tokBody))
+	_ = tokenResp.Body.Close()
+	accessToken, _ := tokBody["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	// 2. Introspect endpoint — form-encoded (RFC 7662 §2.1).
+	introspectResp := postForm(t, "/oauth2/token/introspect", url.Values{"token": {accessToken}})
+	require.Equal(t, http.StatusOK, introspectResp.StatusCode,
+		"form-encoded introspect must be accepted (RFC 7662 §2.1)")
+	var introBody map[string]any
+	require.NoError(t, json.NewDecoder(introspectResp.Body).Decode(&introBody))
+	_ = introspectResp.Body.Close()
+	assert.True(t, introBody["active"].(bool), "token should introspect active")
+
+	// 3. Revoke endpoint — form-encoded (RFC 7009 §2.1).
+	revokeResp := postForm(t, "/oauth2/token/revoke", url.Values{"token": {accessToken}})
+	require.Equal(t, http.StatusOK, revokeResp.StatusCode,
+		"form-encoded revoke must be accepted (RFC 7009 §2.1)")
+	_, _ = io.Copy(io.Discard, revokeResp.Body)
+	_ = revokeResp.Body.Close()
+
+	// 4. Introspect again — should now be inactive.
+	introspectResp = postForm(t, "/oauth2/token/introspect", url.Values{"token": {accessToken}})
+	require.Equal(t, http.StatusOK, introspectResp.StatusCode)
+	require.NoError(t, json.NewDecoder(introspectResp.Body).Decode(&introBody))
+	_ = introspectResp.Body.Close()
+	assert.False(t, introBody["active"].(bool), "token should introspect inactive after revocation")
+}
+
+// TestOAuthFormCompatDoesNotLeakToOtherEndpoints confirms the form-compat
+// rewrite is scoped only to the OAuth endpoints it targets. Form-encoded
+// bodies to non-OAuth POST endpoints must still be rejected by the JSON-only
+// validator.
+func TestOAuthFormCompatDoesNotLeakToOtherEndpoints(t *testing.T) {
+	resp := postForm(t, adminPath("/identities"), url.Values{"external_id": {"x"}})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"non-OAuth endpoints must still reject form-encoded bodies")
+	_ = resp.Body.Close()
+}


### PR DESCRIPTION
Closes #95.

The global request validator enforces application/json on all mutating requests, but OAuth endpoints are advertised as RFC-compliant and real clients (including pkg/authjwt.VerifyRealTime) post application/x-www-form-urlencoded per spec. Those requests were being rejected with 400 before the handlers ever ran, silently breaking real-time revocation checks.

Adds oauthFormCompatMiddleware ahead of the JSON gate. For POSTs to /oauth2/token, /oauth2/token/introspect, and /oauth2/token/revoke with application/x-www-form-urlencoded, it parses the form, re-encodes as JSON, and rewrites Content-Type so downstream Huma handlers bind normally. Non-OAuth paths are untouched, while form bodies are still rejected.

  Test plan                                                                                                        
                                                                                                                   
  - New tests/integration/oauth_form_compat_test.go: full form-encoded token → introspect(active) → revoke →       
  introspect(inactive) round-trip                                                                                  
  - Negative test: form-encoded POST to /api/v1/identities still 400s
  - Full integration suite: 51 tests, all green                                                              
  - golangci-lint: 0 issues 