### PR TITLE
fix: validate SPIFFE path segments at identity registration

### DIFF
--- a/domain/identity.go
+++ b/domain/identity.go
@@ -345,3 +345,24 @@ func GetIdentitySchema() *IdentitySchema {
 func BuildWIMSEURI(wimseDomain, accountID, projectID string, identityType IdentityType, externalID string) string {
 	return fmt.Sprintf("spiffe://%s/%s/%s/%s/%s", wimseDomain, accountID, projectID, identityType, externalID)
 }
+
+// ValidateSPIFFEPathSegment rejects values that wouldn't survive a round-trip
+// through a strict SPIFFE parser (§2.3 — letters, digits, dot, dash,
+// underscore). Run this on anything destined for BuildWIMSEURI; once stored,
+// the URI is durable and we don't re-check on read.
+func ValidateSPIFFEPathSegment(field, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '.' || r == '-' || r == '_':
+		default:
+			return fmt.Errorf("%s contains character %q not allowed in a SPIFFE path segment (allowed: a-z A-Z 0-9 . - _)", field, r)
+		}
+	}
+	return nil
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -235,6 +235,10 @@ func (a *API) registerAgentOp(ctx context.Context, input *RegisterAgentInput) (*
 		if errors.Is(err, service.ErrPolicySubsetViolation) {
 			return nil, huma.Error400BadRequest(err.Error())
 		}
+		// SPIFFE path-segment validation failures are caller-fixable.
+		if errors.Is(err, service.ErrInvalidIdentityField) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		log.Error().Err(err).Str("external_id", input.Body.ExternalID).Msg("failed to register agent")
 		return nil, huma.Error500InternalServerError("failed to register agent")
 	}

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -203,6 +203,10 @@ func (a *API) createIdentityOp(ctx context.Context, input *CreateIdentityInput) 
 		if errors.Is(err, service.ErrPolicyNotFound) {
 			return nil, huma.Error400BadRequest("credential policy not found in this tenant")
 		}
+		// SPIFFE path-segment validation failures are caller-fixable.
+		if errors.Is(err, service.ErrInvalidIdentityField) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		log.Error().Err(err).Str("external_id", input.Body.ExternalID).Msg("failed to register identity")
 		return nil, huma.Error500InternalServerError("failed to create identity")
 	}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -20,6 +20,10 @@ import (
 // ErrIdentityAlreadyExists is returned when (account_id, project_id, external_id) already exists.
 var ErrIdentityAlreadyExists = errors.New("identity already exists")
 
+// ErrInvalidIdentityField marks caller-fixable input errors on registration
+// (currently the SPIFFE path-segment check). Maps to 400 at the HTTP boundary.
+var ErrInvalidIdentityField = errors.New("invalid identity field")
+
 // IdentityService handles identity lifecycle operations.
 type IdentityService struct {
 	repo          *postgres.IdentityRepository
@@ -111,9 +115,6 @@ type RegisterIdentityRequest struct {
 
 // RegisterIdentity creates a new identity with a WIMSE URI.
 func (s *IdentityService) RegisterIdentity(ctx context.Context, req RegisterIdentityRequest) (*domain.Identity, error) {
-	if req.AccountID == "" || req.ProjectID == "" || req.ExternalID == "" {
-		return nil, fmt.Errorf("accountID, projectID, and externalID are required")
-	}
 	if req.OwnerUserID == "" {
 		return nil, fmt.Errorf("owner_user_id is required")
 	}
@@ -125,6 +126,19 @@ func (s *IdentityService) RegisterIdentity(ctx context.Context, req RegisterIden
 	}
 	if !req.IdentityType.Valid() {
 		return nil, fmt.Errorf("invalid identity_type: %s", req.IdentityType)
+	}
+	// Anything that lands in the WIMSE URI path needs to be SPIFFE-clean —
+	// otherwise we mint URIs strict verifiers reject, and a "/" in any of
+	// these fields silently shifts the path layout when parsed back out.
+	for _, f := range []struct{ name, value string }{
+		{"account_id", req.AccountID},
+		{"project_id", req.ProjectID},
+		{"external_id", req.ExternalID},
+		{"identity_type", string(req.IdentityType)},
+	} {
+		if err := domain.ValidateSPIFFEPathSegment(f.name, f.value); err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidIdentityField, err.Error())
+		}
 	}
 	if req.SubType == "" && req.IdentityType == domain.IdentityTypeAgent {
 		req.SubType = domain.SubTypeToolAgent

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -137,7 +137,7 @@ func (s *IdentityService) RegisterIdentity(ctx context.Context, req RegisterIden
 		{"identity_type", string(req.IdentityType)},
 	} {
 		if err := domain.ValidateSPIFFEPathSegment(f.name, f.value); err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrInvalidIdentityField, err.Error())
+			return nil, fmt.Errorf("%w: %w", ErrInvalidIdentityField, err)
 		}
 	}
 	if req.SubType == "" && req.IdentityType == domain.IdentityTypeAgent {

--- a/tests/integration/identity_test.go
+++ b/tests/integration/identity_test.go
@@ -53,6 +53,36 @@ func TestRegisterIdentityDuplicateReturns409(t *testing.T) {
 	_ = resp.Body.Close()
 }
 
+// TestRegisterIdentityRejectsForbiddenSPIFFEChars locks in the SPIFFE §2.3
+// path-segment gate on external_id. The path_traversal case is the one that
+// actually matters — without the gate it slips through into the WIMSE URI.
+func TestRegisterIdentityRejectsForbiddenSPIFFEChars(t *testing.T) {
+	cases := []struct {
+		name       string
+		externalID string
+	}{
+		{"slash", "agent/with/slash"},
+		{"at_sign", "agent@example"},
+		{"space", "agent with space"},
+		{"path_traversal", "../admin"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := post(t, adminPath("/identities"), map[string]any{
+				"external_id":    tc.externalID,
+				"trust_level":    "unverified",
+				"owner_user_id":  "user-test-owner",
+				"allowed_scopes": []string{"billing:read"},
+			}, adminHeaders())
+			assert.True(t,
+				resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity,
+				"expected 400/422 for forbidden character, got %d", resp.StatusCode,
+			)
+			_ = resp.Body.Close()
+		})
+	}
+}
+
 // TestRegisterIdentityMissingExternalID verifies that omitting external_id returns 400/422.
 func TestRegisterIdentityMissingExternalID(t *testing.T) {
 	resp := post(t, adminPath("/identities"), map[string]any{


### PR DESCRIPTION
## Summary

- `RegisterIdentity` was concatenating `account_id`, `project_id`, `external_id`, and `identity_type` straight into the WIMSE URI with no character check, so a `/`, `@`, or space in any of those fields produced URIs that strict SPIFFE verifiers reject.
- A `/` was the dangerous case — `parseWIMSEURI` splits the path back out, and a tampered `external_id` could shift the account/project/identity_type layout without detection.
- Adds `ValidateSPIFFEPathSegment` in `domain` (allowed set per [SPIFFE §2.3](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE.md#23-path) — letters, digits, dot, dash, underscore), gates the four path-contributing fields in `RegisterIdentity`, and surfaces a new `ErrInvalidIdentityField` sentinel.
- Identity + agent handlers map the new sentinel to `400` instead of the `500` default.
- Existing rows that already contain spec-violating characters keep working — validation only runs at registration.

Fixes #44

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `make test` passes (new `TestRegisterIdentityRejectsForbiddenSPIFFEChars` covers `/`, `@`, space, `../admin`)