### PR TITLE
replace attestation trust-promotion stub with pluggable verifiers (OIDC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ OAuth/OIDC authenticates a human to a service. **ZeroID implements true delegate
 - **WIMSE/SPIFFE URIs** — Stable, globally unique identity URIs: `spiffe://{domain}/{account}/{project}/{type}/{id}` for every agent. Tokens carry the WIMSE URI as `sub`, so every downstream system receives a meaningful, verifiable identity—not just a client ID.
 - **Credential Policies** — Governance templates that enforce TTL, allowed grant types, required trust levels, and max delegation depth. Defines each agent's operational envelope programmatically, replacing per-action consent with policy-based controls.
 - **Continuous Access Evaluation (CAE)** — Revoke credentials in real time when risk signals fire via the OpenID Shared Signals Framework (SSF). Revoke the orchestrator's credential and the entire downstream chain is invalidated immediately—no waiting for token expiry.
-- **Attestation Framework** — Software, platform, and hardware attestation to bootstrap or elevate trust levels before credentials are issued.
+- **Attestation Framework** — Pluggable verifiers behind a fail-closed contract: software, platform, and hardware attestation elevate trust levels before credentials are issued. Ships with an OIDC verifier (GitHub Actions, GCP Workload Identity, Kubernetes projected SA tokens, etc.) plus per-tenant `AttestationPolicy` for issuer allowlisting and claim binding. Full reference: [`docs/attestation.md`](docs/attestation.md).
 - **WIMSE Proof Tokens** — Single-use, nonce-bound tokens for service-to-service verification and replay protection.
 
 ---
@@ -632,7 +632,12 @@ graph TD
 | GET | `/api/v1/credential-policies/{id}` | Get credential policy |
 | PATCH | `/api/v1/credential-policies/{id}` | Update credential policy |
 | POST | `/api/v1/credentials/{id}/revoke` | Revoke credential |
-| POST | `/api/v1/attestations` | Submit attestation |
+| POST | `/api/v1/attestation/submit` | Submit attestation proof |
+| POST | `/api/v1/attestation/verify` | Verify proof + promote trust + issue credential |
+| GET | `/api/v1/attestation/{id}` | Get attestation record |
+| PUT | `/api/v1/attestation-policies` | Upsert per-tenant attestation policy |
+| GET | `/api/v1/attestation-policies` | List attestation policies |
+| DELETE | `/api/v1/attestation-policies/{id}` | Delete attestation policy |
 | POST | `/api/v1/signals/ingest` | Ingest CAE signal |
 | GET | `/api/v1/signals/stream` | SSE signal stream |
 | POST | `/api/v1/proofs/generate` | Generate WIMSE proof token |

--- a/config.go
+++ b/config.go
@@ -21,15 +21,28 @@ const DefaultAdminPathPrefix = "/api/v1"
 
 // Config holds the complete ZeroID service configuration.
 type Config struct {
-	Server    ServerConfig    `koanf:"server"`
-	Database  DatabaseConfig  `koanf:"database"`
-	Keys      KeysConfig      `koanf:"keys"`
-	Token     TokenConfig     `koanf:"token"`
-	Telemetry TelemetryConfig `koanf:"telemetry"`
-	Logging   LoggingConfig   `koanf:"logging"`
+	Server      ServerConfig      `koanf:"server"`
+	Database    DatabaseConfig    `koanf:"database"`
+	Keys        KeysConfig        `koanf:"keys"`
+	Token       TokenConfig       `koanf:"token"`
+	Telemetry   TelemetryConfig   `koanf:"telemetry"`
+	Logging     LoggingConfig     `koanf:"logging"`
+	Attestation AttestationConfig `koanf:"attestation"`
 
 	// WIMSEDomain is the domain prefix for SPIFFE/WIMSE URIs (e.g. "zeroid.dev").
 	WIMSEDomain string `koanf:"wimse_domain"`
+}
+
+// AttestationConfig governs the attestation verification subsystem. The
+// default is fail-closed: no proof type has a verifier wired until a tenant
+// configures an AttestationPolicy for it. AllowUnsafeDevStub re-enables the
+// legacy demo behaviour (any submitted proof verifies) behind an explicit
+// opt-in, so production deployments cannot accidentally inherit it.
+type AttestationConfig struct {
+	// AllowUnsafeDevStub, when true, registers a stub verifier that accepts
+	// any submitted proof for any configured proof type. Prints a loud
+	// startup warning. MUST never be enabled in production.
+	AllowUnsafeDevStub bool `koanf:"allow_unsafe_dev_stub"`
 }
 
 // ServerConfig holds HTTP server settings.

--- a/config.go
+++ b/config.go
@@ -236,6 +236,11 @@ func loadDefaults(k *koanf.Koanf) error {
 		// Admin path prefix
 		"server.admin_path_prefix": DefaultAdminPathPrefix,
 
+		// Attestation — fail-closed by default. AllowUnsafeDevStub is
+		// opt-in for development only; production deployments must leave
+		// it false.
+		"attestation.allow_unsafe_dev_stub": false,
+
 		// Logging
 		"logging.level": "info",
 	}
@@ -282,6 +287,9 @@ func loadEnvVars(k *koanf.Koanf) error {
 		// WIMSE
 		"ZEROID_WIMSE_DOMAIN": "wimse_domain",
 
+		// Attestation
+		"ZEROID_ALLOW_UNSAFE_DEV_STUB": "attestation.allow_unsafe_dev_stub",
+
 		// Telemetry
 		"OTEL_EXPORTER_OTLP_ENDPOINT": "telemetry.endpoint",
 		"OTEL_ENABLED":                "telemetry.enabled",
@@ -298,7 +306,9 @@ func loadEnvVars(k *koanf.Koanf) error {
 		}
 
 		switch {
-		case strings.HasSuffix(configPath, ".enabled") || strings.HasSuffix(configPath, ".insecure"):
+		case strings.HasSuffix(configPath, ".enabled") ||
+			strings.HasSuffix(configPath, ".insecure") ||
+			strings.HasSuffix(configPath, ".allow_unsafe_dev_stub"):
 			if boolVal, err := strconv.ParseBool(value); err == nil {
 				_ = k.Set(configPath, boolVal)
 			}

--- a/config.go
+++ b/config.go
@@ -34,14 +34,21 @@ type Config struct {
 }
 
 // AttestationConfig governs the attestation verification subsystem. The
-// default is fail-closed: no proof type has a verifier wired until a tenant
-// configures an AttestationPolicy for it. AllowUnsafeDevStub re-enables the
-// legacy demo behaviour (any submitted proof verifies) behind an explicit
-// opt-in, so production deployments cannot accidentally inherit it.
+// real verifier path (OIDC) is always wired and fail-closed without a
+// tenant-configured AttestationPolicy. AllowUnsafeDevStub controls
+// whether a permissive stub covers the proof types whose real verifier
+// hasn't shipped yet (image_hash, tpm).
 type AttestationConfig struct {
-	// AllowUnsafeDevStub, when true, registers a stub verifier that accepts
-	// any submitted proof for any configured proof type. Prints a loud
-	// startup warning. MUST never be enabled in production.
+	// AllowUnsafeDevStub, when true, registers a stub verifier that
+	// accepts any submitted proof for image_hash and tpm. Prints a
+	// loud startup warning whenever it's installed.
+	//
+	// Default is true today: until image_hash / tpm real verifiers
+	// land, the stub is the only way demo flows that submit those
+	// proof types keep working — flipping the default to false would
+	// hard-reject them. Deployments that don't use image_hash or tpm
+	// should set ZEROID_ALLOW_UNSAFE_DEV_STUB=false. The OIDC verifier
+	// (the only real verifier shipped) is unaffected by this flag.
 	AllowUnsafeDevStub bool `koanf:"allow_unsafe_dev_stub"`
 }
 
@@ -236,10 +243,11 @@ func loadDefaults(k *koanf.Koanf) error {
 		// Admin path prefix
 		"server.admin_path_prefix": DefaultAdminPathPrefix,
 
-		// Attestation — fail-closed by default. AllowUnsafeDevStub is
-		// opt-in for development only; production deployments must leave
-		// it false.
-		"attestation.allow_unsafe_dev_stub": false,
+		// Attestation — dev stub on by default until image_hash / tpm
+		// real verifiers ship. Override with
+		// ZEROID_ALLOW_UNSAFE_DEV_STUB=false for deployments that don't
+		// submit those proof types (or once real verifiers land).
+		"attestation.allow_unsafe_dev_stub": true,
 
 		// Logging
 		"logging.level": "info",

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -240,7 +240,7 @@ Each pod requests a token with `aud=zeroid` via projected service-account volume
 
 | YAML key | Env var | Default | Effect |
 |---|---|---|---|
-| `attestation.allow_unsafe_dev_stub` | `ZEROID_ALLOW_UNSAFE_DEV_STUB` | `true` (transitional) | Registers the dev stub for `image_hash` and `tpm`. Prints a startup WARN whenever true. |
+| `attestation.allow_unsafe_dev_stub` | `ZEROID_ALLOW_UNSAFE_DEV_STUB` | `true` (transitional) | (1) Registers the dev stub for `image_hash` and `tpm`. (2) Enables the missing-policy bypass on `/verify` for **all** registered proof types — see [Permissive bypass](#permissive-bypass-during-the-rollout-transitional). Prints a startup WARN whenever true; per-request WARN whenever the bypass fires. |
 
 When the stub is active, the server logs:
 
@@ -259,10 +259,30 @@ Until real `image_hash` and `tpm` verifiers ship, fail-closing those proof types
 `/attestation/verify` rejects with HTTP 400 (and `ErrAttestationRejected` underneath) when:
 
 - The proof type has no verifier registered in this deployment.
-- The tenant has no active `AttestationPolicy` for the proof type.
+- The tenant has no active `AttestationPolicy` for the proof type **and** the permissive bypass is disabled (see below).
 - The verifier itself rejects (bad signature, untrusted issuer, claim mismatch, etc.).
 
 Re-verifying an already-verified record returns 409 `ErrAttestationAlreadyVerified`. This guards against retry-driven duplicate credential issuance.
+
+### Permissive bypass during the rollout (transitional)
+
+When `cfg.Attestation.AllowUnsafeDevStub=true` (the current default — see [Why is the default `true` today?](#why-is-the-default-true-today)), the missing-policy gate is bypassed for **any** proof type whose verifier is registered:
+
+- The registered verifier is **not** invoked (the OIDC verifier requires a non-empty policy config to mean anything; the dev stub doesn't read config).
+- The service synthesises a stub-shape `Result` so the rest of the pipeline (issue credential → promote trust → mark record verified) runs unchanged.
+- A `WARN`-level log fires per request, including `account_id`, `project_id`, `proof_type`, `attestation_id` and `identity_id` — operators use this to find tenants that still need a real policy before the flag is flipped off.
+
+The verifier-must-be-registered gate stays strict in this mode: a typo'd or unsupported proof type still rejects, so the bypass can't paper over schema bugs.
+
+Net effect on existing tenants:
+
+| Tenant state | Strict mode (`flag=false`) | Permissive mode (`flag=true`, current default) |
+|---|---|---|
+| Submits any proof, no policy | ❌ 400 "no attestation policy configured" | ✅ 200, WARN logged |
+| Submits `oidc_token`, has policy | ✅ if real OIDC verification passes | ✅ if real OIDC verification passes (bypass does not apply when policy is present) |
+| Submits proof with no registered verifier | ❌ 400 "no verifier registered" | ❌ 400 "no verifier registered" (bypass does not skip this gate) |
+
+The bypass disappears the day `AllowUnsafeDevStub` is flipped to `false`.
 
 ### Concurrent-write safety
 

--- a/docs/attestation.md
+++ b/docs/attestation.md
@@ -1,0 +1,370 @@
+# Attestation
+
+> Cryptographic proof that an identity actually runs in the environment it claims — used to elevate trust before issuing a credential.
+
+Until PR #93 the attestation path was a stub: any submitted proof flipped the identity's `is_verified` flag and promoted its trust level. This document is the reference for the replacement — a pluggable verifier framework with per-tenant policy, fail-closed by default, and the OIDC verifier as the first implementation.
+
+---
+
+## Overview
+
+An **attestation** is a piece of proof material an identity submits to ZeroID claiming "I am the workload I say I am, running where I say I run." On successful verification, ZeroID:
+
+1. Promotes the identity's `trust_level` (software/platform → `verified_third_party`, hardware → `first_party`).
+2. Issues a bootstrap credential the workload uses for subsequent flows.
+3. Records the verified subject, issuer, and expiry on the attestation row for audit.
+
+The framework is **fail-closed**: missing verifier, missing tenant policy, or a verifier-side rejection all leave the identity un-promoted and no credential issued.
+
+### Supported proof types
+
+| Proof type | Verifier | Status |
+|---|---|---|
+| `oidc_token` | OIDC verifier (this PR) | Production-ready |
+| `image_hash` | Dev stub | Stub-only — real verifier pending |
+| `tpm` | Dev stub | Stub-only — real verifier pending |
+
+The dev stub accepts any proof for `image_hash` / `tpm` so demo flows that submit those keep working until real verifiers land. It is currently **on by default** during the rollout (see [Operator runbook](#operator-runbook)). The OIDC verifier runs fail-closed regardless.
+
+---
+
+## Architecture
+
+Two types in `internal/attestation/` collaborate:
+
+```
+                 ┌──────────────────────┐
+                 │  AttestationService  │
+                 │  (internal/service)  │
+                 └──────────┬───────────┘
+                            │ verify(record, accountID, projectID)
+                            ▼
+        ┌───────────────────────────────────────────────┐
+        │  internal/attestation/                        │
+        │                                               │
+        │   ┌──────────────┐    ┌──────────────────┐    │
+        │   │   Registry   │    │  PolicyService   │    │
+        │   │              │    │                  │    │
+        │   │  ProofType → │    │  per-tenant      │    │
+        │   │  Verifier    │◄───│  config + write- │    │
+        │   │              │    │  time gate       │    │
+        │   └──────┬───────┘    └─────────┬────────┘    │
+        │          │                      │             │
+        │          ▼                      ▼             │
+        │   ┌──────────────┐    ┌──────────────────┐    │
+        │   │ OIDCVerifier │    │ DevStubVerifier  │    │
+        │   └──────────────┘    └──────────────────┘    │
+        └───────────────────────────────────────────────┘
+```
+
+- **`Registry`** maps `domain.ProofType → Verifier`. Built at server startup, read-only at request time. Verifiers are wired via `Register(v)` in `server.go`.
+- **`Verifier` interface** — one implementation per proof type:
+  ```go
+  type Verifier interface {
+      ProofType() domain.ProofType
+      Verify(ctx context.Context, record *domain.AttestationRecord, policyConfig []byte) (*Result, error)
+  }
+  ```
+- **`PolicyService`** manages per-tenant `AttestationPolicy` rows. It is co-located with the registry because the policy is read on every verify call, and because `UpsertPolicy` uses the registry as a write-time gate: a policy cannot be created for a proof type that has no verifier wired in this deployment.
+
+### Verify flow
+
+```
+client submits proof          ZeroID admin API
+       │                              │
+       │ POST /attestation/submit     │
+       ├─────────────────────────────►│
+       │                              │ store AttestationRecord
+       │                              │ (is_verified=false)
+       │                              │
+       │ POST /attestation/verify     │
+       ├─────────────────────────────►│
+       │                              │
+       │            ┌─────────────────┤
+       │            │ AttestationService.VerifyAttestation
+       │            ▼
+       │  1. fail-closed: re-verify guard, registry.Get(),
+       │     policySvc.GetPolicy() — any miss → 400 reject
+       │  2. verifier.Verify(record, policy.Config)
+       │  3. credentialSvc.IssueCredential(...)        ← credential first
+       │  4. identitySvc.UpdateIdentity(trust=verified)← then promote
+       │  5. repo.Update(record + verified flags)     ← then commit
+       │            │
+       │            ▼
+       │   200 with token + credential + verified record
+       ◄──────────────────────────────┤
+```
+
+Write ordering is deliberate: credential issuance is the most-likely failure point, so it runs first; promotion and record update run after. A failure between steps 4 and 5 would leave trust promoted with the record unmarked — the re-verify guard (`ErrAttestationAlreadyVerified`) prevents a retry from minting a second credential. The full fix for that narrow window is tracked in [issue #98](https://github.com/highflame-ai/zeroid/issues/98).
+
+---
+
+## OIDC verifier
+
+The OIDC verifier accepts JWTs from upstream OIDC providers (GitHub Actions, GCP Workload Identity, Kubernetes projected SA tokens, AWS IAM OIDC, etc.) without per-provider code. Every major agent runtime ships an OIDC token issuer, so this one verifier covers most realistic deployment shapes.
+
+### Verification steps
+
+1. **Parse JWT header insecurely** to read the `iss` claim. No signature check yet.
+2. **Match `iss` against the tenant's allowlist** (`OIDCPolicyConfig.Issuers`). Unknown issuers are rejected here — no JWKS fetch, no network call.
+3. **Resolve JWKS** for the matched issuer. Fetched via OIDC discovery (`/.well-known/openid-configuration` → `jwks_uri`), cached per-issuer for 1 hour. The discovery doc's `issuer` field is verified to match the fetch URL (RFC 8414 §3.3) so a DNS or MITM attacker can't redirect `jwks_uri`.
+4. **Verify signature + standard time claims** (`exp`, `iat`, `nbf`) with 30s clock skew tolerance. The cached key set's `kid` must match the token's `kid`.
+5. **Audience check** — if `Audiences` is configured, the JWT's `aud` claim must contain at least one configured value.
+6. **Required-claim check** — for each `(key, value)` in `RequiredClaims`, the token must contain `key` with the exact string value.
+
+On success the verifier returns the JWT's `sub`, `iss`, `exp`, and the full claim map. Those propagate to the `AttestationRecord` for audit.
+
+### Security properties
+
+- **Issuer allowlist is the trust anchor.** A perfectly-signed JWT from an issuer not in the policy is rejected before any network call to that issuer's discovery endpoint.
+- **HTTPS required for non-loopback issuers.** OIDC discovery is unauthenticated — over plain HTTP a network attacker could substitute their own keys. `https://` is required at policy write time. Loopback addresses (`localhost`, `127.0.0.1`, `::1`) are exempted for local-dev and `httptest`-based integration tests.
+- **Discovery doc body is capped at 1 MiB.** A compromised issuer can't OOM the verifier by streaming an arbitrarily large response.
+- **JWKS fetched from the issuer's own discovery doc, not policy config.** Operators don't paste public keys into ZeroID — the issuer publishes them, ZeroID fetches them, and the discovery `issuer` field must match the URL we fetched from.
+- **Trailing-slash normalisation on `iss` matching.** `https://accounts.google.com` and `https://accounts.google.com/` are treated as the same issuer; mild config typos don't lock clients out.
+
+---
+
+## Configuring an `AttestationPolicy`
+
+A policy ties a tenant + proof type to the rules a submitted proof must satisfy. One policy per `(account_id, project_id, proof_type)`.
+
+### Endpoint
+
+```
+PUT /api/v1/attestation-policies
+Content-Type: application/json
+
+{
+  "proof_type": "oidc_token",
+  "config": { ... per-proof-type schema ... },
+  "is_active": true
+}
+```
+
+`PUT` is upsert. `is_active=false` soft-disables. Two concurrent PUTs for the same key are race-safe (atomic `INSERT … ON CONFLICT`).
+
+### `OIDCPolicyConfig` schema
+
+```jsonc
+{
+  "issuers": [
+    {
+      "url": "https://token.actions.githubusercontent.com",
+      "audiences": ["https://github.com/myorg"],          // optional
+      "required_claims": {                                  // optional
+        "repository": "myorg/myrepo",
+        "ref": "refs/heads/main"
+      }
+    }
+  ]
+}
+```
+
+- `issuers` — at least one entry; the JWT's `iss` claim must match one (after trailing-slash normalisation).
+- `audiences` — if non-empty, JWT's `aud` claim must contain at least one of these. If empty, no audience check.
+- `required_claims` — exact string match on each key. Use this to bind tokens to a specific workload (the GitHub Actions example bound to a single repo + branch is the canonical pattern).
+
+### Worked example: GitHub Actions OIDC
+
+A workflow in `myorg/myrepo` on `main` is allowed to attest. Anything else is rejected.
+
+```bash
+curl -X PUT https://zeroid.example.com/api/v1/attestation-policies \
+  -H "Content-Type: application/json" \
+  -H "X-Account-ID: acct_123" -H "X-Project-ID: proj_456" \
+  -d '{
+    "proof_type": "oidc_token",
+    "config": {
+      "issuers": [{
+        "url": "https://token.actions.githubusercontent.com",
+        "audiences": ["https://github.com/myorg"],
+        "required_claims": {
+          "repository": "myorg/myrepo",
+          "ref": "refs/heads/main"
+        }
+      }]
+    }
+  }'
+```
+
+In the workflow:
+
+```yaml
+- uses: actions/github-script@v7
+  with:
+    script: |
+      const token = await core.getIDToken('https://github.com/myorg');
+      // POST to /api/v1/attestation/submit with proof_type=oidc_token, proof_value=token
+      // then POST /api/v1/attestation/verify with the returned record id
+```
+
+### Worked example: GCP Workload Identity Federation
+
+```jsonc
+{
+  "issuers": [{
+    "url": "https://accounts.google.com",
+    "audiences": ["//iam.googleapis.com/projects/.../locations/global/workloadIdentityPools/.../providers/zeroid"],
+    "required_claims": {
+      "google.compute_engine.project_id": "my-prod-project",
+      "google.compute_engine.zone":       "us-central1-a"
+    }
+  }]
+}
+```
+
+### Worked example: Kubernetes projected service-account tokens
+
+The cluster's API-server JWKS is published at `https://<api-server>/openid/v1/jwks`. The cluster issuer (whatever `kubectl get --raw '/.well-known/openid-configuration'` returns as `issuer`) goes in the policy:
+
+```jsonc
+{
+  "issuers": [{
+    "url": "https://kubernetes.default.svc.cluster.local",
+    "audiences": ["zeroid"],
+    "required_claims": {
+      "kubernetes.io/serviceaccount/namespace": "production",
+      "kubernetes.io/serviceaccount/service-account.name": "agent-runner"
+    }
+  }]
+}
+```
+
+Each pod requests a token with `aud=zeroid` via projected service-account volume; the workload submits that token as the attestation proof.
+
+---
+
+## Operator runbook
+
+### Configuration
+
+| YAML key | Env var | Default | Effect |
+|---|---|---|---|
+| `attestation.allow_unsafe_dev_stub` | `ZEROID_ALLOW_UNSAFE_DEV_STUB` | `true` (transitional) | Registers the dev stub for `image_hash` and `tpm`. Prints a startup WARN whenever true. |
+
+When the stub is active, the server logs:
+
+```
+WARN ATTESTATION: AllowUnsafeDevStub is enabled — any submitted proof will verify. DO NOT enable in production.
+```
+
+The stub **only** covers proof types whose real verifier hasn't shipped (`image_hash`, `tpm`). The OIDC verifier is wired regardless of this flag and runs fail-closed.
+
+### Why is the default `true` today?
+
+Until real `image_hash` and `tpm` verifiers ship, fail-closing those proof types would break existing demo flows that submit them. The transitional default keeps current customer integrations working without forcing them to add config. Deployments that don't use `image_hash` or `tpm` should set `ZEROID_ALLOW_UNSAFE_DEV_STUB=false`. Once the real verifiers land, the default flips back to `false`.
+
+### Fail-closed contract
+
+`/attestation/verify` rejects with HTTP 400 (and `ErrAttestationRejected` underneath) when:
+
+- The proof type has no verifier registered in this deployment.
+- The tenant has no active `AttestationPolicy` for the proof type.
+- The verifier itself rejects (bad signature, untrusted issuer, claim mismatch, etc.).
+
+Re-verifying an already-verified record returns 409 `ErrAttestationAlreadyVerified`. This guards against retry-driven duplicate credential issuance.
+
+### Concurrent-write safety
+
+`UpsertPolicy` uses `INSERT … ON CONFLICT DO UPDATE` so two simultaneous admin PUTs for the same `(tenant, proof_type)` race only on the row lock. Neither produces a 500. `TestAttestationPolicyUpsertIsConcurrencySafe` (8-way parallel) covers this.
+
+### Rate limiting / DoS posture
+
+- OIDC discovery + JWKS fetches are cached per-issuer for 1 hour.
+- The discovery response body is capped at 1 MiB.
+- Policy validation runs at write time, so misconfigurations (missing issuer list, malformed URL, `http://` issuer) surface as 400 immediately rather than at /verify time.
+
+---
+
+## Adding a new verifier
+
+To add a verifier for a new proof type — e.g. an `image_hash` verifier that compares container digests against a per-tenant allowlist:
+
+1. **Implement the `Verifier` interface** in `internal/attestation/<proof_type>.go`:
+
+   ```go
+   type ImageHashVerifier struct{ /* ... */ }
+   func (v *ImageHashVerifier) ProofType() domain.ProofType { return domain.ProofTypeImageHash }
+   func (v *ImageHashVerifier) Verify(ctx context.Context, record *domain.AttestationRecord, policyConfig []byte) (*Result, error) {
+       // 1. Parse policyConfig into the typed struct for image_hash.
+       // 2. Look up record.ProofValue against the policy's allowlist.
+       // 3. Return Result{Subject: digest, ExpiresAt: nil, Claims: ...} or an error.
+   }
+   ```
+
+2. **Define the typed config** in `domain/attestation_policy.go`:
+
+   ```go
+   type ImageHashPolicyConfig struct {
+       Allowlist []ImageHashEntry `json:"allowlist"`
+   }
+   ```
+
+3. **Add the typed config validator branch** in `internal/attestation/policy.go::validatePolicyConfig`:
+
+   ```go
+   case domain.ProofTypeImageHash:
+       var cfg domain.ImageHashPolicyConfig
+       if err := json.Unmarshal(rawCfg, &cfg); err != nil { ... }
+       if len(cfg.Allowlist) == 0 { ... }
+       // typed validation
+   ```
+
+4. **Register in `server.go`**:
+
+   ```go
+   attestationVerifiers.Register(attestation.NewImageHashVerifier(/* deps */))
+   ```
+
+5. **Add integration tests** in `tests/integration/attestation_<proof_type>_test.go` covering happy path, bad input, write-time policy validation, fail-closed without policy.
+
+The dev stub for that proof type can stay registered alongside (last-write wins on `Register`) until you're confident the real verifier covers all flows; then drop the stub from `server.go`.
+
+---
+
+## Migration notes
+
+### Schema (`migrations/014_attestation_policies.up.sql`)
+
+Adds `attestation_policies` with a unique constraint on `(account_id, project_id, proof_type)` and a partial index on `is_active = TRUE` for the verify hot path.
+
+### Behavior change for existing tenants
+
+Before: any submitted proof verified. After: tenants must configure an `AttestationPolicy` for every proof type they want to accept. Existing demo flows submitting `oidc_token` proofs against a tenant with no policy will start receiving 400 `attestation proof rejected: no attestation policy configured`. The fix is to PUT the policy.
+
+For `image_hash` and `tpm`, the dev stub keeps the legacy "any proof verifies" behavior alive while the real verifiers are built. See the [Operator runbook](#operator-runbook) for how to flip it off.
+
+### Auditability
+
+Every verification — pass or fail — leaves a row trail:
+
+- `AttestationRecord.is_verified` flips only on success.
+- `verified_at`, `expires_at`, `credential_id` are populated atomically with the success state.
+- `proof_hash` (sha256 of the original `proof_value`) is recorded at submit time so audit can detect proof reuse without storing the raw token.
+
+---
+
+## References
+
+- RFC 7519 — JSON Web Token
+- RFC 7517 — JSON Web Key
+- RFC 8414 — OAuth 2.0 Authorization Server Metadata (the §3.3 issuer-pinning rule the verifier follows)
+- OpenID Connect Discovery 1.0 — `.well-known/openid-configuration` shape
+- GitHub Actions OIDC: <https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect>
+- GCP Workload Identity Federation: <https://cloud.google.com/iam/docs/workload-identity-federation>
+- Kubernetes projected service-account tokens: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection>
+
+## Source map
+
+| Concern | File |
+|---|---|
+| `Verifier` interface + `Registry` | `internal/attestation/verifier.go` |
+| OIDC verifier | `internal/attestation/oidc.go` |
+| Dev stub | `internal/attestation/stub.go` |
+| Policy service + write-time gate | `internal/attestation/policy.go` |
+| Policy repository | `internal/store/postgres/attestation_policy.go` |
+| Verify orchestration | `internal/service/attestation.go` |
+| HTTP handlers | `internal/handler/attestation.go`, `internal/handler/attestation_policy.go` |
+| Domain types | `domain/attestation.go`, `domain/attestation_policy.go` |
+| Schema | `migrations/014_attestation_policies.up.sql` |
+| Tests | `tests/integration/attestation_oidc_test.go` |

--- a/domain/attestation.go
+++ b/domain/attestation.go
@@ -58,6 +58,6 @@ type AttestationRecord struct {
 	IsVerified   bool             `bun:"is_verified"                   json:"is_verified"`
 	ExpiresAt    *time.Time       `bun:"expires_at"                    json:"expires_at,omitempty"`
 	IsExpired    bool             `bun:"is_expired"                    json:"is_expired"`
-	CredentialID string           `bun:"credential_id,type:uuid"       json:"credential_id,omitempty"`
+	CredentialID string           `bun:"credential_id,type:uuid,nullzero" json:"credential_id,omitempty"`
 	CreatedAt    time.Time        `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
 }

--- a/domain/attestation_policy.go
+++ b/domain/attestation_policy.go
@@ -1,0 +1,61 @@
+package domain
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// AttestationPolicy is per-tenant per-proof-type trust configuration.
+// A policy row says: "for proof_type X in this tenant, here are the
+// accepted issuers/roots/hashes and the rules that must match". No policy
+// row means the verifier for that proof type is unconfigured and all
+// verification attempts fail closed.
+//
+// Config is a JSONB blob whose shape depends on ProofType:
+//   - oidc_token: OIDCPolicyConfig
+//   - image_hash: (not yet implemented) ImageHashPolicyConfig
+//   - tpm:        (not yet implemented) TPMPolicyConfig
+//
+// Storing the proof-type-specific shape inline avoids a separate table per
+// verifier and lets new verifiers land without schema changes.
+type AttestationPolicy struct {
+	bun.BaseModel `bun:"table:attestation_policies,alias:ap"`
+
+	ID        string          `bun:"id,pk,type:uuid"              json:"id"`
+	AccountID string          `bun:"account_id,type:varchar(255)" json:"account_id"`
+	ProjectID string          `bun:"project_id,type:varchar(255)" json:"project_id"`
+	ProofType ProofType       `bun:"proof_type,type:varchar(50)"  json:"proof_type"`
+	Config    json.RawMessage `bun:"config,type:jsonb"            json:"config"`
+	IsActive  bool            `bun:"is_active"                    json:"is_active"`
+	CreatedAt time.Time       `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
+	UpdatedAt time.Time       `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updated_at"`
+}
+
+// OIDCPolicyConfig is the Config payload for proof_type=oidc_token. Defines
+// which upstream IdP JWTs are accepted and what claim constraints they must
+// satisfy before trust is promoted.
+type OIDCPolicyConfig struct {
+	// Issuers is the allowlist of trusted OIDC issuers. At least one must
+	// match the incoming JWT's iss claim for verification to proceed.
+	Issuers []OIDCIssuerConfig `json:"issuers"`
+}
+
+// OIDCIssuerConfig describes one trusted OIDC issuer and its constraints.
+type OIDCIssuerConfig struct {
+	// URL is the issuer URL (matched against the JWT iss claim and used to
+	// discover the JWKS endpoint via .well-known/openid-configuration).
+	URL string `json:"url"`
+
+	// Audiences, if non-empty, requires the JWT aud claim to contain at
+	// least one of these values. Empty disables audience checking.
+	Audiences []string `json:"audiences,omitempty"`
+
+	// RequiredClaims are exact-string-match requirements on additional JWT
+	// claims. Every key listed must be present on the token and equal the
+	// configured value. Use this to bind tokens to a specific workload,
+	// e.g. {"repository": "myorg/myrepo", "ref": "refs/heads/main"} for
+	// GitHub Actions OIDC.
+	RequiredClaims map[string]string `json:"required_claims,omitempty"`
+}

--- a/internal/attestation/doc.go
+++ b/internal/attestation/doc.go
@@ -1,0 +1,29 @@
+// Package attestation implements the verifier framework used by the
+// /attestation/verify endpoint to promote an identity's trust level.
+//
+// Two collaborating types live here:
+//
+//   - Registry maps domain.ProofType to a Verifier implementation.
+//     One verifier per proof type. Built at server startup; read-only
+//     at request time, so no locking is needed after construction.
+//
+//   - PolicyService manages per-tenant AttestationPolicy rows and
+//     gates write-time creation against the registry: a policy can
+//     only exist for a proof type that has a verifier wired in this
+//     deployment. The two types are co-located because the policy is
+//     read on every Verifier.Verify call.
+//
+// Verifiers plug in via Registry.Register from server.go. The OIDC
+// verifier (oidc.go) is the production implementation. DevStubVerifier
+// (stub.go) is an opt-in backstop for proof types whose real verifier
+// hasn't shipped yet (image_hash, tpm); it is gated by
+// cfg.Attestation.AllowUnsafeDevStub and prints a startup WARN
+// whenever it's installed.
+//
+// The framework is fail-closed: missing verifier, missing tenant
+// policy, or a verifier-side rejection all leave the identity
+// un-promoted and no credential issued. See docs/attestation.md for
+// the full reference, including the OIDC verify flow, the
+// AttestationPolicy schema with worked examples, the operator
+// runbook, and the steps to add a new verifier.
+package attestation

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -176,15 +176,17 @@ func anyAudienceMatches(got, want []string) bool {
 	return false
 }
 
-// jwksCache is a tiny per-issuer in-memory JWKS cache. It coalesces misses
-// so a burst of verification requests doesn't fan out into multiple JWKS
-// HTTP calls for the same issuer.
+// jwksCache is a per-issuer in-memory JWKS cache. Each issuer entry carries
+// its own mutex so a cold-cache miss on issuer A doesn't block lookups for
+// issuer B. Concurrent misses on the SAME issuer coalesce via the entry
+// mutex — one fetch, everyone else waits for it to populate.
 type jwksCache struct {
-	mu      sync.Mutex
+	mu      sync.Mutex // protects the entries map only, not the fetch
 	entries map[string]*jwksEntry
 }
 
 type jwksEntry struct {
+	mu        sync.Mutex // held during fetch; released when keys is populated
 	keys      jwk.Set
 	expiresAt time.Time
 }
@@ -194,13 +196,23 @@ func newJWKSCache() *jwksCache {
 }
 
 // get returns a cached key set for issuerURL, refreshing via OIDC discovery
-// when the entry is absent or stale.
+// when the entry is absent or stale. The two-phase locking pattern (map
+// mutex for entry lookup, then entry mutex for fetch) ensures cross-issuer
+// lookups don't serialize on a single slow upstream.
 func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL string, ttl time.Duration) (jwk.Set, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
+	entry, ok := c.entries[issuerURL]
+	if !ok {
+		entry = &jwksEntry{}
+		c.entries[issuerURL] = entry
+	}
+	c.mu.Unlock()
 
-	if e, ok := c.entries[issuerURL]; ok && time.Now().Before(e.expiresAt) {
-		return e.keys, nil
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	if entry.keys != nil && time.Now().Before(entry.expiresAt) {
+		return entry.keys, nil
 	}
 
 	jwksURL, err := discoverJWKSURL(ctx, httpClient, issuerURL)
@@ -212,7 +224,8 @@ func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL 
 		return nil, fmt.Errorf("fetch JWKS %s: %w", jwksURL, err)
 	}
 
-	c.entries[issuerURL] = &jwksEntry{keys: keySet, expiresAt: time.Now().Add(ttl)}
+	entry.keys = keySet
+	entry.expiresAt = time.Now().Add(ttl)
 	return keySet, nil
 }
 
@@ -220,28 +233,42 @@ func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL 
 // document. Issuers that don't serve /.well-known/openid-configuration are
 // not supported by this verifier — they'd need a dedicated pinned-keys
 // verifier, which can be added later if a concrete tenant needs it.
+//
+// Per RFC 8414 §3.3, the issuer field in the discovery document MUST match
+// the issuer URL used to fetch it — otherwise a DNS-hijacked or MITM'd
+// discovery endpoint could redirect jwks_uri at attacker-controlled keys
+// while pretending to serve the trusted issuer's metadata.
 func discoverJWKSURL(ctx context.Context, httpClient *http.Client, issuerURL string) (string, error) {
-	url := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("build discovery request: %w", err)
 	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("discovery GET %s: %w", url, err)
+		return "", fmt.Errorf("discovery GET %s: %w", discoveryURL, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("discovery %s returned %d", url, resp.StatusCode)
+		return "", fmt.Errorf("discovery %s returned %d", discoveryURL, resp.StatusCode)
 	}
 	var doc struct {
+		Issuer  string `json:"issuer"`
 		JWKSURI string `json:"jwks_uri"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
 		return "", fmt.Errorf("parse discovery doc: %w", err)
 	}
 	if doc.JWKSURI == "" {
-		return "", fmt.Errorf("discovery doc at %s has no jwks_uri", url)
+		return "", fmt.Errorf("discovery doc at %s has no jwks_uri", discoveryURL)
+	}
+	// RFC 8414 §3.3: the discovery doc's issuer field MUST match the URL
+	// we used to fetch it. Trailing slashes are insignificant (same
+	// normalisation as findIssuer).
+	want := strings.TrimRight(issuerURL, "/")
+	got := strings.TrimRight(doc.Issuer, "/")
+	if got != want {
+		return "", fmt.Errorf("discovery doc issuer mismatch: got %q, want %q", doc.Issuer, issuerURL)
 	}
 	return doc.JWKSURI, nil
 }

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -1,0 +1,247 @@
+package attestation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// OIDCVerifier verifies JWTs issued by upstream OIDC providers (GitHub
+// Actions, GCP Workload Identity, Kubernetes projected SA tokens, AWS IAM
+// OIDC, etc.) against a tenant-configured issuer allowlist. It is the
+// default workload-attestation verifier: every major agent runtime ships
+// an OIDC token issuer, so this one verifier covers the realistic deployment
+// shapes without per-provider code.
+//
+// Verification flow:
+//  1. Parse JWT header without verifying to read the iss claim.
+//  2. Match iss against the tenant's OIDCPolicyConfig.Issuers allowlist.
+//     Unknown issuers fail here — no JWKS fetch, no network call.
+//  3. Fetch JWKS for the matched issuer (cached per-issuer for 1h) via
+//     OIDC discovery (.well-known/openid-configuration → jwks_uri).
+//  4. Verify the JWT signature and standard time claims (exp/iat/nbf).
+//  5. Enforce audience constraint if Audiences is non-empty.
+//  6. Enforce RequiredClaims exact-string-match on each listed claim.
+type OIDCVerifier struct {
+	cache    *jwksCache
+	http     *http.Client
+	cacheTTL time.Duration
+}
+
+// NewOIDCVerifier creates a verifier with a shared JWKS cache. httpClient
+// is used for both OIDC discovery and JWKS fetches; passing a custom one
+// is useful in tests (httptest.NewServer has no DNS).
+func NewOIDCVerifier(httpClient *http.Client) *OIDCVerifier {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &OIDCVerifier{
+		cache:    newJWKSCache(),
+		http:     httpClient,
+		cacheTTL: 1 * time.Hour,
+	}
+}
+
+// ProofType reports oidc_token. One OIDCVerifier per registry.
+func (v *OIDCVerifier) ProofType() domain.ProofType { return domain.ProofTypeOIDCToken }
+
+// Verify implements the full OIDC flow described on OIDCVerifier.
+func (v *OIDCVerifier) Verify(ctx context.Context, record *domain.AttestationRecord, policyConfig []byte) (*Result, error) {
+	if len(policyConfig) == 0 {
+		return nil, fmt.Errorf("oidc verifier: policy config is empty")
+	}
+	var cfg domain.OIDCPolicyConfig
+	if err := json.Unmarshal(policyConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("oidc verifier: invalid policy config: %w", err)
+	}
+	if len(cfg.Issuers) == 0 {
+		return nil, fmt.Errorf("oidc verifier: policy has no trusted issuers configured")
+	}
+
+	rawToken := strings.TrimSpace(record.ProofValue)
+	if rawToken == "" {
+		return nil, fmt.Errorf("oidc verifier: empty proof value")
+	}
+
+	// Step 1–2: peek at the token's iss claim to pick the matching issuer
+	// config. ParseInsecure skips signature verification — safe because we
+	// treat the result as untrusted until step 4 runs the real check.
+	peek, err := jwt.ParseInsecure([]byte(rawToken))
+	if err != nil {
+		return nil, fmt.Errorf("oidc verifier: malformed JWT: %w", err)
+	}
+	issuerClaim := peek.Issuer()
+	if issuerClaim == "" {
+		return nil, fmt.Errorf("oidc verifier: JWT has no iss claim")
+	}
+	matchedIssuer, ok := findIssuer(cfg.Issuers, issuerClaim)
+	if !ok {
+		return nil, fmt.Errorf("oidc verifier: issuer not in allowlist: %s", issuerClaim)
+	}
+
+	// Step 3: resolve JWKS (cached).
+	keySet, err := v.cache.get(ctx, v.http, matchedIssuer.URL, v.cacheTTL)
+	if err != nil {
+		return nil, fmt.Errorf("oidc verifier: JWKS fetch failed: %w", err)
+	}
+
+	// Step 4: verify signature + standard claims. jwt.Parse enforces
+	// exp/iat/nbf by default, and the KeySet option requires a matching
+	// kid — so a tampered token or one from a foreign signer will fail.
+	tok, err := jwt.Parse(
+		[]byte(rawToken),
+		jwt.WithKeySet(keySet),
+		jwt.WithIssuer(matchedIssuer.URL),
+		jwt.WithValidate(true),
+		jwt.WithAcceptableSkew(30*time.Second),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("oidc verifier: token validation failed: %w", err)
+	}
+
+	// Step 5: audience. jwx's WithAudience rejects the token unless the
+	// aud claim contains the given string — we OR across configured
+	// audiences by trying each. Empty audiences means no audience check.
+	if len(matchedIssuer.Audiences) > 0 {
+		if !anyAudienceMatches(tok.Audience(), matchedIssuer.Audiences) {
+			return nil, fmt.Errorf("oidc verifier: aud claim does not match any configured audience")
+		}
+	}
+
+	// Step 6: required claims — exact string match on each key. These are
+	// the workload-identity binders (e.g. repository, ref for GitHub).
+	allClaims, err := tok.AsMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("oidc verifier: unable to read token claims: %w", err)
+	}
+	for wantKey, wantVal := range matchedIssuer.RequiredClaims {
+		got, ok := allClaims[wantKey]
+		if !ok {
+			return nil, fmt.Errorf("oidc verifier: required claim missing: %s", wantKey)
+		}
+		gotStr, ok := got.(string)
+		if !ok || gotStr != wantVal {
+			return nil, fmt.Errorf("oidc verifier: required claim mismatch: %s", wantKey)
+		}
+	}
+
+	var expiresAt *time.Time
+	if exp := tok.Expiration(); !exp.IsZero() {
+		e := exp
+		expiresAt = &e
+	}
+
+	return &Result{
+		Subject:   tok.Subject(),
+		Issuer:    tok.Issuer(),
+		ExpiresAt: expiresAt,
+		Claims:    allClaims,
+	}, nil
+}
+
+// findIssuer returns the config entry whose URL matches issuerClaim. The
+// match is exact after trimming trailing slashes — OIDC discovery treats
+// "https://x" and "https://x/" as the same issuer, and we follow suit so
+// mild config typos don't lock clients out.
+func findIssuer(configured []domain.OIDCIssuerConfig, issuerClaim string) (domain.OIDCIssuerConfig, bool) {
+	norm := strings.TrimRight(issuerClaim, "/")
+	for _, c := range configured {
+		if strings.TrimRight(c.URL, "/") == norm {
+			return c, true
+		}
+	}
+	return domain.OIDCIssuerConfig{}, false
+}
+
+// anyAudienceMatches reports whether any element of got is present in want.
+func anyAudienceMatches(got, want []string) bool {
+	wantSet := make(map[string]struct{}, len(want))
+	for _, w := range want {
+		wantSet[w] = struct{}{}
+	}
+	for _, g := range got {
+		if _, ok := wantSet[g]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// jwksCache is a tiny per-issuer in-memory JWKS cache. It coalesces misses
+// so a burst of verification requests doesn't fan out into multiple JWKS
+// HTTP calls for the same issuer.
+type jwksCache struct {
+	mu      sync.Mutex
+	entries map[string]*jwksEntry
+}
+
+type jwksEntry struct {
+	keys      jwk.Set
+	expiresAt time.Time
+}
+
+func newJWKSCache() *jwksCache {
+	return &jwksCache{entries: make(map[string]*jwksEntry)}
+}
+
+// get returns a cached key set for issuerURL, refreshing via OIDC discovery
+// when the entry is absent or stale.
+func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL string, ttl time.Duration) (jwk.Set, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if e, ok := c.entries[issuerURL]; ok && time.Now().Before(e.expiresAt) {
+		return e.keys, nil
+	}
+
+	jwksURL, err := discoverJWKSURL(ctx, httpClient, issuerURL)
+	if err != nil {
+		return nil, err
+	}
+	keySet, err := jwk.Fetch(ctx, jwksURL, jwk.WithHTTPClient(httpClient))
+	if err != nil {
+		return nil, fmt.Errorf("fetch JWKS %s: %w", jwksURL, err)
+	}
+
+	c.entries[issuerURL] = &jwksEntry{keys: keySet, expiresAt: time.Now().Add(ttl)}
+	return keySet, nil
+}
+
+// discoverJWKSURL pulls the jwks_uri out of the issuer's OIDC discovery
+// document. Issuers that don't serve /.well-known/openid-configuration are
+// not supported by this verifier — they'd need a dedicated pinned-keys
+// verifier, which can be added later if a concrete tenant needs it.
+func discoverJWKSURL(ctx context.Context, httpClient *http.Client, issuerURL string) (string, error) {
+	url := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build discovery request: %w", err)
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("discovery GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("discovery %s returned %d", url, resp.StatusCode)
+	}
+	var doc struct {
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return "", fmt.Errorf("parse discovery doc: %w", err)
+	}
+	if doc.JWKSURI == "" {
+		return "", fmt.Errorf("discovery doc at %s has no jwks_uri", url)
+	}
+	return doc.JWKSURI, nil
+}

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -14,6 +15,12 @@ import (
 
 	"github.com/highflame-ai/zeroid/domain"
 )
+
+// maxDiscoveryDocBytes caps how much of an OIDC discovery response we will
+// read and decode. Real-world discovery docs are a few kilobytes; a 1 MiB
+// ceiling gives generous headroom while bounding memory a malicious or
+// compromised issuer can force this process to allocate during a fetch.
+const maxDiscoveryDocBytes = 1 << 20 // 1 MiB
 
 // OIDCVerifier verifies JWTs issued by upstream OIDC providers (GitHub
 // Actions, GCP Workload Identity, Kubernetes projected SA tokens, AWS IAM
@@ -256,7 +263,10 @@ func discoverJWKSURL(ctx context.Context, httpClient *http.Client, issuerURL str
 		Issuer  string `json:"issuer"`
 		JWKSURI string `json:"jwks_uri"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+	// Bound the decode at maxDiscoveryDocBytes. Without the limit a
+	// malicious issuer could stream gigabytes into json.Decode, exhausting
+	// memory before we ever inspected a byte.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxDiscoveryDocBytes)).Decode(&doc); err != nil {
 		return "", fmt.Errorf("parse discovery doc: %w", err)
 	}
 	if doc.JWKSURI == "" {

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -104,10 +104,17 @@ func (v *OIDCVerifier) Verify(ctx context.Context, record *domain.AttestationRec
 	// Step 4: verify signature + standard claims. jwt.Parse enforces
 	// exp/iat/nbf by default, and the KeySet option requires a matching
 	// kid — so a tampered token or one from a foreign signer will fail.
+	//
+	// Use issuerClaim (not matchedIssuer.URL) for WithIssuer because
+	// jwx's WithIssuer does a strict string compare; a trailing-slash
+	// mismatch between the configured policy URL and the token's iss
+	// claim would reject an otherwise-valid token. The iss claim was
+	// already trust-checked by findIssuer (normalized-equality against
+	// the allowlist), so feeding it back here is safe.
 	tok, err := jwt.Parse(
 		[]byte(rawToken),
 		jwt.WithKeySet(keySet),
-		jwt.WithIssuer(matchedIssuer.URL),
+		jwt.WithIssuer(issuerClaim),
 		jwt.WithValidate(true),
 		jwt.WithAcceptableSkew(30*time.Second),
 	)

--- a/internal/attestation/policy.go
+++ b/internal/attestation/policy.go
@@ -1,4 +1,4 @@
-package service
+package attestation
 
 import (
 	"context"
@@ -12,40 +12,38 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/highflame-ai/zeroid/domain"
-	"github.com/highflame-ai/zeroid/internal/attestation"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
-// ErrInvalidAttestationPolicy is returned for caller-induced validation
-// errors on UpsertPolicy (bad proof_type, malformed config, non-https
+// ErrInvalidPolicy is returned for caller-induced validation errors on
+// PolicyService.UpsertPolicy (bad proof_type, malformed config, non-https
 // issuer URL, etc.). Distinguished from infrastructure errors so the
 // handler maps it to 400 rather than 500.
-var ErrInvalidAttestationPolicy = errors.New("invalid attestation policy")
+var ErrInvalidPolicy = errors.New("invalid attestation policy")
 
-// AttestationPolicyService is a thin wrapper around the policy repo. The
-// verifier registry holds the concrete verification code; this service
-// just manages the per-tenant configuration those verifiers read.
+// PolicyService manages per-tenant attestation policies. It lives in the
+// same package as the verifier registry because the policy is read on
+// every verify call — co-locating shortens the call graph and lets the
+// service reach the registry directly for the write-time "is this proof
+// type implemented?" gate.
 //
-// The registry reference is also used as a write-time gate: a policy can
-// only be created for a proof type that has a registered verifier in
-// this deployment. Without the gate, operators could pre-stage policy
-// rows that nothing reads, with misconfigurations only surfacing at
-// /verify time.
-type AttestationPolicyService struct {
+// Without that gate, operators could pre-stage policy rows that nothing
+// reads, with misconfigurations only surfacing at /verify time.
+type PolicyService struct {
 	repo      *postgres.AttestationPolicyRepository
-	verifiers *attestation.Registry
+	verifiers *Registry
 }
 
-// NewAttestationPolicyService creates a new service. The verifier
-// registry is required so UpsertPolicy can reject policies for proof
-// types that have no verifier wired.
-func NewAttestationPolicyService(repo *postgres.AttestationPolicyRepository, verifiers *attestation.Registry) *AttestationPolicyService {
-	return &AttestationPolicyService{repo: repo, verifiers: verifiers}
+// NewPolicyService creates a new policy service. The verifier registry
+// is required so UpsertPolicy can reject policies for proof types that
+// have no verifier wired.
+func NewPolicyService(repo *postgres.AttestationPolicyRepository, verifiers *Registry) *PolicyService {
+	return &PolicyService{repo: repo, verifiers: verifiers}
 }
 
-// UpsertAttestationPolicyRequest captures the payload accepted by the
-// admin API. Config is JSONB and its shape depends on ProofType.
-type UpsertAttestationPolicyRequest struct {
+// UpsertPolicyRequest captures the payload accepted by the admin API.
+// Config is JSONB and its shape depends on ProofType.
+type UpsertPolicyRequest struct {
 	AccountID string
 	ProjectID string
 	ProofType domain.ProofType
@@ -59,9 +57,9 @@ type UpsertAttestationPolicyRequest struct {
 // same key can't both see "not found" and race on the unique constraint —
 // an earlier read-then-write version did, producing a 500 under concurrent
 // writes.
-func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertAttestationPolicyRequest) (*domain.AttestationPolicy, error) {
+func (s *PolicyService) UpsertPolicy(ctx context.Context, req UpsertPolicyRequest) (*domain.AttestationPolicy, error) {
 	if !req.ProofType.Valid() {
-		return nil, fmt.Errorf("%w: invalid proof_type %q", ErrInvalidAttestationPolicy, req.ProofType)
+		return nil, fmt.Errorf("%w: invalid proof_type %q", ErrInvalidPolicy, req.ProofType)
 	}
 	// Reject policies for proof types that have no registered verifier in
 	// this deployment. Without this gate the row would persist and only
@@ -69,16 +67,16 @@ func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertA
 	// to exercise image_hash or tpm flows must enable
 	// attestation.allow_unsafe_dev_stub to register the dev stub.
 	if _, err := s.verifiers.Get(req.ProofType); err != nil {
-		return nil, fmt.Errorf("%w: no verifier registered for proof_type %q", ErrInvalidAttestationPolicy, req.ProofType)
+		return nil, fmt.Errorf("%w: no verifier registered for proof_type %q", ErrInvalidPolicy, req.ProofType)
 	}
 	if len(req.Config) == 0 {
-		return nil, fmt.Errorf("%w: config is required", ErrInvalidAttestationPolicy)
+		return nil, fmt.Errorf("%w: config is required", ErrInvalidPolicy)
 	}
 	// Validate the per-proof-type config shape up front so bad configs can't
 	// sit in the DB until a /verify call finally trips on them. Catches
 	// typos, wrong types, missing issuer URLs, etc. at write time.
 	if err := validatePolicyConfig(req.ProofType, req.Config); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidAttestationPolicy, err)
+		return nil, fmt.Errorf("%w: %v", ErrInvalidPolicy, err)
 	}
 
 	active := true
@@ -167,17 +165,17 @@ func isLoopbackHost(host string) bool {
 
 // GetPolicy returns the policy for the given tenant + proof type, or
 // ErrAttestationPolicyNotFound if unset. Used by the verification path.
-func (s *AttestationPolicyService) GetPolicy(ctx context.Context, accountID, projectID string, pt domain.ProofType) (*domain.AttestationPolicy, error) {
+func (s *PolicyService) GetPolicy(ctx context.Context, accountID, projectID string, pt domain.ProofType) (*domain.AttestationPolicy, error) {
 	return s.repo.GetByTenantProofType(ctx, accountID, projectID, pt)
 }
 
 // ListPolicies returns all policies for a tenant.
-func (s *AttestationPolicyService) ListPolicies(ctx context.Context, accountID, projectID string) ([]*domain.AttestationPolicy, error) {
+func (s *PolicyService) ListPolicies(ctx context.Context, accountID, projectID string) ([]*domain.AttestationPolicy, error) {
 	return s.repo.List(ctx, accountID, projectID)
 }
 
 // DeletePolicy removes a policy by ID. Policies not belonging to the tenant
 // are silently no-op per the repo's idempotent delete semantics.
-func (s *AttestationPolicyService) DeletePolicy(ctx context.Context, id, accountID, projectID string) error {
+func (s *PolicyService) DeletePolicy(ctx context.Context, id, accountID, projectID string) error {
 	return s.repo.Delete(ctx, id, accountID, projectID)
 }

--- a/internal/attestation/stub.go
+++ b/internal/attestation/stub.go
@@ -1,0 +1,47 @@
+package attestation
+
+import (
+	"context"
+	"time"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// DevStubVerifier accepts any submitted proof without inspecting it.
+// Registered ONLY when cfg.Attestation.AllowUnsafeDevStub is set, and
+// ONLY for proof types that do not already have a real verifier wired
+// (the registry overwrites on double-Register, but the server wires the
+// stub last per-type so it fills gaps rather than replacing real
+// verifiers).
+//
+// The server emits a WARN-level startup log whenever this verifier is
+// installed. Do not use in production — it exists only to preserve
+// legacy demo flows during the transition from the old "mark verified
+// unconditionally" code path.
+type DevStubVerifier struct {
+	pt domain.ProofType
+}
+
+// NewDevStubVerifier returns a stub bound to a specific proof type. One
+// stub instance per proof type so Register can place each under its
+// expected key.
+func NewDevStubVerifier(pt domain.ProofType) *DevStubVerifier {
+	return &DevStubVerifier{pt: pt}
+}
+
+// ProofType reports which proof type this stub covers.
+func (v *DevStubVerifier) ProofType() domain.ProofType { return v.pt }
+
+// Verify unconditionally accepts the proof and returns a Result whose
+// Subject is the submitted ProofValue. This matches the legacy demo
+// behaviour so existing flows keep working when the unsafe flag is set.
+// The 24-hour ExpiresAt gives the dev path a finite lifetime so
+// downstream code that bounds trust by ExpiresAt still behaves.
+func (v *DevStubVerifier) Verify(_ context.Context, record *domain.AttestationRecord, _ []byte) (*Result, error) {
+	expires := time.Now().Add(24 * time.Hour)
+	return &Result{
+		Subject:   record.ProofValue,
+		Issuer:    "dev-stub",
+		ExpiresAt: &expires,
+	}, nil
+}

--- a/internal/attestation/stub.go
+++ b/internal/attestation/stub.go
@@ -13,8 +13,11 @@ import (
 // (image_hash, tpm). The server emits a WARN-level startup log whenever
 // the stub is installed.
 //
-// Do not use in production — it exists only to keep demo flows working
-// for proof types whose real verifiers are still being implemented.
+// Currently the flag defaults to true — until image_hash / tpm real
+// verifiers ship, this is the only way demos that submit those proof
+// types keep working. Deployments that don't need them (or that have
+// landed real verifiers) should set AllowUnsafeDevStub=false. The OIDC
+// verifier is unaffected: it's always wired and runs fail-closed.
 type DevStubVerifier struct {
 	pt domain.ProofType
 }

--- a/internal/attestation/stub.go
+++ b/internal/attestation/stub.go
@@ -9,15 +9,12 @@ import (
 
 // DevStubVerifier accepts any submitted proof without inspecting it.
 // Registered ONLY when cfg.Attestation.AllowUnsafeDevStub is set, and
-// ONLY for proof types that do not already have a real verifier wired
-// (the registry overwrites on double-Register, but the server wires the
-// stub last per-type so it fills gaps rather than replacing real
-// verifiers).
+// ONLY for proof types that have no real verifier shipped yet
+// (image_hash, tpm). The server emits a WARN-level startup log whenever
+// the stub is installed.
 //
-// The server emits a WARN-level startup log whenever this verifier is
-// installed. Do not use in production — it exists only to preserve
-// legacy demo flows during the transition from the old "mark verified
-// unconditionally" code path.
+// Do not use in production — it exists only to keep demo flows working
+// for proof types whose real verifiers are still being implemented.
 type DevStubVerifier struct {
 	pt domain.ProofType
 }

--- a/internal/attestation/verifier.go
+++ b/internal/attestation/verifier.go
@@ -1,0 +1,103 @@
+// Package attestation defines the verifier plug-in interface and concrete
+// verifiers used by the attestation submission → verification pipeline.
+//
+// Design: one Verifier per domain.ProofType, discovered through a Registry.
+// If a tenant has no AttestationPolicy for a proof type, or no Verifier is
+// registered for that type, verification fails closed — the record stays
+// unverified, no trust promotion, no credential issuance. This replaces the
+// previous stub that accepted any submitted proof.
+package attestation
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// ErrNoVerifier is returned when the registry has no Verifier wired for a
+// requested ProofType. Callers surface this as a 400 (invalid proof type
+// for this deployment) rather than 500.
+var ErrNoVerifier = errors.New("no verifier registered for this proof type")
+
+// Result is what a Verifier returns on success. These values are copied onto
+// the AttestationRecord so subsequent auditing, introspection, and trust
+// decisions can see WHO attested, via WHICH issuer, and WHEN the proof
+// expires (for short-lived proofs like OIDC JWTs).
+type Result struct {
+	// Subject is the verified principal bound to the proof (e.g. the JWT
+	// sub claim for oidc_token, the image digest for image_hash).
+	Subject string
+
+	// Issuer identifies the authority that produced the proof (e.g. the
+	// JWT iss claim). Empty for proof types with no external authority.
+	Issuer string
+
+	// ExpiresAt, when non-nil, bounds the attestation's validity. For
+	// time-bounded proofs like OIDC JWTs this mirrors the exp claim and
+	// propagates to AttestationRecord.ExpiresAt.
+	ExpiresAt *time.Time
+
+	// Claims is an optional grab-bag of verified claims (e.g. the full JWT
+	// claim set on oidc_token). Kept for audit logging and for future
+	// policy matchers that key on structured claims.
+	Claims map[string]any
+}
+
+// Verifier validates the ProofValue on an AttestationRecord against a
+// tenant-scoped policy. Implementations MUST be safe to call concurrently.
+//
+// policyConfig is the raw JSONB Config from the AttestationPolicy row for
+// the caller's tenant + this proof type. Verifiers own the parsing of that
+// blob so the registry doesn't need to know each verifier's config shape.
+type Verifier interface {
+	// ProofType returns the ProofType this verifier handles. One Verifier
+	// per ProofType; the registry uses this for lookup.
+	ProofType() domain.ProofType
+
+	// Verify returns a Result when the proof is valid under the supplied
+	// policy, or an error describing why it was rejected. An error must
+	// NOT be swallowed into a zero-value Result — the caller treats any
+	// error as "attestation rejected, do not promote trust".
+	Verify(ctx context.Context, record *domain.AttestationRecord, policyConfig []byte) (*Result, error)
+}
+
+// Registry maps ProofType → Verifier. Built at server startup; read-only at
+// request time, so no locking is needed after construction.
+type Registry struct {
+	verifiers map[domain.ProofType]Verifier
+}
+
+// NewRegistry creates an empty registry. Register each Verifier via Register
+// before the server begins serving requests.
+func NewRegistry() *Registry {
+	return &Registry{verifiers: make(map[domain.ProofType]Verifier)}
+}
+
+// Register wires a Verifier into the registry. Registering twice for the
+// same ProofType overwrites; this is intentional for the dev-stub path
+// where the stub fills in wherever no real verifier is wired.
+func (r *Registry) Register(v Verifier) {
+	r.verifiers[v.ProofType()] = v
+}
+
+// Get returns the Verifier for pt, or ErrNoVerifier if none is registered.
+func (r *Registry) Get(pt domain.ProofType) (Verifier, error) {
+	v, ok := r.verifiers[pt]
+	if !ok {
+		return nil, ErrNoVerifier
+	}
+	return v, nil
+}
+
+// ProofTypes returns the ProofTypes that have a verifier wired. Order is
+// not specified. Used for startup logging so operators can see which
+// verifiers are active.
+func (r *Registry) ProofTypes() []domain.ProofType {
+	out := make([]domain.ProofType, 0, len(r.verifiers))
+	for pt := range r.verifiers {
+		out = append(out, pt)
+	}
+	return out
+}

--- a/internal/attestation/verifier.go
+++ b/internal/attestation/verifier.go
@@ -1,11 +1,3 @@
-// Package attestation defines the verifier plug-in interface and concrete
-// verifiers used by the attestation submission → verification pipeline.
-//
-// Design: one Verifier per domain.ProofType, discovered through a Registry.
-// If a tenant has no AttestationPolicy for a proof type, or no Verifier is
-// registered for that type, verification fails closed — the record stays
-// unverified, no trust promotion, no credential issuance. This replaces the
-// previous stub that accepted any submitted proof.
 package attestation
 
 import (

--- a/internal/handler/attestation.go
+++ b/internal/handler/attestation.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/highflame-ai/zeroid/domain"
 	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
+	"github.com/highflame-ai/zeroid/internal/service"
 )
 
 // ── Attestation types ────────────────────────────────────────────────────────
@@ -106,6 +108,12 @@ func (a *API) verifyAttestationOp(ctx context.Context, input *VerifyAttestationI
 
 	result, err := a.attestationSvc.VerifyAttestation(ctx, input.Body.AttestationID, tenant.AccountID, tenant.ProjectID)
 	if err != nil {
+		// Rejection (bad proof, unconfigured verifier, no policy) is a
+		// client/config error, not a server fault — 400 with the cause.
+		if errors.Is(err, service.ErrAttestationRejected) {
+			log.Info().Err(err).Str("attestation_id", input.Body.AttestationID).Msg("attestation verification rejected")
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		log.Error().Err(err).Str("attestation_id", input.Body.AttestationID).Msg("attestation verification failed")
 		return nil, huma.Error500InternalServerError("attestation verification failed")
 	}

--- a/internal/handler/attestation.go
+++ b/internal/handler/attestation.go
@@ -114,6 +114,13 @@ func (a *API) verifyAttestationOp(ctx context.Context, input *VerifyAttestationI
 			log.Info().Err(err).Str("attestation_id", input.Body.AttestationID).Msg("attestation verification rejected")
 			return nil, huma.Error400BadRequest(err.Error())
 		}
+		// Re-verification of a record that's already verified is a
+		// caller mistake — 409 so clients can distinguish idempotent
+		// retries from validation errors.
+		if errors.Is(err, service.ErrAttestationAlreadyVerified) {
+			log.Info().Err(err).Str("attestation_id", input.Body.AttestationID).Msg("attestation already verified")
+			return nil, huma.Error409Conflict(err.Error())
+		}
 		log.Error().Err(err).Str("attestation_id", input.Body.AttestationID).Msg("attestation verification failed")
 		return nil, huma.Error500InternalServerError("attestation verification failed")
 	}

--- a/internal/handler/attestation_policy.go
+++ b/internal/handler/attestation_policy.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -91,6 +92,12 @@ func (a *API) upsertAttestationPolicyOp(ctx context.Context, input *UpsertAttest
 		IsActive:  input.Body.IsActive,
 	})
 	if err != nil {
+		// Validation errors (bad config, non-https issuer URL, etc.) are
+		// client-fixable — return 400 with the cause so the admin can
+		// correct the payload. Everything else is infrastructure.
+		if errors.Is(err, service.ErrInvalidAttestationPolicy) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		log.Error().Err(err).Str("proof_type", input.Body.ProofType).Msg("failed to upsert attestation policy")
 		return nil, huma.Error500InternalServerError("failed to upsert attestation policy")
 	}

--- a/internal/handler/attestation_policy.go
+++ b/internal/handler/attestation_policy.go
@@ -1,0 +1,129 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
+	"github.com/highflame-ai/zeroid/internal/service"
+)
+
+// ── Attestation policy types ─────────────────────────────────────────────────
+
+// UpsertAttestationPolicyInput is the request body for creating or updating
+// a tenant's policy for a specific proof type. The unique (tenant, proof_type)
+// key means there's no separate create vs. update endpoint — callers PUT
+// whatever shape they want and the service routes to insert or update.
+type UpsertAttestationPolicyInput struct {
+	Body struct {
+		ProofType string          `json:"proof_type" required:"true" enum:"image_hash,oidc_token,tpm" doc:"Proof type this policy governs"`
+		Config    json.RawMessage `json:"config" required:"true" doc:"Verifier-specific configuration (shape depends on proof_type)"`
+		IsActive  *bool           `json:"is_active,omitempty" doc:"Set false to disable without deleting (default: true)"`
+	}
+}
+
+type AttestationPolicyOutput struct {
+	Body *domain.AttestationPolicy
+}
+
+type AttestationPolicyListOutput struct {
+	Body struct {
+		Policies []*domain.AttestationPolicy `json:"policies"`
+	}
+}
+
+type AttestationPolicyIDInput struct {
+	ID string `path:"id" doc:"Attestation policy UUID"`
+}
+
+// ── Attestation policy routes ────────────────────────────────────────────────
+
+func (a *API) registerAttestationPolicyRoutes(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID:   "upsert-attestation-policy",
+		Method:        http.MethodPut,
+		Path:          "/attestation-policies",
+		Summary:       "Create or update an attestation policy for a proof type",
+		Description:   "One policy per (tenant, proof_type). PUT is upsert — the unique constraint on the underlying row means repeated calls overwrite the existing config.",
+		Tags:          []string{"Attestation Policy"},
+		DefaultStatus: http.StatusOK,
+	}, a.upsertAttestationPolicyOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "list-attestation-policies",
+		Method:      http.MethodGet,
+		Path:        "/attestation-policies",
+		Summary:     "List attestation policies for the current tenant",
+		Tags:        []string{"Attestation Policy"},
+	}, a.listAttestationPoliciesOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "delete-attestation-policy",
+		Method:        http.MethodDelete,
+		Path:          "/attestation-policies/{id}",
+		Summary:       "Delete an attestation policy",
+		Tags:          []string{"Attestation Policy"},
+		DefaultStatus: http.StatusNoContent,
+	}, a.deleteAttestationPolicyOp)
+}
+
+func (a *API) upsertAttestationPolicyOp(ctx context.Context, input *UpsertAttestationPolicyInput) (*AttestationPolicyOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	pt := domain.ProofType(input.Body.ProofType)
+	if !pt.Valid() {
+		return nil, huma.Error400BadRequest("invalid proof_type")
+	}
+
+	policy, err := a.attestationPolicySvc.UpsertPolicy(ctx, service.UpsertAttestationPolicyRequest{
+		AccountID: tenant.AccountID,
+		ProjectID: tenant.ProjectID,
+		ProofType: pt,
+		Config:    input.Body.Config,
+		IsActive:  input.Body.IsActive,
+	})
+	if err != nil {
+		log.Error().Err(err).Str("proof_type", input.Body.ProofType).Msg("failed to upsert attestation policy")
+		return nil, huma.Error500InternalServerError("failed to upsert attestation policy")
+	}
+	return &AttestationPolicyOutput{Body: policy}, nil
+}
+
+func (a *API) listAttestationPoliciesOp(ctx context.Context, _ *struct{}) (*AttestationPolicyListOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	policies, err := a.attestationPolicySvc.ListPolicies(ctx, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to list attestation policies")
+		return nil, huma.Error500InternalServerError("failed to list attestation policies")
+	}
+	if policies == nil {
+		policies = []*domain.AttestationPolicy{}
+	}
+	out := &AttestationPolicyListOutput{}
+	out.Body.Policies = policies
+	return out, nil
+}
+
+func (a *API) deleteAttestationPolicyOp(ctx context.Context, input *AttestationPolicyIDInput) (*struct{}, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+	if err := a.attestationPolicySvc.DeletePolicy(ctx, input.ID, tenant.AccountID, tenant.ProjectID); err != nil {
+		log.Error().Err(err).Str("policy_id", input.ID).Msg("failed to delete attestation policy")
+		return nil, huma.Error500InternalServerError("failed to delete attestation policy")
+	}
+	return nil, nil
+}

--- a/internal/handler/attestation_policy.go
+++ b/internal/handler/attestation_policy.go
@@ -10,8 +10,8 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/attestation"
 	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
-	"github.com/highflame-ai/zeroid/internal/service"
 )
 
 // ── Attestation policy types ─────────────────────────────────────────────────
@@ -84,7 +84,7 @@ func (a *API) upsertAttestationPolicyOp(ctx context.Context, input *UpsertAttest
 		return nil, huma.Error400BadRequest("invalid proof_type")
 	}
 
-	policy, err := a.attestationPolicySvc.UpsertPolicy(ctx, service.UpsertAttestationPolicyRequest{
+	policy, err := a.attestationPolicySvc.UpsertPolicy(ctx, attestation.UpsertPolicyRequest{
 		AccountID: tenant.AccountID,
 		ProjectID: tenant.ProjectID,
 		ProofType: pt,
@@ -95,7 +95,7 @@ func (a *API) upsertAttestationPolicyOp(ctx context.Context, input *UpsertAttest
 		// Validation errors (bad config, non-https issuer URL, etc.) are
 		// client-fixable — return 400 with the cause so the admin can
 		// correct the payload. Everything else is infrastructure.
-		if errors.Is(err, service.ErrInvalidAttestationPolicy) {
+		if errors.Is(err, attestation.ErrInvalidPolicy) {
 			return nil, huma.Error400BadRequest(err.Error())
 		}
 		log.Error().Err(err).Str("proof_type", input.Body.ProofType).Msg("failed to upsert attestation policy")

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -20,21 +20,22 @@ import (
 
 // API holds all service dependencies and exposes Huma-compatible handler methods.
 type API struct {
-	identitySvc         *service.IdentityService
-	credSvc             *service.CredentialService
-	credentialPolicySvc *service.CredentialPolicyService
-	attestationSvc      *service.AttestationService
-	proofSvc            *service.ProofService
-	oauthSvc            *service.OAuthService
-	oauthClientSvc      *service.OAuthClientService
-	signalSvc           *service.SignalService
-	apiKeySvc           *service.APIKeyService
-	agentSvc            *service.AgentService
-	jwksSvc             *signing.JWKSService
-	db                  *bun.DB
-	issuer              string
-	baseURL             string
-	startTime           time.Time
+	identitySvc          *service.IdentityService
+	credSvc              *service.CredentialService
+	credentialPolicySvc  *service.CredentialPolicyService
+	attestationSvc       *service.AttestationService
+	attestationPolicySvc *service.AttestationPolicyService
+	proofSvc             *service.ProofService
+	oauthSvc             *service.OAuthService
+	oauthClientSvc       *service.OAuthClientService
+	signalSvc            *service.SignalService
+	apiKeySvc            *service.APIKeyService
+	agentSvc             *service.AgentService
+	jwksSvc              *signing.JWKSService
+	db                   *bun.DB
+	issuer               string
+	baseURL              string
+	startTime            time.Time
 }
 
 // NewAPI creates a new API with all service dependencies.
@@ -43,6 +44,7 @@ func NewAPI(
 	credSvc *service.CredentialService,
 	credentialPolicySvc *service.CredentialPolicyService,
 	attestationSvc *service.AttestationService,
+	attestationPolicySvc *service.AttestationPolicyService,
 	proofSvc *service.ProofService,
 	oauthSvc *service.OAuthService,
 	oauthClientSvc *service.OAuthClientService,
@@ -54,21 +56,22 @@ func NewAPI(
 	issuer, baseURL string,
 ) *API {
 	return &API{
-		identitySvc:         identitySvc,
-		credSvc:             credSvc,
-		credentialPolicySvc: credentialPolicySvc,
-		attestationSvc:      attestationSvc,
-		proofSvc:            proofSvc,
-		oauthSvc:            oauthSvc,
-		oauthClientSvc:      oauthClientSvc,
-		signalSvc:           signalSvc,
-		apiKeySvc:           apiKeySvc,
-		agentSvc:            agentSvc,
-		jwksSvc:             jwksSvc,
-		db:                  db,
-		issuer:              issuer,
-		baseURL:             baseURL,
-		startTime:           time.Now(),
+		identitySvc:          identitySvc,
+		credSvc:              credSvc,
+		credentialPolicySvc:  credentialPolicySvc,
+		attestationSvc:       attestationSvc,
+		attestationPolicySvc: attestationPolicySvc,
+		proofSvc:             proofSvc,
+		oauthSvc:             oauthSvc,
+		oauthClientSvc:       oauthClientSvc,
+		signalSvc:            signalSvc,
+		apiKeySvc:            apiKeySvc,
+		agentSvc:             agentSvc,
+		jwksSvc:              jwksSvc,
+		db:                   db,
+		issuer:               issuer,
+		baseURL:              baseURL,
+		startTime:            time.Now(),
 	}
 }
 
@@ -107,6 +110,7 @@ func (a *API) RegisterAdmin(api huma.API, router chi.Router) {
 	a.registerCredentialPolicyRoutes(api)
 	a.registerCredentialRoutes(api)
 	a.registerAttestationRoutes(api)
+	a.registerAttestationPolicyRoutes(api)
 	a.registerOAuthClientRoutes(api)
 	a.registerAPIKeyRoutes(api)
 	a.registerAgentRoutes(api)

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -14,6 +14,7 @@ import (
 	gojson "github.com/goccy/go-json"
 	"github.com/uptrace/bun"
 
+	"github.com/highflame-ai/zeroid/internal/attestation"
 	"github.com/highflame-ai/zeroid/internal/service"
 	"github.com/highflame-ai/zeroid/internal/signing"
 )
@@ -24,7 +25,7 @@ type API struct {
 	credSvc              *service.CredentialService
 	credentialPolicySvc  *service.CredentialPolicyService
 	attestationSvc       *service.AttestationService
-	attestationPolicySvc *service.AttestationPolicyService
+	attestationPolicySvc *attestation.PolicyService
 	proofSvc             *service.ProofService
 	oauthSvc             *service.OAuthService
 	oauthClientSvc       *service.OAuthClientService
@@ -45,7 +46,7 @@ func NewAPI(
 	credSvc *service.CredentialService,
 	credentialPolicySvc *service.CredentialPolicyService,
 	attestationSvc *service.AttestationService,
-	attestationPolicySvc *service.AttestationPolicyService,
+	attestationPolicySvc *attestation.PolicyService,
 	proofSvc *service.ProofService,
 	oauthSvc *service.OAuthService,
 	oauthClientSvc *service.OAuthClientService,

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -81,23 +81,36 @@ type VerifyAttestationResult struct {
 	Credential  *domain.IssuedCredential
 }
 
+// ErrAttestationAlreadyVerified is returned when VerifyAttestation is called
+// on a record that is already marked verified. Re-verification is rejected
+// so a partial-failure retry cannot mint a second credential against the
+// same proof.
+var ErrAttestationAlreadyVerified = errors.New("attestation already verified")
+
 // VerifyAttestation runs the proof through the registered Verifier for its
-// ProofType, using the caller's tenant policy. On success it marks the
-// record verified, copies the issuer / subject / expiry from the Verifier
-// Result onto the record, promotes the identity's trust level, and issues
-// a credential. Any failure along the way leaves the record unverified and
-// returns an error — no partial state.
+// ProofType, using the caller's tenant policy. On success it issues a
+// credential, promotes the identity's trust level, and commits the record
+// update with the credential link and the verified issuer/subject/expiry.
 //
 // Fail-closed contract:
 //   - No Verifier registered for the proof type → ErrAttestationRejected.
 //   - No AttestationPolicy for the tenant + proof type → ErrAttestationRejected.
 //   - Verifier.Verify returns an error → ErrAttestationRejected.
+//   - Record already verified → ErrAttestationAlreadyVerified (rejects retries).
 //
-// This replaces the previous stub that accepted any submitted proof.
+// Write ordering rationale: credential issuance runs BEFORE identity trust
+// promotion, so the most common failure (IssueCredential) leaves nothing
+// committed. Trust promotion and record update run last, in that order, so
+// a failure between them leaves trust promoted (harmless — backed by a
+// valid proof) with the record unmarked. The re-verify guard prevents a
+// second IssueCredential call in that retry window.
 func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountID, projectID string) (*VerifyAttestationResult, error) {
 	record, err := s.repo.GetByID(ctx, id, accountID, projectID)
 	if err != nil {
 		return nil, err
+	}
+	if record.IsVerified {
+		return nil, fmt.Errorf("%w: record %s", ErrAttestationAlreadyVerified, record.ID)
 	}
 
 	verifier, err := s.verifiers.Get(record.ProofType)
@@ -118,23 +131,17 @@ func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountI
 		return nil, fmt.Errorf("%w: %v", ErrAttestationRejected, err)
 	}
 
-	now := time.Now()
-	record.IsVerified = true
-	record.VerifiedAt = &now
-	if result.ExpiresAt != nil {
-		record.ExpiresAt = result.ExpiresAt
-	}
-
-	// Elevate trust level based on attestation level.
-	promotedTrust := trustLevelForAttestation(record.Level)
-	identity, err := s.identitySvc.UpdateIdentity(ctx, record.IdentityID, accountID, projectID, UpdateIdentityRequest{
-		TrustLevel: promotedTrust,
-	})
+	// Load the identity without promoting yet — IssueCredential needs a
+	// valid, non-nil, usable identity and re-fetching guarantees we see
+	// the current state (another request might have deactivated it).
+	identity, err := s.identitySvc.GetIdentity(ctx, record.IdentityID, accountID, projectID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to promote identity trust level: %w", err)
+		return nil, fmt.Errorf("failed to load identity for verified attestation: %w", err)
 	}
 
-	// Issue a credential for the newly verified identity.
+	// Step 1: issue the credential. This is the most likely failure point
+	// (policy checks, scope derivation, signing). Running it first means
+	// a failure leaves no partial state behind.
 	accessToken, cred, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:  identity,
 		GrantType: domain.GrantTypeClientCredentials,
@@ -143,8 +150,23 @@ func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountI
 		return nil, fmt.Errorf("failed to issue post-attestation credential: %w", err)
 	}
 
-	record.CredentialID = cred.ID
+	// Step 2: promote trust level. Backed by the just-verified proof.
+	promotedTrust := trustLevelForAttestation(record.Level)
+	if _, err := s.identitySvc.UpdateIdentity(ctx, record.IdentityID, accountID, projectID, UpdateIdentityRequest{
+		TrustLevel: promotedTrust,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to promote identity trust level: %w", err)
+	}
 
+	// Step 3: commit the record with verified flag, audit fields, and
+	// credential link in a single write.
+	now := time.Now()
+	record.IsVerified = true
+	record.VerifiedAt = &now
+	if result.ExpiresAt != nil {
+		record.ExpiresAt = result.ExpiresAt
+	}
+	record.CredentialID = cred.ID
 	if err := s.repo.Update(ctx, record); err != nil {
 		return nil, fmt.Errorf("failed to update attestation record: %w", err)
 	}

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -3,28 +3,49 @@ package service
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/attestation"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
-// AttestationService handles attestation submission and verification.
+// ErrAttestationRejected is returned when a submitted proof fails verification.
+// Distinguished from infrastructure errors so the handler can respond 400 rather
+// than 500 — rejection is a client/config problem, not a server fault.
+var ErrAttestationRejected = errors.New("attestation proof rejected")
+
+// AttestationService handles attestation submission and verification. The
+// verifier registry and attestation-policy service together implement the
+// fail-closed contract: no policy + no verifier = no trust promotion.
 type AttestationService struct {
 	repo          *postgres.AttestationRepository
 	credentialSvc *CredentialService
 	identitySvc   *IdentityService
+	verifiers     *attestation.Registry
+	policySvc     *AttestationPolicyService
 }
 
-// NewAttestationService creates a new AttestationService.
-func NewAttestationService(repo *postgres.AttestationRepository, credentialSvc *CredentialService, identitySvc *IdentityService) *AttestationService {
+// NewAttestationService creates a new AttestationService. verifiers and
+// policySvc are required: VerifyAttestation fails closed when no verifier
+// is registered for a proof type or no tenant policy exists.
+func NewAttestationService(
+	repo *postgres.AttestationRepository,
+	credentialSvc *CredentialService,
+	identitySvc *IdentityService,
+	verifiers *attestation.Registry,
+	policySvc *AttestationPolicyService,
+) *AttestationService {
 	return &AttestationService{
 		repo:          repo,
 		credentialSvc: credentialSvc,
 		identitySvc:   identitySvc,
+		verifiers:     verifiers,
+		policySvc:     policySvc,
 	}
 }
 
@@ -60,19 +81,49 @@ type VerifyAttestationResult struct {
 	Credential  *domain.IssuedCredential
 }
 
-// VerifyAttestation validates an attestation, marks it as verified, elevates the identity's
-// trust level to match the attestation level, and auto-issues a credential.
-// TODO: replace the stub proof check with real verification (image hash, OIDC, TPM).
+// VerifyAttestation runs the proof through the registered Verifier for its
+// ProofType, using the caller's tenant policy. On success it marks the
+// record verified, copies the issuer / subject / expiry from the Verifier
+// Result onto the record, promotes the identity's trust level, and issues
+// a credential. Any failure along the way leaves the record unverified and
+// returns an error — no partial state.
+//
+// Fail-closed contract:
+//   - No Verifier registered for the proof type → ErrAttestationRejected.
+//   - No AttestationPolicy for the tenant + proof type → ErrAttestationRejected.
+//   - Verifier.Verify returns an error → ErrAttestationRejected.
+//
+// This replaces the previous stub that accepted any submitted proof.
 func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountID, projectID string) (*VerifyAttestationResult, error) {
 	record, err := s.repo.GetByID(ctx, id, accountID, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	// --- stub: mark as verified (replace with real proof validation) ---
+	verifier, err := s.verifiers.Get(record.ProofType)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAttestationRejected, err)
+	}
+
+	policy, err := s.policySvc.GetPolicy(ctx, accountID, projectID, record.ProofType)
+	if err != nil {
+		if errors.Is(err, postgres.ErrAttestationPolicyNotFound) {
+			return nil, fmt.Errorf("%w: no attestation policy configured for proof type %s", ErrAttestationRejected, record.ProofType)
+		}
+		return nil, err
+	}
+
+	result, err := verifier.Verify(ctx, record, policy.Config)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAttestationRejected, err)
+	}
+
 	now := time.Now()
 	record.IsVerified = true
 	record.VerifiedAt = &now
+	if result.ExpiresAt != nil {
+		record.ExpiresAt = result.ExpiresAt
+	}
 
 	// Elevate trust level based on attestation level.
 	promotedTrust := trustLevelForAttestation(record.Level)

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -5,9 +5,11 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/attestation"
@@ -22,31 +24,58 @@ var ErrAttestationRejected = errors.New("attestation proof rejected")
 // AttestationService handles attestation submission and verification. The
 // verifier registry and attestation-policy service together implement the
 // fail-closed contract: no policy + no verifier = no trust promotion.
+//
+// When allowUnsafeDevStub is true (sourced from
+// cfg.Attestation.AllowUnsafeDevStub at construction time), VerifyAttestation
+// permits a transitional bypass: if the tenant has no AttestationPolicy
+// configured but the verifier IS registered, the service synthesises a
+// stub-shape Result and continues. The verifier itself is not invoked in
+// that case (the OIDC verifier requires a non-empty policy config to mean
+// anything; the stub doesn't read config). A loud WARN logs every such
+// bypass so operators can prioritise migrating those tenants to a real
+// policy before the flag is flipped off.
 type AttestationService struct {
 	repo          *postgres.AttestationRepository
 	credentialSvc *CredentialService
 	identitySvc   *IdentityService
 	verifiers     *attestation.Registry
 	policySvc     *attestation.PolicyService
+
+	// permissive is the runtime-mutable form of cfg.Attestation.AllowUnsafeDevStub.
+	// Stored as int32 so SetPermissive can flip it without a mutex —
+	// integration tests need to toggle the bypass mid-suite.
+	permissive atomic.Bool
 }
 
 // NewAttestationService creates a new AttestationService. verifiers and
 // policySvc are required: VerifyAttestation fails closed when no verifier
-// is registered for a proof type or no tenant policy exists.
+// is registered for a proof type or no tenant policy exists, unless
+// allowUnsafeDevStub is true (transitional bypass).
 func NewAttestationService(
 	repo *postgres.AttestationRepository,
 	credentialSvc *CredentialService,
 	identitySvc *IdentityService,
 	verifiers *attestation.Registry,
 	policySvc *attestation.PolicyService,
+	allowUnsafeDevStub bool,
 ) *AttestationService {
-	return &AttestationService{
+	s := &AttestationService{
 		repo:          repo,
 		credentialSvc: credentialSvc,
 		identitySvc:   identitySvc,
 		verifiers:     verifiers,
 		policySvc:     policySvc,
 	}
+	s.permissive.Store(allowUnsafeDevStub)
+	return s
+}
+
+// SetPermissive flips the missing-policy bypass at runtime. Production
+// code should not call this; it exists so integration tests can exercise
+// both modes without standing up a second server. Server.SetAttestationPermissive
+// is the public surface.
+func (s *AttestationService) SetPermissive(enabled bool) {
+	s.permissive.Store(enabled)
 }
 
 // SubmitAttestation records a new attestation proof.
@@ -94,7 +123,9 @@ var ErrAttestationAlreadyVerified = errors.New("attestation already verified")
 //
 // Fail-closed contract:
 //   - No Verifier registered for the proof type → ErrAttestationRejected.
-//   - No AttestationPolicy for the tenant + proof type → ErrAttestationRejected.
+//   - No AttestationPolicy AND permissive bypass disabled → ErrAttestationRejected.
+//   - No AttestationPolicy AND permissive bypass enabled → synthesised Result
+//     (transitional; logs WARN per request).
 //   - Verifier.Verify returns an error → ErrAttestationRejected.
 //   - Record already verified → ErrAttestationAlreadyVerified (rejects retries).
 //
@@ -113,22 +144,46 @@ func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountI
 		return nil, fmt.Errorf("%w: record %s", ErrAttestationAlreadyVerified, record.ID)
 	}
 
+	// Gate 1: verifier must be registered for this proof type. This stays
+	// strict in permissive mode too — a typo'd or unsupported proof type
+	// shouldn't auto-accept just because the dev-stub flag is on.
 	verifier, err := s.verifiers.Get(record.ProofType)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrAttestationRejected, err)
 	}
 
-	policy, err := s.policySvc.GetPolicy(ctx, accountID, projectID, record.ProofType)
-	if err != nil {
-		if errors.Is(err, postgres.ErrAttestationPolicyNotFound) {
+	// Gate 2: tenant policy. Permissive mode bypasses this gate by
+	// synthesising a stub-shape Result instead of running the verifier
+	// (OIDC requires a policy to mean anything; the stub doesn't read
+	// config). Logged WARN per request so operators can find tenants
+	// that still need a real policy.
+	var result *attestation.Result
+	policy, policyErr := s.policySvc.GetPolicy(ctx, accountID, projectID, record.ProofType)
+	switch {
+	case errors.Is(policyErr, postgres.ErrAttestationPolicyNotFound):
+		if !s.permissive.Load() {
 			return nil, fmt.Errorf("%w: no attestation policy configured for proof type %s", ErrAttestationRejected, record.ProofType)
 		}
-		return nil, err
-	}
-
-	result, err := verifier.Verify(ctx, record, policy.Config)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrAttestationRejected, err)
+		log.Warn().
+			Str("identity_id", record.IdentityID).
+			Str("account_id", accountID).
+			Str("project_id", projectID).
+			Str("proof_type", string(record.ProofType)).
+			Str("attestation_id", record.ID).
+			Msg("ATTESTATION: accepting proof with no AttestationPolicy because allow_unsafe_dev_stub=true. Configure a policy for this tenant + proof_type to switch to real verification.")
+		expires := time.Now().Add(24 * time.Hour)
+		result = &attestation.Result{
+			Subject:   record.ProofValue,
+			Issuer:    "dev-stub-no-policy",
+			ExpiresAt: &expires,
+		}
+	case policyErr != nil:
+		return nil, policyErr
+	default:
+		result, err = verifier.Verify(ctx, record, policy.Config)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrAttestationRejected, err)
+		}
 	}
 
 	// Load the identity without promoting yet — IssueCredential needs a

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -142,6 +142,14 @@ func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountI
 	// Step 1: issue the credential. This is the most likely failure point
 	// (policy checks, scope derivation, signing). Running it first means
 	// a failure leaves no partial state behind.
+	//
+	// GrantType is fixed to client_credentials regardless of how the
+	// identity will subsequently authenticate. Verified attestation is a
+	// workload-bootstrap event: the identity has just proven its
+	// runtime properties (image hash, OIDC claims, TPM quote) and the
+	// returned token represents that boot-time trust, not a user-driven
+	// session. Downstream flows can still token-exchange / jwt-bearer
+	// against this credential; the bootstrap shape just doesn't change.
 	accessToken, cred, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:  identity,
 		GrantType: domain.GrantTypeClientCredentials,

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -27,7 +27,7 @@ type AttestationService struct {
 	credentialSvc *CredentialService
 	identitySvc   *IdentityService
 	verifiers     *attestation.Registry
-	policySvc     *AttestationPolicyService
+	policySvc     *attestation.PolicyService
 }
 
 // NewAttestationService creates a new AttestationService. verifiers and
@@ -38,7 +38,7 @@ func NewAttestationService(
 	credentialSvc *CredentialService,
 	identitySvc *IdentityService,
 	verifiers *attestation.Registry,
-	policySvc *AttestationPolicyService,
+	policySvc *attestation.PolicyService,
 ) *AttestationService {
 	return &AttestationService{
 		repo:          repo,

--- a/internal/service/attestation_policy.go
+++ b/internal/service/attestation_policy.go
@@ -3,13 +3,22 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
+
+// ErrInvalidAttestationPolicy is returned for caller-induced validation
+// errors on UpsertPolicy (bad proof_type, malformed config, non-https
+// issuer URL, etc.). Distinguished from infrastructure errors so the
+// handler maps it to 400 rather than 500.
+var ErrInvalidAttestationPolicy = errors.New("invalid attestation policy")
 
 // AttestationPolicyService is a thin wrapper around the policy repo. The
 // verifier registry holds the concrete verification code; this service
@@ -39,15 +48,25 @@ type UpsertAttestationPolicyRequest struct {
 // this is the admin API's natural write shape.
 func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertAttestationPolicyRequest) (*domain.AttestationPolicy, error) {
 	if !req.ProofType.Valid() {
-		return nil, fmt.Errorf("invalid proof_type: %s", req.ProofType)
+		return nil, fmt.Errorf("%w: invalid proof_type %q", ErrInvalidAttestationPolicy, req.ProofType)
 	}
 	if len(req.Config) == 0 {
-		return nil, fmt.Errorf("config is required")
+		return nil, fmt.Errorf("%w: config is required", ErrInvalidAttestationPolicy)
+	}
+	// Validate the per-proof-type config shape up front so bad configs can't
+	// sit in the DB until a /verify call finally trips on them. Catches
+	// typos, wrong types, missing issuer URLs, etc. at write time.
+	if err := validatePolicyConfig(req.ProofType, req.Config); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidAttestationPolicy, err)
 	}
 
-	existing, err := s.repo.GetByTenantProofType(ctx, req.AccountID, req.ProjectID, req.ProofType)
-	switch err {
-	case nil:
+	// GetByTenantProofTypeAny ignores is_active so an upsert against a
+	// soft-disabled row updates it in place. GetByTenantProofType filters
+	// is_active and would drive this branch into an INSERT that violates
+	// the uq_attestation_policy_tenant_type unique constraint.
+	existing, err := s.repo.GetByTenantProofTypeAny(ctx, req.AccountID, req.ProjectID, req.ProofType)
+	switch {
+	case err == nil:
 		existing.Config = req.Config
 		if req.IsActive != nil {
 			existing.IsActive = *req.IsActive
@@ -56,7 +75,7 @@ func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertA
 			return nil, err
 		}
 		return existing, nil
-	case postgres.ErrAttestationPolicyNotFound:
+	case errors.Is(err, postgres.ErrAttestationPolicyNotFound):
 		active := true
 		if req.IsActive != nil {
 			active = *req.IsActive
@@ -76,6 +95,65 @@ func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertA
 	default:
 		return nil, err
 	}
+}
+
+// validatePolicyConfig checks the per-proof-type Config shape at write time.
+// Parsing the JSONB into its typed Go struct catches the obvious "this will
+// never verify successfully" cases (missing issuer list, non-https issuer
+// URL, malformed URL, etc.) before the config reaches the verifier.
+func validatePolicyConfig(pt domain.ProofType, cfg json.RawMessage) error {
+	switch pt {
+	case domain.ProofTypeOIDCToken:
+		var oidc domain.OIDCPolicyConfig
+		if err := json.Unmarshal(cfg, &oidc); err != nil {
+			return fmt.Errorf("invalid oidc_token config: %w", err)
+		}
+		if len(oidc.Issuers) == 0 {
+			return fmt.Errorf("invalid oidc_token config: at least one issuer is required")
+		}
+		for i, iss := range oidc.Issuers {
+			if strings.TrimSpace(iss.URL) == "" {
+				return fmt.Errorf("invalid oidc_token config: issuer[%d].url is empty", i)
+			}
+			u, err := url.Parse(iss.URL)
+			if err != nil {
+				return fmt.Errorf("invalid oidc_token config: issuer[%d].url is malformed: %w", i, err)
+			}
+			// OIDC discovery is unauthenticated — if we'd fetch jwks_uri
+			// over plain HTTP, a DNS or network attacker could substitute
+			// their own keys and forge any workload identity. Require TLS
+			// except for loopback addresses, which are safe to serve over
+			// HTTP because traffic never leaves the machine — useful for
+			// local dev and httptest-based integration tests.
+			if u.Scheme != "https" && !isLoopbackHost(u.Host) {
+				return fmt.Errorf("invalid oidc_token config: issuer[%d].url must use https (got %q)", i, u.Scheme)
+			}
+		}
+	case domain.ProofTypeImageHash, domain.ProofTypeTPM:
+		// No typed config yet — verifiers for these proof types haven't
+		// shipped. Accept the raw blob so operators can pre-configure
+		// policy rows before the verifier lands.
+	default:
+		return fmt.Errorf("unsupported proof_type: %s", pt)
+	}
+	return nil
+}
+
+// isLoopbackHost reports whether the host portion of a URL (possibly
+// including a port) is a loopback address. Used to carve out a safe-to-
+// serve-over-HTTP exception for OIDC discovery in dev/test environments.
+func isLoopbackHost(host string) bool {
+	// Strip an optional :port suffix. Host is in URL form already so
+	// IPv6 addresses are bracketed as [::1]:port — handle both shapes.
+	if i := strings.LastIndex(host, ":"); i >= 0 && !strings.Contains(host[i+1:], "]") {
+		host = host[:i]
+	}
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
 }
 
 // GetPolicy returns the policy for the given tenant + proof type, or

--- a/internal/service/attestation_policy.go
+++ b/internal/service/attestation_policy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
@@ -129,13 +130,15 @@ func validatePolicyConfig(pt domain.ProofType, cfg json.RawMessage) error {
 // including a port) is a loopback address. Used to carve out a safe-to-
 // serve-over-HTTP exception for OIDC discovery in dev/test environments.
 func isLoopbackHost(host string) bool {
-	// Strip an optional :port suffix. Host is in URL form already so
-	// IPv6 addresses are bracketed as [::1]:port — handle both shapes.
-	if i := strings.LastIndex(host, ":"); i >= 0 && !strings.Contains(host[i+1:], "]") {
-		host = host[:i]
+	// net.SplitHostPort strips brackets from IPv6 hosts and separates the
+	// port cleanly. On hosts without a port it returns an error; fall back
+	// to the raw host string and strip any brackets that remain.
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
 	}
-	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
-	switch host {
+	h = strings.TrimPrefix(strings.TrimSuffix(h, "]"), "[")
+	switch h {
 	case "localhost", "127.0.0.1", "::1":
 		return true
 	}

--- a/internal/service/attestation_policy.go
+++ b/internal/service/attestation_policy.go
@@ -1,0 +1,96 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
+)
+
+// AttestationPolicyService is a thin wrapper around the policy repo. The
+// verifier registry holds the concrete verification code; this service
+// just manages the per-tenant configuration those verifiers read.
+type AttestationPolicyService struct {
+	repo *postgres.AttestationPolicyRepository
+}
+
+// NewAttestationPolicyService creates a new service.
+func NewAttestationPolicyService(repo *postgres.AttestationPolicyRepository) *AttestationPolicyService {
+	return &AttestationPolicyService{repo: repo}
+}
+
+// UpsertAttestationPolicyRequest captures the payload accepted by the
+// admin API. Config is JSONB and its shape depends on ProofType.
+type UpsertAttestationPolicyRequest struct {
+	AccountID string
+	ProjectID string
+	ProofType domain.ProofType
+	Config    json.RawMessage
+	IsActive  *bool
+}
+
+// UpsertPolicy creates a policy if none exists for the (tenant, proof_type)
+// pair, or updates the existing one in place. The unique index
+// uq_attestation_policy_tenant_type guarantees a single row per key, so
+// this is the admin API's natural write shape.
+func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertAttestationPolicyRequest) (*domain.AttestationPolicy, error) {
+	if !req.ProofType.Valid() {
+		return nil, fmt.Errorf("invalid proof_type: %s", req.ProofType)
+	}
+	if len(req.Config) == 0 {
+		return nil, fmt.Errorf("config is required")
+	}
+
+	existing, err := s.repo.GetByTenantProofType(ctx, req.AccountID, req.ProjectID, req.ProofType)
+	switch err {
+	case nil:
+		existing.Config = req.Config
+		if req.IsActive != nil {
+			existing.IsActive = *req.IsActive
+		}
+		if err := s.repo.Update(ctx, existing); err != nil {
+			return nil, err
+		}
+		return existing, nil
+	case postgres.ErrAttestationPolicyNotFound:
+		active := true
+		if req.IsActive != nil {
+			active = *req.IsActive
+		}
+		p := &domain.AttestationPolicy{
+			ID:        uuid.New().String(),
+			AccountID: req.AccountID,
+			ProjectID: req.ProjectID,
+			ProofType: req.ProofType,
+			Config:    req.Config,
+			IsActive:  active,
+		}
+		if err := s.repo.Create(ctx, p); err != nil {
+			return nil, err
+		}
+		return p, nil
+	default:
+		return nil, err
+	}
+}
+
+// GetPolicy returns the policy for the given tenant + proof type, or
+// ErrAttestationPolicyNotFound if unset. Used by the verification path.
+func (s *AttestationPolicyService) GetPolicy(ctx context.Context, accountID, projectID string, pt domain.ProofType) (*domain.AttestationPolicy, error) {
+	return s.repo.GetByTenantProofType(ctx, accountID, projectID, pt)
+}
+
+// ListPolicies returns all policies for a tenant.
+func (s *AttestationPolicyService) ListPolicies(ctx context.Context, accountID, projectID string) ([]*domain.AttestationPolicy, error) {
+	return s.repo.List(ctx, accountID, projectID)
+}
+
+// DeletePolicy removes a policy by ID. Policies not belonging to the tenant
+// are silently no-op per the repo's idempotent delete semantics.
+func (s *AttestationPolicyService) DeletePolicy(ctx context.Context, id, accountID, projectID string) error {
+	return s.repo.Delete(ctx, id, accountID, projectID)
+}

--- a/internal/service/attestation_policy.go
+++ b/internal/service/attestation_policy.go
@@ -43,9 +43,11 @@ type UpsertAttestationPolicyRequest struct {
 }
 
 // UpsertPolicy creates a policy if none exists for the (tenant, proof_type)
-// pair, or updates the existing one in place. The unique index
-// uq_attestation_policy_tenant_type guarantees a single row per key, so
-// this is the admin API's natural write shape.
+// pair, or updates the existing one in place. Backed by a single atomic
+// INSERT ... ON CONFLICT statement so two concurrent admin PUTs for the
+// same key can't both see "not found" and race on the unique constraint —
+// an earlier read-then-write version did, producing a 500 under concurrent
+// writes.
 func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertAttestationPolicyRequest) (*domain.AttestationPolicy, error) {
 	if !req.ProofType.Valid() {
 		return nil, fmt.Errorf("%w: invalid proof_type %q", ErrInvalidAttestationPolicy, req.ProofType)
@@ -60,41 +62,25 @@ func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertA
 		return nil, fmt.Errorf("%w: %v", ErrInvalidAttestationPolicy, err)
 	}
 
-	// GetByTenantProofTypeAny ignores is_active so an upsert against a
-	// soft-disabled row updates it in place. GetByTenantProofType filters
-	// is_active and would drive this branch into an INSERT that violates
-	// the uq_attestation_policy_tenant_type unique constraint.
-	existing, err := s.repo.GetByTenantProofTypeAny(ctx, req.AccountID, req.ProjectID, req.ProofType)
-	switch {
-	case err == nil:
-		existing.Config = req.Config
-		if req.IsActive != nil {
-			existing.IsActive = *req.IsActive
-		}
-		if err := s.repo.Update(ctx, existing); err != nil {
-			return nil, err
-		}
-		return existing, nil
-	case errors.Is(err, postgres.ErrAttestationPolicyNotFound):
-		active := true
-		if req.IsActive != nil {
-			active = *req.IsActive
-		}
-		p := &domain.AttestationPolicy{
-			ID:        uuid.New().String(),
-			AccountID: req.AccountID,
-			ProjectID: req.ProjectID,
-			ProofType: req.ProofType,
-			Config:    req.Config,
-			IsActive:  active,
-		}
-		if err := s.repo.Create(ctx, p); err != nil {
-			return nil, err
-		}
-		return p, nil
-	default:
+	active := true
+	if req.IsActive != nil {
+		active = *req.IsActive
+	}
+	p := &domain.AttestationPolicy{
+		ID:        uuid.New().String(),
+		AccountID: req.AccountID,
+		ProjectID: req.ProjectID,
+		ProofType: req.ProofType,
+		Config:    req.Config,
+		IsActive:  active,
+	}
+	// Only overwrite is_active on conflict when the caller explicitly set
+	// it. Otherwise a PUT that lacks is_active would silently re-enable a
+	// previously disabled policy.
+	if err := s.repo.Upsert(ctx, p, req.IsActive != nil); err != nil {
 		return nil, err
 	}
+	return p, nil
 }
 
 // validatePolicyConfig checks the per-proof-type Config shape at write time.

--- a/internal/service/attestation_policy.go
+++ b/internal/service/attestation_policy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/attestation"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
@@ -24,13 +25,22 @@ var ErrInvalidAttestationPolicy = errors.New("invalid attestation policy")
 // AttestationPolicyService is a thin wrapper around the policy repo. The
 // verifier registry holds the concrete verification code; this service
 // just manages the per-tenant configuration those verifiers read.
+//
+// The registry reference is also used as a write-time gate: a policy can
+// only be created for a proof type that has a registered verifier in
+// this deployment. Without the gate, operators could pre-stage policy
+// rows that nothing reads, with misconfigurations only surfacing at
+// /verify time.
 type AttestationPolicyService struct {
-	repo *postgres.AttestationPolicyRepository
+	repo      *postgres.AttestationPolicyRepository
+	verifiers *attestation.Registry
 }
 
-// NewAttestationPolicyService creates a new service.
-func NewAttestationPolicyService(repo *postgres.AttestationPolicyRepository) *AttestationPolicyService {
-	return &AttestationPolicyService{repo: repo}
+// NewAttestationPolicyService creates a new service. The verifier
+// registry is required so UpsertPolicy can reject policies for proof
+// types that have no verifier wired.
+func NewAttestationPolicyService(repo *postgres.AttestationPolicyRepository, verifiers *attestation.Registry) *AttestationPolicyService {
+	return &AttestationPolicyService{repo: repo, verifiers: verifiers}
 }
 
 // UpsertAttestationPolicyRequest captures the payload accepted by the
@@ -52,6 +62,14 @@ type UpsertAttestationPolicyRequest struct {
 func (s *AttestationPolicyService) UpsertPolicy(ctx context.Context, req UpsertAttestationPolicyRequest) (*domain.AttestationPolicy, error) {
 	if !req.ProofType.Valid() {
 		return nil, fmt.Errorf("%w: invalid proof_type %q", ErrInvalidAttestationPolicy, req.ProofType)
+	}
+	// Reject policies for proof types that have no registered verifier in
+	// this deployment. Without this gate the row would persist and only
+	// surface its uselessness at /verify time. Dev deployments that need
+	// to exercise image_hash or tpm flows must enable
+	// attestation.allow_unsafe_dev_stub to register the dev stub.
+	if _, err := s.verifiers.Get(req.ProofType); err != nil {
+		return nil, fmt.Errorf("%w: no verifier registered for proof_type %q", ErrInvalidAttestationPolicy, req.ProofType)
 	}
 	if len(req.Config) == 0 {
 		return nil, fmt.Errorf("%w: config is required", ErrInvalidAttestationPolicy)
@@ -117,9 +135,11 @@ func validatePolicyConfig(pt domain.ProofType, cfg json.RawMessage) error {
 			}
 		}
 	case domain.ProofTypeImageHash, domain.ProofTypeTPM:
-		// No typed config yet — verifiers for these proof types haven't
-		// shipped. Accept the raw blob so operators can pre-configure
-		// policy rows before the verifier lands.
+		// No typed config schema yet — the only registered verifier for
+		// these proof types is the dev stub (gated by allow_unsafe_dev_stub
+		// in UpsertPolicy above), and the stub doesn't inspect config.
+		// When real verifiers ship, replace this branch with their typed
+		// validation.
 	default:
 		return fmt.Errorf("unsupported proof_type: %s", pt)
 	}

--- a/internal/store/postgres/attestation_policy.go
+++ b/internal/store/postgres/attestation_policy.go
@@ -76,6 +76,27 @@ func (r *AttestationPolicyRepository) GetByTenantProofType(ctx context.Context, 
 	return p, nil
 }
 
+// GetByTenantProofTypeAny returns the policy for the tenant + proof type
+// regardless of is_active. Used by the upsert path so a soft-disabled policy
+// can be re-enabled without violating the unique (account_id, project_id,
+// proof_type) constraint (GetByTenantProofType would miss the row and the
+// follow-up INSERT would fail).
+func (r *AttestationPolicyRepository) GetByTenantProofTypeAny(ctx context.Context, accountID, projectID string, pt domain.ProofType) (*domain.AttestationPolicy, error) {
+	p := &domain.AttestationPolicy{}
+	err := r.db.NewSelect().Model(p).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("proof_type = ?", string(pt)).
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrAttestationPolicyNotFound
+		}
+		return nil, fmt.Errorf("failed to get attestation policy: %w", err)
+	}
+	return p, nil
+}
+
 // List returns all policies for a tenant.
 func (r *AttestationPolicyRepository) List(ctx context.Context, accountID, projectID string) ([]*domain.AttestationPolicy, error) {
 	var policies []*domain.AttestationPolicy

--- a/internal/store/postgres/attestation_policy.go
+++ b/internal/store/postgres/attestation_policy.go
@@ -1,0 +1,122 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/uptrace/bun"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// AttestationPolicyRepository handles CRUD for per-tenant attestation
+// verification policies. The lookup path (GetByTenantProofType) is the
+// hot one — called on every /attestation/verify — and is the one guarded
+// by the uq_attestation_policy_tenant_type unique index.
+type AttestationPolicyRepository struct {
+	db *bun.DB
+}
+
+// NewAttestationPolicyRepository creates a new AttestationPolicyRepository.
+func NewAttestationPolicyRepository(db *bun.DB) *AttestationPolicyRepository {
+	return &AttestationPolicyRepository{db: db}
+}
+
+// ErrAttestationPolicyNotFound is returned by GetByTenantProofType when no
+// active policy row exists for the tenant + proof type. Callers at the
+// verification hot path use this to fail closed.
+var ErrAttestationPolicyNotFound = errors.New("attestation policy not found")
+
+// Create inserts a new policy row.
+func (r *AttestationPolicyRepository) Create(ctx context.Context, p *domain.AttestationPolicy) error {
+	_, err := r.db.NewInsert().Model(p).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create attestation policy: %w", err)
+	}
+	return nil
+}
+
+// GetByID retrieves a policy by ID, scoped to tenant.
+func (r *AttestationPolicyRepository) GetByID(ctx context.Context, id, accountID, projectID string) (*domain.AttestationPolicy, error) {
+	p := &domain.AttestationPolicy{}
+	err := r.db.NewSelect().Model(p).
+		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrAttestationPolicyNotFound
+		}
+		return nil, fmt.Errorf("failed to get attestation policy: %w", err)
+	}
+	return p, nil
+}
+
+// GetByTenantProofType fetches the active policy for the tenant + proof
+// type. This is the verification hot path; absence is a normal condition
+// (fail-closed semantics) so we return ErrAttestationPolicyNotFound rather
+// than an opaque wrapped error.
+func (r *AttestationPolicyRepository) GetByTenantProofType(ctx context.Context, accountID, projectID string, pt domain.ProofType) (*domain.AttestationPolicy, error) {
+	p := &domain.AttestationPolicy{}
+	err := r.db.NewSelect().Model(p).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("proof_type = ?", string(pt)).
+		Where("is_active = TRUE").
+		Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrAttestationPolicyNotFound
+		}
+		return nil, fmt.Errorf("failed to get attestation policy: %w", err)
+	}
+	return p, nil
+}
+
+// List returns all policies for a tenant.
+func (r *AttestationPolicyRepository) List(ctx context.Context, accountID, projectID string) ([]*domain.AttestationPolicy, error) {
+	var policies []*domain.AttestationPolicy
+	err := r.db.NewSelect().Model(&policies).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		OrderExpr("created_at DESC").
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list attestation policies: %w", err)
+	}
+	return policies, nil
+}
+
+// Update overwrites an existing policy's mutable fields (config, is_active).
+func (r *AttestationPolicyRepository) Update(ctx context.Context, p *domain.AttestationPolicy) error {
+	_, err := r.db.NewUpdate().Model(p).
+		Set("config = ?", p.Config).
+		Set("is_active = ?", p.IsActive).
+		Set("updated_at = NOW()").
+		Where("id = ?", p.ID).
+		Where("account_id = ?", p.AccountID).
+		Where("project_id = ?", p.ProjectID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to update attestation policy: %w", err)
+	}
+	return nil
+}
+
+// Delete removes a policy by ID, scoped to tenant. Returns nil even if no
+// rows matched (idempotent delete semantics — callers that need strict
+// existence checking should GetByID first).
+func (r *AttestationPolicyRepository) Delete(ctx context.Context, id, accountID, projectID string) error {
+	_, err := r.db.NewDelete().Model((*domain.AttestationPolicy)(nil)).
+		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to delete attestation policy: %w", err)
+	}
+	return nil
+}

--- a/internal/store/postgres/attestation_policy.go
+++ b/internal/store/postgres/attestation_policy.go
@@ -76,25 +76,32 @@ func (r *AttestationPolicyRepository) GetByTenantProofType(ctx context.Context, 
 	return p, nil
 }
 
-// GetByTenantProofTypeAny returns the policy for the tenant + proof type
-// regardless of is_active. Used by the upsert path so a soft-disabled policy
-// can be re-enabled without violating the unique (account_id, project_id,
-// proof_type) constraint (GetByTenantProofType would miss the row and the
-// follow-up INSERT would fail).
-func (r *AttestationPolicyRepository) GetByTenantProofTypeAny(ctx context.Context, accountID, projectID string, pt domain.ProofType) (*domain.AttestationPolicy, error) {
-	p := &domain.AttestationPolicy{}
-	err := r.db.NewSelect().Model(p).
-		Where("account_id = ?", accountID).
-		Where("project_id = ?", projectID).
-		Where("proof_type = ?", string(pt)).
-		Scan(ctx)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrAttestationPolicyNotFound
-		}
-		return nil, fmt.Errorf("failed to get attestation policy: %w", err)
+// Upsert inserts a new policy row or updates the existing row for the
+// tenant + proof_type in a single atomic statement. Two concurrent admin
+// requests for the same key race only on the DB's row-lock — neither 500s
+// with a unique-constraint violation, which the prior read-then-write
+// pattern could hit. Last-writer-wins semantics on the config column.
+//
+// When updateIsActive is true, EXCLUDED.is_active overwrites the stored
+// value; when false (caller didn't specify), the existing is_active is
+// preserved so a PUT-without-is_active cannot silently re-enable a
+// previously disabled policy.
+//
+// Bun's INSERT ... RETURNING populates p back with the row's authoritative
+// state (on conflict, the existing row's id and created_at are kept; only
+// the SET columns change).
+func (r *AttestationPolicyRepository) Upsert(ctx context.Context, p *domain.AttestationPolicy, updateIsActive bool) error {
+	q := r.db.NewInsert().Model(p).
+		On("CONFLICT (account_id, project_id, proof_type) DO UPDATE").
+		Set("config = EXCLUDED.config").
+		Set("updated_at = NOW()")
+	if updateIsActive {
+		q = q.Set("is_active = EXCLUDED.is_active")
 	}
-	return p, nil
+	if _, err := q.Returning("*").Exec(ctx); err != nil {
+		return fmt.Errorf("failed to upsert attestation policy: %w", err)
+	}
+	return nil
 }
 
 // List returns all policies for a tenant.

--- a/internal/store/postgres/attestation_policy.go
+++ b/internal/store/postgres/attestation_policy.go
@@ -29,32 +29,6 @@ func NewAttestationPolicyRepository(db *bun.DB) *AttestationPolicyRepository {
 // verification hot path use this to fail closed.
 var ErrAttestationPolicyNotFound = errors.New("attestation policy not found")
 
-// Create inserts a new policy row.
-func (r *AttestationPolicyRepository) Create(ctx context.Context, p *domain.AttestationPolicy) error {
-	_, err := r.db.NewInsert().Model(p).Exec(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create attestation policy: %w", err)
-	}
-	return nil
-}
-
-// GetByID retrieves a policy by ID, scoped to tenant.
-func (r *AttestationPolicyRepository) GetByID(ctx context.Context, id, accountID, projectID string) (*domain.AttestationPolicy, error) {
-	p := &domain.AttestationPolicy{}
-	err := r.db.NewSelect().Model(p).
-		Where("id = ?", id).
-		Where("account_id = ?", accountID).
-		Where("project_id = ?", projectID).
-		Scan(ctx)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrAttestationPolicyNotFound
-		}
-		return nil, fmt.Errorf("failed to get attestation policy: %w", err)
-	}
-	return p, nil
-}
-
 // GetByTenantProofType fetches the active policy for the tenant + proof
 // type. This is the verification hot path; absence is a normal condition
 // (fail-closed semantics) so we return ErrAttestationPolicyNotFound rather
@@ -118,25 +92,8 @@ func (r *AttestationPolicyRepository) List(ctx context.Context, accountID, proje
 	return policies, nil
 }
 
-// Update overwrites an existing policy's mutable fields (config, is_active).
-func (r *AttestationPolicyRepository) Update(ctx context.Context, p *domain.AttestationPolicy) error {
-	_, err := r.db.NewUpdate().Model(p).
-		Set("config = ?", p.Config).
-		Set("is_active = ?", p.IsActive).
-		Set("updated_at = NOW()").
-		Where("id = ?", p.ID).
-		Where("account_id = ?", p.AccountID).
-		Where("project_id = ?", p.ProjectID).
-		Exec(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to update attestation policy: %w", err)
-	}
-	return nil
-}
-
 // Delete removes a policy by ID, scoped to tenant. Returns nil even if no
-// rows matched (idempotent delete semantics — callers that need strict
-// existence checking should GetByID first).
+// rows matched (idempotent delete semantics).
 func (r *AttestationPolicyRepository) Delete(ctx context.Context, id, accountID, projectID string) error {
 	_, err := r.db.NewDelete().Model((*domain.AttestationPolicy)(nil)).
 		Where("id = ?", id).

--- a/migrations/010_attestation_policies.down.sql
+++ b/migrations/010_attestation_policies.down.sql
@@ -1,0 +1,3 @@
+-- 010_attestation_policies.down.sql
+DROP INDEX IF EXISTS idx_attestation_policies_lookup;
+DROP TABLE IF EXISTS attestation_policies;

--- a/migrations/010_attestation_policies.up.sql
+++ b/migrations/010_attestation_policies.up.sql
@@ -1,0 +1,31 @@
+-- 010_attestation_policies.up.sql
+-- Per-tenant attestation trust configuration.
+--
+-- Each row declares "for this tenant + this proof type, here are the trusted
+-- issuers / allowed hashes / accepted roots". The authoritative check runs
+-- in internal/attestation: no row → verifier for that proof type is
+-- unconfigured → all verification attempts fail closed.
+--
+-- The config column is JSONB because each proof type has a different shape
+-- (see domain.OIDCPolicyConfig, etc.). Storing inline avoids a table per
+-- verifier and lets new verifiers land without schema changes.
+
+CREATE TABLE IF NOT EXISTS attestation_policies (
+    id         UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id VARCHAR(255) NOT NULL,
+    project_id VARCHAR(255) NOT NULL,
+    proof_type VARCHAR(50)  NOT NULL,
+    config     JSONB        NOT NULL,
+    is_active  BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    -- A tenant has at most one policy per proof type. Updating an existing
+    -- issuer allowlist is an UPDATE, not a new row — keeps lookups O(1).
+    CONSTRAINT uq_attestation_policy_tenant_type
+        UNIQUE (account_id, project_id, proof_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_attestation_policies_lookup
+    ON attestation_policies (account_id, project_id, proof_type)
+    WHERE is_active = TRUE;

--- a/server.go
+++ b/server.go
@@ -149,9 +149,11 @@ func NewServer(cfg Config) (*Server, error) {
 	authCodeRepo := postgres.NewAuthCodeRepository(db)
 
 	// Build the attestation verifier registry. Real verifiers are wired
-	// first (OIDC today; image_hash and TPM to follow). The dev stub only
-	// fills in for proof types without a real verifier, and only when the
-	// unsafe flag is set — so production deployments fail closed by default.
+	// first (OIDC today). The dev stub — only registered when the unsafe
+	// flag is set — covers image_hash and TPM because those verifiers have
+	// not landed yet, so without the stub any submission with those proof
+	// types would fail closed. Production deployments leave the flag off
+	// and those proof types stay unimplemented (as intended).
 	attestationVerifiers := attestation.NewRegistry()
 	attestationVerifiers.Register(attestation.NewOIDCVerifier(nil))
 	if cfg.Attestation.AllowUnsafeDevStub {
@@ -165,6 +167,9 @@ func NewServer(cfg Config) (*Server, error) {
 			}
 		}
 	}
+	log.Info().
+		Interface("proof_types", attestationVerifiers.ProofTypes()).
+		Msg("Attestation verifiers registered")
 
 	// Initialize services.
 	// credentialPolicySvc must be created before identitySvc because every

--- a/server.go
+++ b/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/uptrace/bun/driver/pgdriver"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/attestation"
 	"github.com/highflame-ai/zeroid/internal/database"
 	"github.com/highflame-ai/zeroid/internal/handler"
 	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
@@ -138,6 +139,7 @@ func NewServer(cfg Config) (*Server, error) {
 	identityRepo := postgres.NewIdentityRepository(db)
 	credentialRepo := postgres.NewCredentialRepository(db)
 	attestationRepo := postgres.NewAttestationRepository(db)
+	attestationPolicyRepo := postgres.NewAttestationPolicyRepository(db)
 	signalRepo := postgres.NewSignalRepository(db)
 	proofRepo := postgres.NewProofRepository(db)
 	oauthClientRepo := postgres.NewOAuthClientRepository(db)
@@ -145,6 +147,24 @@ func NewServer(cfg Config) (*Server, error) {
 	apiKeyRepo := postgres.NewAPIKeyRepository(db)
 	refreshTokenRepo := postgres.NewRefreshTokenRepository(db)
 	authCodeRepo := postgres.NewAuthCodeRepository(db)
+
+	// Build the attestation verifier registry. Real verifiers are wired
+	// first (OIDC today; image_hash and TPM to follow). The dev stub only
+	// fills in for proof types without a real verifier, and only when the
+	// unsafe flag is set — so production deployments fail closed by default.
+	attestationVerifiers := attestation.NewRegistry()
+	attestationVerifiers.Register(attestation.NewOIDCVerifier(nil))
+	if cfg.Attestation.AllowUnsafeDevStub {
+		log.Warn().Msg("ATTESTATION: AllowUnsafeDevStub is enabled — any submitted proof will verify. DO NOT enable in production.")
+		for _, pt := range []domain.ProofType{
+			domain.ProofTypeImageHash,
+			domain.ProofTypeTPM,
+		} {
+			if _, err := attestationVerifiers.Get(pt); err != nil {
+				attestationVerifiers.Register(attestation.NewDevStubVerifier(pt))
+			}
+		}
+	}
 
 	// Initialize services.
 	// credentialPolicySvc must be created before identitySvc because every
@@ -154,7 +174,8 @@ func NewServer(cfg Config) (*Server, error) {
 	credentialPolicySvc := service.NewCredentialPolicyService(credentialPolicyRepo)
 	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, cfg.WIMSEDomain)
 	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL)
-	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc)
+	attestationPolicySvc := service.NewAttestationPolicyService(attestationPolicyRepo)
+	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc)
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)
 	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo)
@@ -175,7 +196,7 @@ func NewServer(cfg Config) (*Server, error) {
 	// Create shared API handler.
 	apiHandler := handler.NewAPI(
 		identitySvc, credentialSvc, credentialPolicySvc,
-		attestationSvc, proofSvc, oauthSvc, oauthClientSvc,
+		attestationSvc, attestationPolicySvc, proofSvc, oauthSvc, oauthClientSvc,
 		signalSvc, apiKeySvc, agentSvc, jwksSvc, db,
 		cfg.Token.Issuer, cfg.Token.BaseURL,
 	)

--- a/server.go
+++ b/server.go
@@ -183,7 +183,7 @@ func NewServer(cfg Config) (*Server, error) {
 	signalSvc := service.NewSignalService(signalRepo, credentialRepo, identityRepo)
 	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, apiKeyRepo, credentialSvc, signalSvc, cfg.WIMSEDomain)
 	attestationPolicySvc := attestation.NewPolicyService(attestationPolicyRepo, attestationVerifiers)
-	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc)
+	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc, cfg.Attestation.AllowUnsafeDevStub)
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)
 	refreshTokenSvc := service.NewRefreshTokenService(refreshTokenRepo, db)
@@ -467,6 +467,16 @@ func (s *Server) Use(middleware func(http.Handler) http.Handler) {
 	s.globalMWState.mu.Lock()
 	defer s.globalMWState.mu.Unlock()
 	s.globalMWState.fn = middleware
+}
+
+// SetAttestationPermissive flips the missing-policy bypass on the attestation
+// verify path at runtime. The initial value is taken from
+// cfg.Attestation.AllowUnsafeDevStub at NewServer time; this setter is the
+// escape hatch for integration tests that need to exercise both modes against
+// the same server instance. Production deployments should set the flag via
+// configuration and never call this.
+func (s *Server) SetAttestationPermissive(enabled bool) {
+	s.attestationSvc.SetPermissive(enabled)
 }
 
 // SetTrustedServiceValidator sets the validator used during external principal

--- a/server.go
+++ b/server.go
@@ -153,23 +153,16 @@ func NewServer(cfg Config) (*Server, error) {
 	auditRepo := postgres.NewAuditLogRepository(db)
 
 	// Build the attestation verifier registry. Real verifiers are wired
-	// first (OIDC today). The dev stub — only registered when the unsafe
-	// flag is set — covers image_hash and TPM because those verifiers have
-	// not landed yet, so without the stub any submission with those proof
-	// types would fail closed. Production deployments leave the flag off
-	// and those proof types stay unimplemented (as intended).
+	// first (OIDC today). Dev stubs cover image_hash and TPM only — those
+	// proof types have no real verifier yet, so the stub is the only way
+	// to exercise demo flows that submit them. Production deployments
+	// leave AllowUnsafeDevStub off and those proof types stay unimplemented.
 	attestationVerifiers := attestation.NewRegistry()
 	attestationVerifiers.Register(attestation.NewOIDCVerifier(nil))
 	if cfg.Attestation.AllowUnsafeDevStub {
 		log.Warn().Msg("ATTESTATION: AllowUnsafeDevStub is enabled — any submitted proof will verify. DO NOT enable in production.")
-		for _, pt := range []domain.ProofType{
-			domain.ProofTypeImageHash,
-			domain.ProofTypeTPM,
-		} {
-			if _, err := attestationVerifiers.Get(pt); err != nil {
-				attestationVerifiers.Register(attestation.NewDevStubVerifier(pt))
-			}
-		}
+		attestationVerifiers.Register(attestation.NewDevStubVerifier(domain.ProofTypeImageHash))
+		attestationVerifiers.Register(attestation.NewDevStubVerifier(domain.ProofTypeTPM))
 	}
 	log.Info().
 		Interface("proof_types", attestationVerifiers.ProofTypes()).
@@ -189,7 +182,7 @@ func NewServer(cfg Config) (*Server, error) {
 	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL)
 	signalSvc := service.NewSignalService(signalRepo, credentialRepo, identityRepo)
 	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, apiKeyRepo, credentialSvc, signalSvc, cfg.WIMSEDomain)
-	attestationPolicySvc := service.NewAttestationPolicyService(attestationPolicyRepo)
+	attestationPolicySvc := service.NewAttestationPolicyService(attestationPolicyRepo, attestationVerifiers)
 	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc)
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)

--- a/server.go
+++ b/server.go
@@ -182,7 +182,7 @@ func NewServer(cfg Config) (*Server, error) {
 	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL)
 	signalSvc := service.NewSignalService(signalRepo, credentialRepo, identityRepo)
 	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, apiKeyRepo, credentialSvc, signalSvc, cfg.WIMSEDomain)
-	attestationPolicySvc := service.NewAttestationPolicyService(attestationPolicyRepo, attestationVerifiers)
+	attestationPolicySvc := attestation.NewPolicyService(attestationPolicyRepo, attestationVerifiers)
 	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc)
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -366,6 +366,41 @@ func TestAttestationPolicyUpsertReactivatesDisabled(t *testing.T) {
 		"upserting an inactive policy must reactivate it, not 500 on unique constraint")
 }
 
+// TestAttestationPolicyUpsertIsConcurrencySafe fires N simultaneous PUTs
+// for the same (tenant, proof_type) and asserts every one returns 200.
+// Under the prior read-then-write implementation two concurrent upserts
+// could both see "not found", both try to INSERT, and the loser would
+// 500 with a unique-constraint violation. The atomic INSERT ... ON
+// CONFLICT path eliminates that race.
+func TestAttestationPolicyUpsertIsConcurrencySafe(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
+	// Use a tenant that no other test touches so the race is clean.
+	tenant := tenantHeaders("acct-upsert-race-"+uid(""), "proj-upsert-race-"+uid(""))
+
+	const parallelism = 8
+	results := make(chan int, parallelism)
+	body := map[string]any{
+		"proof_type": "oidc_token",
+		"config": map[string]any{
+			"issuers": []map[string]any{{"url": iss.URL}},
+		},
+	}
+	for i := 0; i < parallelism; i++ {
+		go func() {
+			resp := doRequest(t, http.MethodPut, adminPath("/attestation-policies"), body, tenant)
+			_ = resp.Body.Close()
+			results <- resp.StatusCode
+		}()
+	}
+	for i := 0; i < parallelism; i++ {
+		status := <-results
+		assert.Equal(t, http.StatusOK, status,
+			"every concurrent upsert must succeed; atomic INSERT ... ON CONFLICT has no race window")
+	}
+}
+
 // TestAttestationPolicyRejectsNonHTTPSIssuer exercises the write-time config
 // validator: an http://... issuer URL should be rejected before it's stored,
 // because OIDC discovery over plaintext lets a network attacker swap JWKS.

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -417,6 +417,54 @@ func TestAttestationPolicyRejectsNonHTTPSIssuer(t *testing.T) {
 	assertErrorBodyContains(t, resp, "https")
 }
 
+// TestAttestationOIDCDiscoveryBodyCap guards the 1 MiB body limit on
+// OIDC discovery doc fetches: a malicious or compromised issuer that serves
+// an arbitrarily large discovery response must not be able to exhaust
+// ZeroID's memory during decode. The test stands up a discovery endpoint
+// that streams padding beyond the cap, configures it as a trusted issuer,
+// and asserts the verify call fails without crashing.
+func TestAttestationOIDCDiscoveryBodyCap(t *testing.T) {
+	mux := http.NewServeMux()
+	var issuerURL string
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Preamble starts a valid JSON object; padding then pushes the
+		// response well past the 1 MiB cap. The decoder must fail before
+		// finishing the object.
+		_, _ = w.Write([]byte(`{"issuer":"` + issuerURL + `","jwks_uri":"` + issuerURL + `/jwks","padding":"`))
+		padding := make([]byte, 2*1024*1024) // 2 MiB
+		for i := range padding {
+			padding[i] = 'A'
+		}
+		_, _ = w.Write(padding)
+		_, _ = w.Write([]byte(`"}`))
+	})
+	// A trivial jwks handler — we shouldn't reach it because discovery
+	// fails, but Huma's Go client still completes the request cleanly.
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	issuerURL = srv.URL
+
+	reg := registerAgent(t, uid("attest-oidc-oom"))
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{"url": issuerURL}},
+	})
+
+	// Any signed token will do — we never get past discovery.
+	bogusToken := "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3dyb25nIn0.signature"
+	id := submitAttestation(t, reg.AgentID, "oidc_token", bogusToken)
+
+	resp := verifyAttestation(t, id)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"oversized discovery response must be rejected, not OOM the server")
+}
+
 // flipLastByte returns the last byte of s with a single bit flipped, so
 // good[:len(good)-1] + flipLastByte(good) produces a JWT with a corrupted
 // signature byte.

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -1,0 +1,285 @@
+package integration_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// oidcIssuer stands up a minimal OIDC discovery + JWKS server for tests so
+// the attestation OIDC verifier has a real issuer to talk to. It returns
+// the issuer URL and a function that mints signed JWTs with caller-supplied
+// claims.
+type oidcIssuer struct {
+	URL     string
+	signKey jwk.Key
+	sign    func(claims map[string]any) string
+	close   func()
+}
+
+func newOIDCIssuer(t *testing.T) *oidcIssuer {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signKey, err := jwk.FromRaw(priv)
+	require.NoError(t, err)
+	require.NoError(t, signKey.Set(jwk.KeyIDKey, "test-issuer-key-1"))
+	require.NoError(t, signKey.Set(jwk.AlgorithmKey, jwa.RS256))
+
+	pubKey, err := signKey.PublicKey()
+	require.NoError(t, err)
+	require.NoError(t, pubKey.Set(jwk.KeyIDKey, "test-issuer-key-1"))
+	require.NoError(t, pubKey.Set(jwk.AlgorithmKey, jwa.RS256))
+	require.NoError(t, pubKey.Set(jwk.KeyUsageKey, "sig"))
+
+	jwks := jwk.NewSet()
+	require.NoError(t, jwks.AddKey(pubKey))
+
+	mux := http.NewServeMux()
+	var issuerURL string
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   issuerURL,
+			"jwks_uri": issuerURL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	})
+
+	srv := httptest.NewServer(mux)
+	issuerURL = srv.URL
+
+	sign := func(claims map[string]any) string {
+		t.Helper()
+		tok := jwt.New()
+		require.NoError(t, tok.Set(jwt.IssuerKey, issuerURL))
+		require.NoError(t, tok.Set(jwt.IssuedAtKey, time.Now().Unix()))
+		require.NoError(t, tok.Set(jwt.ExpirationKey, time.Now().Add(5*time.Minute).Unix()))
+		for k, v := range claims {
+			require.NoError(t, tok.Set(k, v))
+		}
+		signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, signKey))
+		require.NoError(t, err)
+		return string(signed)
+	}
+
+	return &oidcIssuer{URL: issuerURL, signKey: signKey, sign: sign, close: srv.Close}
+}
+
+// submitAttestation wraps the submit endpoint so each test can post a proof
+// in one line. Returns the created record's UUID.
+func submitAttestation(t *testing.T, identityID, proofType, proofValue string) string {
+	t.Helper()
+	resp := post(t, adminPath("/attestation/submit"), map[string]any{
+		"identity_id": identityID,
+		"level":       "software",
+		"proof_type":  proofType,
+		"proof_value": proofValue,
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode,
+		"attestation submit expected 201")
+	return decode(t, resp)["id"].(string)
+}
+
+func verifyAttestation(t *testing.T, attestationID string) *http.Response {
+	t.Helper()
+	return post(t, adminPath("/attestation/verify"), map[string]any{
+		"attestation_id": attestationID,
+	}, adminHeaders())
+}
+
+func upsertOIDCPolicy(t *testing.T, cfg map[string]any) {
+	t.Helper()
+	body := map[string]any{
+		"proof_type": "oidc_token",
+		"config":     cfg,
+	}
+	resp := doRequest(t, http.MethodPut, adminPath("/attestation-policies"), body, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "upsert policy expected 200")
+	_ = resp.Body.Close()
+}
+
+// TestAttestationFailsClosedWithNoPolicy verifies the top-level contract:
+// a submitted oidc_token attestation must not be marked verified when no
+// AttestationPolicy exists for the tenant + proof type. This is the fix
+// for the "any submitted attestation becomes verified trust" bug.
+func TestAttestationFailsClosedWithNoPolicy(t *testing.T) {
+	reg := registerAgent(t, uid("attest-no-policy"))
+	token := newOIDCIssuer(t).sign(map[string]any{"sub": "ci-job-1"})
+	id := submitAttestation(t, reg.AgentID, "oidc_token", token)
+
+	resp := verifyAttestation(t, id)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"verify must fail closed when the tenant has no attestation policy")
+}
+
+// TestAttestationOIDCVerifierHappyPath covers the full working flow:
+// trusted issuer + signed JWT + matching audience/claims → verified,
+// identity trust promoted, credential issued.
+func TestAttestationOIDCVerifierHappyPath(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
+	reg := registerAgent(t, uid("attest-oidc-ok"))
+
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{
+			"url":       iss.URL,
+			"audiences": []string{"zeroid://test"},
+			"required_claims": map[string]string{
+				"repository": "myorg/myrepo",
+			},
+		}},
+	})
+
+	token := iss.sign(map[string]any{
+		"sub":        "ci-job-42",
+		"aud":        "zeroid://test",
+		"repository": "myorg/myrepo",
+	})
+	id := submitAttestation(t, reg.AgentID, "oidc_token", token)
+
+	resp := verifyAttestation(t, id)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "happy-path verify expected 200")
+
+	body := decode(t, resp)
+	record := body["record"].(map[string]any)
+	assert.Equal(t, true, record["is_verified"], "record must be marked verified")
+	assert.NotEmpty(t, record["verified_at"])
+	assert.NotEmpty(t, body["token"], "verified attestation must auto-issue a credential")
+}
+
+// TestAttestationOIDCVerifierRejectsUntrustedIssuer enforces the issuer
+// allowlist: a perfectly-signed JWT from an issuer that is NOT in the
+// tenant's policy must be rejected without ever fetching that issuer's JWKS.
+func TestAttestationOIDCVerifierRejectsUntrustedIssuer(t *testing.T) {
+	trusted := newOIDCIssuer(t)
+	untrusted := newOIDCIssuer(t)
+	defer trusted.close()
+	defer untrusted.close()
+
+	reg := registerAgent(t, uid("attest-oidc-untrusted"))
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{"url": trusted.URL}},
+	})
+
+	token := untrusted.sign(map[string]any{"sub": "attacker"})
+	id := submitAttestation(t, reg.AgentID, "oidc_token", token)
+
+	resp := verifyAttestation(t, id)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"JWT from an untrusted issuer must be rejected")
+}
+
+// TestAttestationOIDCVerifierRejectsTamperedSignature ensures the JWT
+// signature is actually checked: flipping a byte in the signature segment
+// must cause verification to fail even when the issuer is trusted.
+func TestAttestationOIDCVerifierRejectsTamperedSignature(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
+	reg := registerAgent(t, uid("attest-oidc-tampered"))
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{"url": iss.URL}},
+	})
+
+	good := iss.sign(map[string]any{"sub": "ci-job-1"})
+	// Flip the last signature byte — the token string format is
+	// header.payload.signature.
+	tampered := good[:len(good)-1] + flipLastByte(good)
+	id := submitAttestation(t, reg.AgentID, "oidc_token", tampered)
+
+	resp := verifyAttestation(t, id)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"tampered JWT must fail signature verification")
+}
+
+// TestAttestationOIDCVerifierRejectsExpired ensures the verifier enforces
+// the JWT exp claim (exp in the past should reject).
+func TestAttestationOIDCVerifierRejectsExpired(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
+	reg := registerAgent(t, uid("attest-oidc-expired"))
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{"url": iss.URL}},
+	})
+
+	// Mint a JWT that expired an hour ago by building it manually — we can't
+	// easily override exp through the iss.sign helper, so do it inline.
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.IssuerKey, iss.URL))
+	require.NoError(t, tok.Set(jwt.IssuedAtKey, time.Now().Add(-2*time.Hour).Unix()))
+	require.NoError(t, tok.Set(jwt.ExpirationKey, time.Now().Add(-1*time.Hour).Unix()))
+	require.NoError(t, tok.Set(jwt.SubjectKey, "ci-job-1"))
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.RS256, iss.signKey))
+	require.NoError(t, err)
+
+	id := submitAttestation(t, reg.AgentID, "oidc_token", string(signed))
+	resp := verifyAttestation(t, id)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"expired JWT must be rejected")
+}
+
+// TestAttestationOIDCVerifierRejectsRequiredClaimMismatch verifies that the
+// RequiredClaims binder actually runs — a token missing/mismatching a
+// configured claim must fail even if signature + issuer + aud all pass.
+func TestAttestationOIDCVerifierRejectsRequiredClaimMismatch(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
+	reg := registerAgent(t, uid("attest-oidc-claim"))
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{
+			"url":             iss.URL,
+			"required_claims": map[string]string{"repository": "myorg/myrepo"},
+		}},
+	})
+
+	// Claim value is wrong (different repo).
+	token := iss.sign(map[string]any{
+		"sub":        "ci-job-1",
+		"repository": "rogueorg/rogue",
+	})
+	id := submitAttestation(t, reg.AgentID, "oidc_token", token)
+
+	resp := verifyAttestation(t, id)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"required_claims mismatch must reject the attestation")
+}
+
+// flipLastByte returns the last byte of s with a single bit flipped, so
+// good[:len(good)-1] + flipLastByte(good) produces a JWT with a corrupted
+// signature byte.
+func flipLastByte(s string) string {
+	b := []byte{s[len(s)-1]}
+	b[0] ^= 0x01
+	// base64url alphabet: keep it valid-looking so parsing gets past the
+	// format check and hits actual signature verification.
+	if b[0] == '.' || b[0] == '=' {
+		b[0] = 'A'
+	}
+	return string(b)
+}

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -1,9 +1,11 @@
 package integration_test
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +17,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// assertErrorBodyContains reads the response body (non-destructively — the
+// body is restored after inspection so tests can still decode it) and
+// asserts that the error message inside includes substr. Covers the case
+// where a test passed with the right status but the WRONG reason (e.g.
+// DB blip 500 → 400 after wrapping); without a body check, those slip
+// through.
+func assertErrorBodyContains(t *testing.T, resp *http.Response, substr string) {
+	t.Helper()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	// Put the bytes back so defer Close and any further decode still work.
+	resp.Body = io.NopCloser(bytes.NewReader(raw))
+	assert.Containsf(t, string(raw), substr,
+		"error response body must mention %q (got: %s)", substr, string(raw))
+}
 
 // oidcIssuer stands up a minimal OIDC discovery + JWKS server for tests so
 // the attestation OIDC verifier has a real issuer to talk to. It returns
@@ -120,14 +138,18 @@ func upsertOIDCPolicy(t *testing.T, cfg map[string]any) {
 // AttestationPolicy exists for the tenant + proof type. This is the fix
 // for the "any submitted attestation becomes verified trust" bug.
 func TestAttestationFailsClosedWithNoPolicy(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
 	reg := registerAgent(t, uid("attest-no-policy"))
-	token := newOIDCIssuer(t).sign(map[string]any{"sub": "ci-job-1"})
+	token := iss.sign(map[string]any{"sub": "ci-job-1"})
 	id := submitAttestation(t, reg.AgentID, "oidc_token", token)
 
 	resp := verifyAttestation(t, id)
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"verify must fail closed when the tenant has no attestation policy")
+	assertErrorBodyContains(t, resp, "no attestation policy configured")
 }
 
 // TestAttestationOIDCVerifierHappyPath covers the full working flow:
@@ -188,6 +210,7 @@ func TestAttestationOIDCVerifierRejectsUntrustedIssuer(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"JWT from an untrusted issuer must be rejected")
+	assertErrorBodyContains(t, resp, "issuer not in allowlist")
 }
 
 // TestAttestationOIDCVerifierRejectsTamperedSignature ensures the JWT
@@ -212,6 +235,10 @@ func TestAttestationOIDCVerifierRejectsTamperedSignature(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"tampered JWT must fail signature verification")
+	// Either "malformed JWT" (base64 decode flagged the corruption) or
+	// "token validation failed" (signature check flagged it) is an
+	// acceptable rejection reason — both come from the OIDC verifier.
+	assertErrorBodyContains(t, resp, "oidc verifier")
 }
 
 // TestAttestationOIDCVerifierRejectsExpired ensures the verifier enforces
@@ -240,6 +267,7 @@ func TestAttestationOIDCVerifierRejectsExpired(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"expired JWT must be rejected")
+	assertErrorBodyContains(t, resp, "token validation failed")
 }
 
 // TestAttestationOIDCVerifierRejectsRequiredClaimMismatch verifies that the
@@ -268,6 +296,90 @@ func TestAttestationOIDCVerifierRejectsRequiredClaimMismatch(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"required_claims mismatch must reject the attestation")
+	assertErrorBodyContains(t, resp, "required claim")
+}
+
+// TestAttestationDoubleVerifyIsRejected enforces the ErrAttestationAlreadyVerified
+// guard: once a record has been verified (even once successfully), a second
+// /verify on the same record must be rejected so a retry-after-partial-
+// failure can't mint a second credential from a single proof.
+func TestAttestationDoubleVerifyIsRejected(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
+	reg := registerAgent(t, uid("attest-double"))
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{"url": iss.URL}},
+	})
+
+	token := iss.sign(map[string]any{"sub": "ci-job-double"})
+	id := submitAttestation(t, reg.AgentID, "oidc_token", token)
+
+	first := verifyAttestation(t, id)
+	require.Equal(t, http.StatusOK, first.StatusCode, "first verify expected 200")
+	_ = first.Body.Close()
+
+	second := verifyAttestation(t, id)
+	defer func() { _ = second.Body.Close() }()
+	assert.Equal(t, http.StatusConflict, second.StatusCode,
+		"second verify on an already-verified record must be 409 Conflict")
+	assertErrorBodyContains(t, second, "already verified")
+}
+
+// TestAttestationPolicyUpsertReactivatesDisabled verifies the upsert-against-
+// inactive-row bug is fixed: disabling a policy via is_active=false and then
+// PUTting a fresh config must update the row in place, not violate the
+// unique constraint.
+func TestAttestationPolicyUpsertReactivatesDisabled(t *testing.T) {
+	iss := newOIDCIssuer(t)
+	defer iss.close()
+
+	// First create an active policy.
+	upsertOIDCPolicy(t, map[string]any{
+		"issuers": []map[string]any{{"url": iss.URL}},
+	})
+
+	// Soft-disable it.
+	disabled := false
+	disableResp := doRequest(t, http.MethodPut, adminPath("/attestation-policies"), map[string]any{
+		"proof_type": "oidc_token",
+		"config": map[string]any{
+			"issuers": []map[string]any{{"url": iss.URL}},
+		},
+		"is_active": &disabled,
+	}, adminHeaders())
+	require.Equal(t, http.StatusOK, disableResp.StatusCode)
+	_ = disableResp.Body.Close()
+
+	// Now re-enable (or just upsert again). Before the fix this hit the
+	// unique constraint because GetByTenantProofType filters is_active.
+	enabled := true
+	reenable := doRequest(t, http.MethodPut, adminPath("/attestation-policies"), map[string]any{
+		"proof_type": "oidc_token",
+		"config": map[string]any{
+			"issuers": []map[string]any{{"url": iss.URL}},
+		},
+		"is_active": &enabled,
+	}, adminHeaders())
+	defer func() { _ = reenable.Body.Close() }()
+	assert.Equal(t, http.StatusOK, reenable.StatusCode,
+		"upserting an inactive policy must reactivate it, not 500 on unique constraint")
+}
+
+// TestAttestationPolicyRejectsNonHTTPSIssuer exercises the write-time config
+// validator: an http://... issuer URL should be rejected before it's stored,
+// because OIDC discovery over plaintext lets a network attacker swap JWKS.
+func TestAttestationPolicyRejectsNonHTTPSIssuer(t *testing.T) {
+	resp := doRequest(t, http.MethodPut, adminPath("/attestation-policies"), map[string]any{
+		"proof_type": "oidc_token",
+		"config": map[string]any{
+			"issuers": []map[string]any{{"url": "http://plaintext.example.com"}},
+		},
+	}, adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"non-https issuer URL must be rejected at write time with 400")
+	assertErrorBodyContains(t, resp, "https")
 }
 
 // flipLastByte returns the last byte of s with a single bit flipped, so

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -455,14 +456,26 @@ func TestAttestationOIDCDiscoveryBodyCap(t *testing.T) {
 		"issuers": []map[string]any{{"url": issuerURL}},
 	})
 
-	// Any signed token will do — we never get past discovery.
-	bogusToken := "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3dyb25nIn0.signature"
+	// Token's iss claim MUST match the configured issuer — otherwise
+	// findIssuer rejects on the allowlist and the verifier never runs
+	// discoverJWKSURL, so the test would pass for the wrong reason and
+	// silently leave the body cap uncovered. A hand-built unsigned JWT
+	// is fine because we want the verifier to fail at discovery, before
+	// any signature check.
+	b64 := base64.RawURLEncoding
+	header := b64.EncodeToString([]byte(`{"alg":"RS256"}`))
+	payload := b64.EncodeToString([]byte(`{"iss":"` + issuerURL + `"}`))
+	bogusToken := header + "." + payload + ".signature"
 	id := submitAttestation(t, reg.AgentID, "oidc_token", bogusToken)
 
 	resp := verifyAttestation(t, id)
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"oversized discovery response must be rejected, not OOM the server")
+	// Body assertion keeps the test honest: status alone would also
+	// pass for "issuer not in allowlist" (a no-op test). Pin to the
+	// JWKS-fetch path so a regression on the body cap is visible.
+	assertErrorBodyContains(t, resp, "JWKS fetch failed")
 }
 
 // flipLastByte returns the last byte of s with a single bit flipped, so

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -462,10 +462,16 @@ func TestAttestationOIDCDiscoveryBodyCap(t *testing.T) {
 	// silently leave the body cap uncovered. A hand-built unsigned JWT
 	// is fine because we want the verifier to fail at discovery, before
 	// any signature check.
+	//
+	// Each JWT segment is base64url. The signature segment must have a
+	// length in {4n, 4n+2, 4n+3} — anything else (e.g. the literal
+	// string "signature" at length 9 = 4n+1) makes jwx reject the token
+	// at parse time with "malformed JWT", which short-circuits before
+	// discovery and leaves the body cap unexercised. Use 8-char "A"s.
 	b64 := base64.RawURLEncoding
 	header := b64.EncodeToString([]byte(`{"alg":"RS256"}`))
 	payload := b64.EncodeToString([]byte(`{"iss":"` + issuerURL + `"}`))
-	bogusToken := header + "." + payload + ".signature"
+	bogusToken := header + "." + payload + ".AAAAAAAA"
 	id := submitAttestation(t, reg.AgentID, "oidc_token", bogusToken)
 
 	resp := verifyAttestation(t, id)

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -484,6 +484,101 @@ func TestAttestationOIDCDiscoveryBodyCap(t *testing.T) {
 	assertErrorBodyContains(t, resp, "JWKS fetch failed")
 }
 
+// registerAgentInTenant is a local helper for the permissive-bypass tests
+// below: registerAgent uses adminHeaders, but the bypass tests need
+// agents in tenants no other test touches so a missing-policy state
+// can be observed without races. Inlines the same call shape with
+// caller-supplied tenant headers.
+func registerAgentInTenant(t *testing.T, externalID string, tenant map[string]string) agentRegistration {
+	t.Helper()
+	resp := post(t, adminPath("/agents/register"), map[string]any{
+		"name":        externalID,
+		"external_id": externalID,
+		"sub_type":    "orchestrator",
+		"trust_level": "first_party",
+		"created_by":  "test-user",
+	}, tenant)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "registerAgentInTenant expected 201")
+	raw := decode(t, resp)
+	agent := raw["identity"].(map[string]any)
+	return agentRegistration{
+		AgentID: agent["id"].(string),
+		APIKey:  raw["api_key"].(string),
+	}
+}
+
+// TestAttestationPermissiveModeAcceptsMissingPolicy covers the
+// transitional bypass that ships with the dev-stub default: when
+// allow_unsafe_dev_stub=true, /attestation/verify accepts any submitted
+// proof for a registered proof type even when the tenant has no
+// AttestationPolicy configured. Existing customers using the legacy
+// "any proof verifies" stub keep working without an upgrade-time
+// scramble to PUT a policy. A WARN log fires per-request so operators
+// can find tenants still using the bypass.
+//
+// Test flips the flag via Server.SetAttestationPermissive — the harness
+// default is false so other tests keep their fail-closed semantics.
+func TestAttestationPermissiveModeAcceptsMissingPolicy(t *testing.T) {
+	testZeroIDServer.SetAttestationPermissive(true)
+	t.Cleanup(func() { testZeroIDServer.SetAttestationPermissive(false) })
+
+	// Use a tenant no other test touches; we deliberately do NOT
+	// upsertOIDCPolicy here so the missing-policy branch fires.
+	tenant := tenantHeaders("acct-permissive-"+uid(""), "proj-permissive-"+uid(""))
+	reg := registerAgentInTenant(t, uid("attest-permissive"), tenant)
+
+	// Token contents are irrelevant — the bypass synthesises a Result
+	// without invoking the OIDC verifier. A valid-shape JWT is enough
+	// to clear the SubmitAttestation handler's enum check.
+	bogusToken := "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2FueXRoaW5nIn0.AAAAAAAA"
+	subResp := doRequest(t, http.MethodPost, adminPath("/attestation/submit"), map[string]any{
+		"identity_id": reg.AgentID,
+		"level":       "software",
+		"proof_type":  "oidc_token",
+		"proof_value": bogusToken,
+	}, tenant)
+	require.Equal(t, http.StatusCreated, subResp.StatusCode, "submit expected 201")
+	id := decode(t, subResp)["id"].(string)
+
+	resp := doRequest(t, http.MethodPost, adminPath("/attestation/verify"), map[string]any{
+		"attestation_id": id,
+	}, tenant)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "permissive mode: missing policy should not reject")
+
+	body := decode(t, resp)
+	record := body["record"].(map[string]any)
+	assert.Equal(t, true, record["is_verified"], "record marked verified via permissive bypass")
+	assert.NotEmpty(t, body["token"], "credential auto-issued via permissive bypass")
+}
+
+// TestAttestationPermissiveModeOffStillFailsClosed pairs with the test
+// above: when the bypass is OFF (the harness default) and no policy
+// exists, /verify must reject. Catches an accidental "always permissive"
+// regression in the service-layer switch.
+func TestAttestationPermissiveModeOffStillFailsClosed(t *testing.T) {
+	// No SetAttestationPermissive(true) — harness default is false.
+	tenant := tenantHeaders("acct-strict-"+uid(""), "proj-strict-"+uid(""))
+	reg := registerAgentInTenant(t, uid("attest-strict"), tenant)
+
+	bogusToken := "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL2FueXRoaW5nIn0.AAAAAAAA"
+	subResp := doRequest(t, http.MethodPost, adminPath("/attestation/submit"), map[string]any{
+		"identity_id": reg.AgentID,
+		"level":       "software",
+		"proof_type":  "oidc_token",
+		"proof_value": bogusToken,
+	}, tenant)
+	require.Equal(t, http.StatusCreated, subResp.StatusCode)
+	id := decode(t, subResp)["id"].(string)
+
+	resp := doRequest(t, http.MethodPost, adminPath("/attestation/verify"), map[string]any{
+		"attestation_id": id,
+	}, tenant)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "strict mode rejects missing policy")
+	assertErrorBodyContains(t, resp, "no attestation policy configured")
+}
+
 // flipLastByte returns the last byte of s with a single bit flipped, so
 // good[:len(good)-1] + flipLastByte(good) produces a JWT with a corrupted
 // signature byte.

--- a/zeroid.yaml
+++ b/zeroid.yaml
@@ -45,3 +45,11 @@ telemetry:
 
 logging:
   level: "debug"
+
+# Attestation verification. The default OIDC verifier is always wired; the
+# dev stub below is a LOCAL-DEV-ONLY backstop that accepts any submitted
+# image_hash or tpm proof so demos and smoke tests keep working before a
+# real verifier lands. MUST be false in production — flip to false (or
+# remove) before shipping. A WARN log prints on startup whenever it's true.
+attestation:
+  allow_unsafe_dev_stub: true

--- a/zeroid.yaml
+++ b/zeroid.yaml
@@ -46,10 +46,12 @@ telemetry:
 logging:
   level: "debug"
 
-# Attestation verification. The default OIDC verifier is always wired; the
-# dev stub below is a LOCAL-DEV-ONLY backstop that accepts any submitted
-# image_hash or tpm proof so demos and smoke tests keep working before a
-# real verifier lands. MUST be false in production — flip to false (or
-# remove) before shipping. A WARN log prints on startup whenever it's true.
+# Attestation verification. The OIDC verifier is always wired and runs
+# fail-closed. The dev stub backs up image_hash and tpm proof types
+# (whose real verifiers haven't shipped yet) so demos and smoke tests
+# that submit those keep working — a WARN log prints on startup whenever
+# it's active. Deployments that don't use those proof types, or where
+# the real verifiers have landed, should set this to false (or via
+# ZEROID_ALLOW_UNSAFE_DEV_STUB=false).
 attestation:
   allow_unsafe_dev_stub: true


### PR DESCRIPTION
Closes #94.

## Summary

Summary

  Previously /attestation/verify marked any submitted proof as verified, promoted trust, and auto-issued
   a credential with no actual verification. This PR lands the scaffold that makes verification
  authoritative, plus the first real verifier.

  - Verifier interface + Registry (internal/attestation/), which is one verifier per ProofType; no verifier
  wired = fail closed.
  - OIDCVerifier, which verifies upstream OIDC JWTs (GitHub Actions, GCP Workload Identity, K8S projected SA
  tokens, AWS IAM OIDC, SPIFFE JWT-SVIDs) against a tenant-scoped issuer allowlist. OIDC discovery, JWKS
   caching (1h per issuer), signature + standard claim validation, optional audience, and required-claim
  binding.
  - DevStubVerifier behind cfg.Attestation.AllowUnsafeDevStub for legacy demo paths. Loud startup WARN;
  OFF by default.
  - attestation_policies table (migration 010) + admin CRUD at PUT/GET/DELETE
  /api/v1/attestation-policies. One row per (tenant, proof_type), JSONB config for verifier-specific
  shape.
  - AttestationService.VerifyAttestation rewired: fetch record → resolve verifier → resolve policy →
  Verifier.Verify → only on success promote trust + issue credential. Rejection returns
  ErrAttestationRejected → 400.

  image_hash and tpm deliberately deferred, smaller once the scaffold exists, land as focused
  follow-ups when tenants actually need them.
  
  ## Test plan

  - New tests/integration/attestation_oidc_test.go:
    - Fails closed when tenant has no policy
    - Happy path: trusted issuer + signed JWT + matching aud/claims → verified + credential issued
    - Rejects untrusted issuer
    - Rejects tampered signature
    - Rejects expired JWT
    - Rejects required-claim mismatch
  - Full suite: 55 tests, all green
  - golangci-lint: 0 issues
