### PR TITLE
fix(security): scope API key get/revoke and signal auto-revoke to caller tenant

### DIFF
--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -152,11 +152,12 @@ func (a *API) createAPIKeyOp(ctx context.Context, input *CreateAPIKeyInput) (*Cr
 }
 
 func (a *API) getAPIKeyOp(ctx context.Context, input *APIKeyIDInput) (*APIKeyOutput, error) {
-	if _, err := internalMiddleware.GetTenant(ctx); err != nil {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	sk, err := a.apiKeySvc.GetKey(ctx, input.ID)
+	sk, err := a.apiKeySvc.GetKey(ctx, input.ID, tenant.AccountID, tenant.ProjectID)
 	if err != nil {
 		return nil, huma.Error404NotFound("API key not found")
 	}
@@ -189,15 +190,23 @@ func (a *API) listAPIKeysOp(ctx context.Context, input *APIKeyListInput) (*APIKe
 }
 
 func (a *API) revokeAPIKeyOp(ctx context.Context, input *RevokeAPIKeyInput) (*RevokeAPIKeyOutput, error) {
-	if _, err := internalMiddleware.GetTenant(ctx); err != nil {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
 	revokedBy := internalMiddleware.GetCallerName(ctx)
 
-	if err := a.apiKeySvc.RevokeKey(ctx, input.ID, revokedBy, input.Body.Reason); err != nil {
+	n, err := a.apiKeySvc.RevokeKey(ctx, input.ID, tenant.AccountID, tenant.ProjectID, revokedBy, input.Body.Reason)
+	if err != nil {
 		log.Error().Err(err).Str("key_id", input.ID).Msg("failed to revoke API key")
 		return nil, huma.Error500InternalServerError("failed to revoke API key")
+	}
+	// Zero rows affected means the key either doesn't exist in this tenant
+	// or is already revoked. Return 404 so cross-tenant callers see the same
+	// response as hitting a truly missing key — avoids existence disclosure.
+	if n == 0 {
+		return nil, huma.Error404NotFound("API key not found")
 	}
 
 	out := &RevokeAPIKeyOutput{}

--- a/internal/service/apikey.go
+++ b/internal/service/apikey.go
@@ -216,14 +216,19 @@ func (s *APIKeyService) ListKeys(ctx context.Context, accountID, projectID, appl
 	return s.repo.ListByAccountProject(ctx, accountID, projectID, applicationID, product, label, limit, offset)
 }
 
-// GetKey returns an API key by ID.
-func (s *APIKeyService) GetKey(ctx context.Context, id string) (*domain.APIKey, error) {
-	return s.repo.GetByID(ctx, id)
+// GetKey returns an API key by ID, scoped to the given tenant. Cross-tenant
+// IDs surface as not-found to prevent existence disclosure.
+func (s *APIKeyService) GetKey(ctx context.Context, id, accountID, projectID string) (*domain.APIKey, error) {
+	return s.repo.GetByID(ctx, id, accountID, projectID)
 }
 
-// RevokeKey revokes an API key by ID.
-func (s *APIKeyService) RevokeKey(ctx context.Context, id, revokedBy, reason string) error {
-	return s.repo.Revoke(ctx, id, revokedBy, reason)
+// RevokeKey revokes an API key by ID, scoped to the given tenant. Returns the
+// number of rows affected — zero means either "not in this tenant" or
+// "already revoked". Callers that need to distinguish can probe GetKey first,
+// but the common revoke-by-ID path treats both as a silent no-op to avoid
+// leaking cross-tenant existence.
+func (s *APIKeyService) RevokeKey(ctx context.Context, id, accountID, projectID, revokedBy, reason string) (int64, error) {
+	return s.repo.Revoke(ctx, id, accountID, projectID, revokedBy, reason)
 }
 
 // generateAPIKey creates a cryptographically random API key with the given prefix.

--- a/internal/service/signal.go
+++ b/internal/service/signal.go
@@ -19,18 +19,23 @@ type SignalSubscriber chan *domain.CAESignal
 
 // SignalService handles CAE signal ingestion and fan-out to subscribers.
 type SignalService struct {
-	repo        *postgres.SignalRepository
-	credRepo    *postgres.CredentialRepository
-	mu          sync.RWMutex
-	subscribers map[string]SignalSubscriber
+	repo         *postgres.SignalRepository
+	credRepo     *postgres.CredentialRepository
+	identityRepo *postgres.IdentityRepository
+	mu           sync.RWMutex
+	subscribers  map[string]SignalSubscriber
 }
 
-// NewSignalService creates a new SignalService.
-func NewSignalService(repo *postgres.SignalRepository, credRepo *postgres.CredentialRepository) *SignalService {
+// NewSignalService creates a new SignalService. identityRepo is required so
+// IngestSignal can verify that a caller-supplied identity_id actually belongs
+// to the caller's tenant before cascading a high/critical-severity revoke
+// to its credentials.
+func NewSignalService(repo *postgres.SignalRepository, credRepo *postgres.CredentialRepository, identityRepo *postgres.IdentityRepository) *SignalService {
 	return &SignalService{
-		repo:        repo,
-		credRepo:    credRepo,
-		subscribers: make(map[string]SignalSubscriber),
+		repo:         repo,
+		credRepo:     credRepo,
+		identityRepo: identityRepo,
+		subscribers:  make(map[string]SignalSubscriber),
 	}
 }
 
@@ -60,17 +65,34 @@ func (s *SignalService) IngestSignal(ctx context.Context, accountID, projectID, 
 		Msg("CAE signal ingested")
 
 	// Auto-revoke all active credentials for high/critical severity signals.
+	// Gate the destructive cascade on a tenant-scoped identity lookup: the
+	// signal row itself is scoped by the caller's tenant, but the underlying
+	// RevokeAllActiveForIdentity repo call takes only an identity UUID. A
+	// caller who submits a signal with another tenant's identity_id would
+	// otherwise revoke that tenant's credentials by UUID guess. The signal
+	// is still stored so the audit trail of the attempt lives in the
+	// caller's tenant log.
 	if identityID != "" && (severity == domain.SignalSeverityHigh || severity == domain.SignalSeverityCritical) {
-		reason := fmt.Sprintf("auto-revoked by CAE signal %s (severity: %s)", signal.ID, severity)
-		n, err := s.credRepo.RevokeAllActiveForIdentity(ctx, identityID, reason)
-		if err != nil {
-			log.Error().Err(err).Str("identity_id", identityID).Msg("Failed to auto-revoke credentials on high/critical signal")
-		} else if n > 0 {
-			log.Info().
-				Int64("revoked_count", n).
-				Str("identity_id", identityID).
+		if _, err := s.identityRepo.GetByID(ctx, identityID, accountID, projectID); err != nil {
+			log.Warn().
+				Err(err).
 				Str("signal_id", signal.ID).
-				Msg("Auto-revoked credentials due to high/critical CAE signal")
+				Str("identity_id", identityID).
+				Str("account_id", accountID).
+				Str("project_id", projectID).
+				Msg("signal references identity outside caller tenant; skipping auto-revoke")
+		} else {
+			reason := fmt.Sprintf("auto-revoked by CAE signal %s (severity: %s)", signal.ID, severity)
+			n, err := s.credRepo.RevokeAllActiveForIdentity(ctx, identityID, reason)
+			if err != nil {
+				log.Error().Err(err).Str("identity_id", identityID).Msg("Failed to auto-revoke credentials on high/critical signal")
+			} else if n > 0 {
+				log.Info().
+					Int64("revoked_count", n).
+					Str("identity_id", identityID).
+					Str("signal_id", signal.ID).
+					Msg("Auto-revoked credentials due to high/critical CAE signal")
+			}
 		}
 	}
 

--- a/internal/store/postgres/apikey.go
+++ b/internal/store/postgres/apikey.go
@@ -56,12 +56,16 @@ func (r *APIKeyRepository) UpdateLastUsed(ctx context.Context, id, ip string) er
 	return err
 }
 
-// GetByID retrieves an API key by its UUID.
-func (r *APIKeyRepository) GetByID(ctx context.Context, id string) (*domain.APIKey, error) {
+// GetByID retrieves an API key by its UUID, scoped to the given tenant.
+// Cross-tenant lookups return the same not-found error as a missing key so
+// callers cannot probe for key existence in other tenants by ID.
+func (r *APIKeyRepository) GetByID(ctx context.Context, id, accountID, projectID string) (*domain.APIKey, error) {
 	sk := new(domain.APIKey)
 	err := r.db.NewSelect().
 		Model(sk).
 		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
 		Scan(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("API key not found: %w", err)
@@ -110,10 +114,13 @@ func (r *APIKeyRepository) ListByAccountProject(ctx context.Context, accountID, 
 	return keys, count, nil
 }
 
-// Revoke marks an API key as revoked.
-func (r *APIKeyRepository) Revoke(ctx context.Context, id, revokedBy, reason string) error {
+// Revoke marks an API key as revoked, scoped to the given tenant. Returns
+// the number of rows updated so callers can distinguish "key exists in
+// another tenant / already revoked" (0 rows) from "revoked now" (1 row)
+// without disclosing cross-tenant existence to end users.
+func (r *APIKeyRepository) Revoke(ctx context.Context, id, accountID, projectID, revokedBy, reason string) (int64, error) {
 	now := time.Now()
-	_, err := r.db.NewUpdate().
+	res, err := r.db.NewUpdate().
 		Model((*domain.APIKey)(nil)).
 		Set("state = ?", domain.APIKeyStateRevoked).
 		Set("revoked_at = ?", now).
@@ -121,9 +128,18 @@ func (r *APIKeyRepository) Revoke(ctx context.Context, id, revokedBy, reason str
 		Set("revoke_reason = ?", reason).
 		Set("updated_at = ?", now).
 		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
 		Where("state = ?", domain.APIKeyStateActive).
 		Exec(ctx)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // GetActiveByIdentityID retrieves the active API key for an identity.

--- a/server.go
+++ b/server.go
@@ -170,7 +170,7 @@ func NewServer(cfg Config) (*Server, error) {
 		AuthCodeIssuer: authCodeIssuer,
 	})
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
-	signalSvc := service.NewSignalService(signalRepo, credentialRepo)
+	signalSvc := service.NewSignalService(signalRepo, credentialRepo, identityRepo)
 
 	// Create shared API handler.
 	apiHandler := handler.NewAPI(

--- a/tests/integration/tenant_isolation_test.go
+++ b/tests/integration/tenant_isolation_test.go
@@ -1,0 +1,197 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerIdentityIn creates an identity under a specific tenant, used for
+// cross-tenant IDOR test scenarios where the default tenant helpers would
+// collapse both sides into one tenant.
+func registerIdentityIn(t *testing.T, headers map[string]string, externalID string, scopes []string) identityResp {
+	t.Helper()
+	body := map[string]any{
+		"external_id":    externalID,
+		"trust_level":    "unverified",
+		"owner_user_id":  "user-test-owner",
+		"allowed_scopes": scopes,
+	}
+	resp := post(t, adminPath("/identities"), body, headers)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "registerIdentityIn: expected 201, got %d", resp.StatusCode)
+	decoded := decode(t, resp)
+	return identityResp{
+		ID:         decoded["id"].(string),
+		ExternalID: decoded["external_id"].(string),
+	}
+}
+
+// createAPIKeyIn creates an API key under a specific tenant and returns the
+// key's UUID. Exercises the same POST /api-keys handler but via caller-
+// supplied tenant headers rather than the default test tenant.
+func createAPIKeyIn(t *testing.T, headers map[string]string, name, product string) string {
+	t.Helper()
+	resp := post(t, adminPath("/api-keys"), map[string]any{
+		"name":    name,
+		"product": product,
+	}, headers)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "createAPIKeyIn: expected 201")
+	body := decode(t, resp)
+	id, _ := body["id"].(string)
+	require.NotEmpty(t, id, "createAPIKeyIn: response missing id")
+	return id
+}
+
+// TestAPIKeyGetIsTenantScoped verifies a caller with tenant B's headers cannot
+// GET /api-keys/{id} for a key that belongs to tenant A, even with the correct
+// UUID. Guards the IDOR at handler:getAPIKeyOp that previously dropped tenant
+// context between the middleware check and the service lookup.
+func TestAPIKeyGetIsTenantScoped(t *testing.T) {
+	tenantA := tenantHeaders("acct-apikey-a-"+uid(""), "proj-apikey-a-"+uid(""))
+	tenantB := tenantHeaders("acct-apikey-b-"+uid(""), "proj-apikey-b-"+uid(""))
+
+	keyID := createAPIKeyIn(t, tenantA, "tenant-a-key", "idor-test")
+
+	// Tenant A owns the key — GET must succeed.
+	ownResp := get(t, adminPath("/api-keys/"+keyID), tenantA)
+	require.Equal(t, http.StatusOK, ownResp.StatusCode,
+		"owning tenant must be able to read its own key")
+	_ = ownResp.Body.Close()
+
+	// Tenant B presenting the correct UUID must see 404 — not the key body,
+	// not a 403 (existence disclosure).
+	crossResp := get(t, adminPath("/api-keys/"+keyID), tenantB)
+	assert.Equal(t, http.StatusNotFound, crossResp.StatusCode,
+		"cross-tenant GET /api-keys/{id} must return 404")
+	_ = crossResp.Body.Close()
+}
+
+// TestAPIKeyRevokeIsTenantScoped verifies that tenant B cannot revoke tenant
+// A's API key even if B knows the UUID. The key remains usable afterward —
+// we confirm by introspecting a token minted from it.
+func TestAPIKeyRevokeIsTenantScoped(t *testing.T) {
+	tenantA := tenantHeaders("acct-revoke-a-"+uid(""), "proj-revoke-a-"+uid(""))
+	tenantB := tenantHeaders("acct-revoke-b-"+uid(""), "proj-revoke-b-"+uid(""))
+
+	// Tenant A: create a key that can mint tokens.
+	createResp := post(t, adminPath("/api-keys"), map[string]any{
+		"name":    "tenant-a-revoke-target",
+		"product": "idor-revoke",
+	}, tenantA)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+	created := decode(t, createResp)
+	keyID := created["id"].(string)
+	apiKey := created["key"].(string)
+	require.NotEmpty(t, apiKey)
+
+	// Sanity: the key works in its own tenant.
+	tokResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, tokResp.StatusCode, "tenant A key must issue tokens")
+	token := decode(t, tokResp)["access_token"].(string)
+
+	// Tenant B: try to revoke by UUID.
+	revResp := post(t, adminPath("/api-keys/"+keyID+"/revoke"), map[string]any{
+		"reason": "IDOR attempt",
+	}, tenantB)
+	assert.Equal(t, http.StatusNotFound, revResp.StatusCode,
+		"cross-tenant revoke must return 404, not 200 'revoked'")
+	_ = revResp.Body.Close()
+
+	// Tenant A's token must still introspect as active — the revoke must not
+	// have touched the underlying state.
+	after := introspect(t, token)
+	assert.True(t, after["active"].(bool),
+		"target tenant's token must stay active after cross-tenant revoke attempt")
+
+	// Same-tenant revoke still works normally.
+	ownRev := post(t, adminPath("/api-keys/"+keyID+"/revoke"), map[string]any{
+		"reason": "cleanup",
+	}, tenantA)
+	assert.Equal(t, http.StatusOK, ownRev.StatusCode,
+		"owning tenant must still be able to revoke its own key")
+	_ = ownRev.Body.Close()
+}
+
+// TestSignalHighSeverityAutoRevokeIsTenantScoped verifies the CAE auto-revoke
+// cascade only fires when the caller-supplied identity_id actually belongs to
+// the caller's tenant. Otherwise a caller with any valid tenant headers could
+// revoke another tenant's credentials by guessing an identity UUID.
+func TestSignalHighSeverityAutoRevokeIsTenantScoped(t *testing.T) {
+	tenantA := tenantHeaders("acct-sig-a-"+uid(""), "proj-sig-a-"+uid(""))
+	tenantB := tenantHeaders("acct-sig-b-"+uid(""), "proj-sig-b-"+uid(""))
+
+	// Tenant A: register identity + OAuth client + mint a token. Cross-tenant
+	// mint needs the identity and client in the same tenant, so bind the
+	// client_id to the identity's external_id — matches the wiring used by
+	// OAuthService.clientCredentials for identity resolution.
+	victimExternalID := uid("victim-agent")
+	identA := registerIdentityIn(t, tenantA, victimExternalID, []string{"data:read"})
+	oauthResp := post(t, adminPath("/oauth/clients"), map[string]any{
+		"client_id":    victimExternalID,
+		"name":         victimExternalID + "-client",
+		"confidential": true,
+		"grant_types":  []string{"client_credentials"},
+		"scopes":       []string{"data:read"},
+	}, tenantA)
+	require.Equal(t, http.StatusCreated, oauthResp.StatusCode, "oauth client creation failed")
+	clientBody := decode(t, oauthResp)
+	client := clientBody["client"].(map[string]any)
+	clientID := client["client_id"].(string)
+	clientSecret := clientBody["client_secret"].(string)
+
+	tokResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    tenantA["X-Account-ID"],
+		"project_id":    tenantA["X-Project-ID"],
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, tokResp.StatusCode, "victim tenant token mint failed")
+	victimToken := decode(t, tokResp)["access_token"].(string)
+	require.True(t, introspect(t, victimToken)["active"].(bool),
+		"victim token must start active")
+
+	// Tenant B: submit a high-severity signal carrying tenant A's identity_id.
+	// The signal row itself is allowed to be recorded under tenant B (audit
+	// trail of the attempt), but the auto-revoke cascade must NOT fire.
+	sigResp := post(t, adminPath("/signals/ingest"), map[string]any{
+		"identity_id": identA.ID,
+		"signal_type": "anomalous_behavior",
+		"severity":    "high",
+		"source":      "idor-test",
+		"payload":     map[string]any{"reason": "cross-tenant revoke attempt"},
+	}, tenantB)
+	require.Equal(t, http.StatusCreated, sigResp.StatusCode,
+		"signal ingest should succeed so the attempt is auditable in the caller tenant")
+	_ = sigResp.Body.Close()
+
+	// Give any async revoke goroutine a moment.
+	time.Sleep(150 * time.Millisecond)
+
+	// Victim token must still be active.
+	result := introspect(t, victimToken)
+	assert.True(t, result["active"].(bool),
+		"cross-tenant high-severity signal must NOT revoke another tenant's credentials")
+
+	// Sanity check: a same-tenant high-severity signal DOES still revoke.
+	sameTenantSig := post(t, adminPath("/signals/ingest"), map[string]any{
+		"identity_id": identA.ID,
+		"signal_type": "anomalous_behavior",
+		"severity":    "high",
+		"source":      "idor-test-control",
+		"payload":     map[string]any{"reason": "same-tenant control"},
+	}, tenantA)
+	require.Equal(t, http.StatusCreated, sameTenantSig.StatusCode)
+	_ = sameTenantSig.Body.Close()
+	time.Sleep(150 * time.Millisecond)
+	result = introspect(t, victimToken)
+	assert.False(t, result["active"].(bool),
+		"same-tenant high-severity signal must still revoke (sanity check)")
+}


### PR DESCRIPTION
Closes #96.


## Summary
Two IDOR bugs in admin paths that only checked "some tenant context exists" and then operated on UUIDs without the tenant filter:

- GET /api-keys/{id} and POST /api-keys/{id}/revoke resolved keys by UUID alone. A caller with any valid tenant headers could read or revoke another tenant's key. Repo GetByID/Revoke now require account_id + project_id and the SQL filters on them. Revoke returns rows-affected so the handler can return 404 on cross-tenant IDs rather than silently 200 "revoked".

- SignalService.IngestSignal recorded the signal with the caller's tenant but the high/critical auto-revoke cascade called RevokeAllActiveForIdentity with identity_id only. A cross-tenant identity UUID would revoke the target tenant's credentials. The service now does a tenant-scoped identity lookup before cascading; the signal itself is still stored so the audit trail of the attempt lives in the caller's tenant log.

Behavior change worth naming: same-tenant double-revoke of an API key now returns 404 on the second call (previously idempotent 200). This is the tradeoff for making cross-tenant and not-found responses identical so existence is not disclosed. No existing test relies on the old idempotency.
                                                                                                                  
##  Test plan                                                 

  - New tests/integration/tenant_isolation_test.go:                                                                
    - TestAPIKeyGetIsTenantScoped: B revoke A's key → 404
    - TestAPIKeyRevokeIsTenantScoped: B revoke A's key → 404, A's token stays active                            
    - TestSignalHighSeverityAutoRevokeIsTenantScoped: B submits signal with A's identity_id → signal recorded in  
  B's tenant, A's token stays active; then same-tenant control signal correctly revokes                            
  - Full suite: 52 tests, 7.9s, all green                                                                          
  - golangci-lint: 0 issues   
