### PR TITLE
feat: propagate product claim from api_key grant to issued JWT

### DIFF
--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -79,6 +79,11 @@ type IssueRequest struct {
 	UseRS256 bool
 	// ApplicationID is the optional application scope (set when API key is linked to an application).
 	ApplicationID string
+	// Product is the optional product scope (e.g. `ai_gateway`, `mcp_gateway`),
+	// set when the issuance source declares which product the credential is for.
+	// Downstream services (Shield, Firehog) read the `product` claim to pick the
+	// correct Cedar action namespace at evaluation time.
+	Product string
 	// SubjectOverride, when non-empty, replaces the default WIMSE URI as the JWT "sub" claim.
 	// Used for external principal exchange (sub = external user ID) and authorization_code
 	// (sub = authenticated user ID). For NHI grants, leave empty to use the WIMSE URI.
@@ -299,6 +304,9 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	// Generic claims for RS256 tokens (api_key grant).
 	if req.ApplicationID != "" {
 		_ = token.Set("application_id", req.ApplicationID)
+	}
+	if req.Product != "" {
+		_ = token.Set("product", req.Product)
 	}
 	if req.UserEmail != "" {
 		_ = token.Set("user_email", req.UserEmail)

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -677,6 +677,11 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 		Scopes:             scopes,
 		GrantType:          domain.GrantTypeAPIKey,
 		UseRS256:           true,
+		// Forward the API key's product binding so downstream services
+		// (Shield/Firehog) pick the right Cedar action namespace
+		// (`AIGateway::Action::*` vs `MCPGateway::Action::*`) instead of
+		// hardcoding one. Empty when the key wasn't tagged at creation.
+		Product: sk.Product,
 		// sub = WIMSE URI (the identity), not the creator.
 		// owner_user_id is set from Identity.OwnerUserID automatically.
 		// The creator is the acting user (the developer using the SDK right now).


### PR DESCRIPTION
## Summary

API keys carry a `product` field in the database (`service_keys.product` — `ai_gateway`, `mcp_gateway`, etc.) but the api_key grant didn't forward it into the issued credential. Downstream services (Highflame Shield, Firehog) had no way to learn which product an inbound JWT was minted for and ended up hardcoding a default namespace, which caused per-project default-deny when a project's permits lived under a different namespace than the route happened to terminate at.

## Change

- Add `Product` field to `IssueRequest` (`internal/service/credential.go`).
- Set the `product` JWT claim alongside the existing `application_id` claim when non-empty (skipped on empty so legacy tokens are unchanged).
- `apiKeyGrant` (`internal/service/oauth.go`) forwards `sk.Product` into the issuance request.

## Why this matters end-to-end

Once this is released, firehog reads `claims.product` and routes the Shield request into the correct Cedar action namespace (`AIGateway::Action::*` for `ai_gateway` keys, `MCPGateway::Action::*` for `mcp_gateway` keys). That's the architectural fix that retires a set of project-wide hotfix permits we deployed today on dev1 + prod to work around the hardcoded namespace.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test ./internal/service/...` — no service-package tests yet (pre-existing).
- [ ] Post-release: bump zeroid in highflame-authn, mint an api_key JWT against a service key with `product = "mcp_gateway"`, decode and confirm the `product` claim is present.
- [ ] Then bump zeroid in highflame-firehog (after firehog [#105](https://github.com/highflame-ai/highflame-firehog/pull/105) merges) and verify Observatory events for MCP-keyed traffic show product = mcp_gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)