### PR TITLE
fix: gate incoming JWTs to the JWT-SVID alg allow-list

### DIFF
--- a/internal/jwtalg/jwtalg.go
+++ b/internal/jwtalg/jwtalg.go
@@ -26,11 +26,11 @@ var allowed = map[string]struct{}{
 // Validate decodes only the protected header (everything before the first
 // ".") and checks alg against the allow-list. No signature work runs.
 func Validate(tokenStr string) error {
-	dot := strings.IndexByte(tokenStr, '.')
-	if dot <= 0 {
+	header, _, found := strings.Cut(tokenStr, ".")
+	if !found || header == "" {
 		return fmt.Errorf("%w: token is not a compact JWS", ErrUnsupportedAlg)
 	}
-	raw, err := base64.RawURLEncoding.DecodeString(tokenStr[:dot])
+	raw, err := base64.RawURLEncoding.DecodeString(header)
 	if err != nil {
 		return fmt.Errorf("%w: header is not valid base64url: %v", ErrUnsupportedAlg, err)
 	}

--- a/internal/jwtalg/jwtalg.go
+++ b/internal/jwtalg/jwtalg.go
@@ -1,0 +1,50 @@
+// Package jwtalg rejects JWTs whose alg isn't in the JWT-SVID §3 allow-list.
+// Run Validate before jwx parses anything so alg=none / HS* dies up-front
+// rather than depending on the verifier's defaults.
+package jwtalg
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrUnsupportedAlg covers both "alg outside the allow-list" and a malformed
+// header. Maps to 400/401 — caller-fixable, not a server fault.
+var ErrUnsupportedAlg = errors.New("unsupported JWT algorithm")
+
+// allowed is the literal set from JWT-SVID §3. Note the absence of "none"
+// and HS* — those are the things this whole file exists to reject.
+var allowed = map[string]struct{}{
+	"ES256": {}, "ES384": {}, "ES512": {},
+	"RS256": {}, "RS384": {}, "RS512": {},
+	"PS256": {}, "PS384": {}, "PS512": {},
+}
+
+// Validate decodes only the protected header (everything before the first
+// ".") and checks alg against the allow-list. No signature work runs.
+func Validate(tokenStr string) error {
+	dot := strings.IndexByte(tokenStr, '.')
+	if dot <= 0 {
+		return fmt.Errorf("%w: token is not a compact JWS", ErrUnsupportedAlg)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(tokenStr[:dot])
+	if err != nil {
+		return fmt.Errorf("%w: header is not valid base64url: %v", ErrUnsupportedAlg, err)
+	}
+	var hdr struct {
+		Alg string `json:"alg"`
+	}
+	if err := json.Unmarshal(raw, &hdr); err != nil {
+		return fmt.Errorf("%w: header is not valid JSON: %v", ErrUnsupportedAlg, err)
+	}
+	if hdr.Alg == "" {
+		return fmt.Errorf("%w: alg header is missing", ErrUnsupportedAlg)
+	}
+	if _, ok := allowed[hdr.Alg]; !ok {
+		return fmt.Errorf("%w: %q is not in the JWT-SVID allow-list", ErrUnsupportedAlg, hdr.Alg)
+	}
+	return nil
+}

--- a/internal/middleware/agent_auth.go
+++ b/internal/middleware/agent_auth.go
@@ -10,6 +10,8 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/internal/jwtalg"
 )
 
 // AgentClaims holds the agent identity claims extracted from a validated ES256 JWT.
@@ -46,6 +48,13 @@ func AgentAuthMiddleware(cfg AgentAuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 			tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+
+			// Reject alg=none / HS* before any further work — JWT-SVID §3.
+			if err := jwtalg.Validate(tokenStr); err != nil {
+				log.Warn().Err(err).Str("path", r.URL.Path).Msg("Agent JWT rejected: bad alg")
+				writeAgentAuthError(w, http.StatusUnauthorized, "invalid or expired token")
+				return
+			}
 
 			parsed, err := jwt.Parse([]byte(tokenStr),
 				jwt.WithKey(jwa.ES256, cfg.PublicKey),

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/jwtalg"
 	"github.com/highflame-ai/zeroid/internal/signing"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
@@ -240,6 +241,11 @@ func (s *OAuthService) jwtBearer(ctx context.Context, req TokenRequest) (*domain
 		return nil, oauthBadRequest("invalid_request", "subject (assertion JWT) is required for jwt_bearer grant")
 	}
 
+	// Reject alg=none / HS* before any further work — JWT-SVID §3.
+	if err := jwtalg.Validate(req.Subject); err != nil {
+		return nil, oauthBadRequestCause("invalid_grant", "assertion JWT uses an unsupported algorithm", err)
+	}
+
 	// Peek at the assertion without signature verification to extract the iss claim (WIMSE URI).
 	peeked, err := jwt.ParseInsecure([]byte(req.Subject))
 	if err != nil {
@@ -357,6 +363,10 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 	}
 
 	// Step 2: Verify the actor_token (sub-agent's signed JWT assertion).
+	// Reject alg=none / HS* before any further work — JWT-SVID §3.
+	if err := jwtalg.Validate(req.ActorToken); err != nil {
+		return nil, oauthBadRequestCause("invalid_grant", "actor_token uses an unsupported algorithm", err)
+	}
 	actorPeeked, err := jwt.ParseInsecure([]byte(req.ActorToken))
 	if err != nil {
 		return nil, oauthBadRequestCause("invalid_grant", "actor_token is malformed", err)
@@ -1062,6 +1072,12 @@ func (s *OAuthService) Revoke(ctx context.Context, tokenStr string) error {
 // the token's kid + alg headers to the correct key automatically.
 // If validate is true, expiry/nbf checks are enforced; if false, only signature is checked.
 func (s *OAuthService) parseToken(tokenStr string, validate bool) (jwt.Token, error) {
+	// Belt-and-braces. WithKeySet trusts the key's own alg, so this isn't
+	// exploitable today — but if the bundle ever ships a key without alg,
+	// the verifier's fallback widens. Cheaper to gate up-front.
+	if err := jwtalg.Validate(tokenStr); err != nil {
+		return nil, err
+	}
 	return jwt.Parse([]byte(tokenStr),
 		jwt.WithKeySet(s.jwksSvc.KeySet()),
 		jwt.WithValidate(validate),

--- a/internal/service/proof.go
+++ b/internal/service/proof.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/jwtalg"
 	"github.com/highflame-ai/zeroid/internal/signing"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
@@ -81,6 +82,10 @@ func (s *ProofService) GenerateProofToken(ctx context.Context, identity *domain.
 
 // VerifyProofToken parses and validates a WIMSE Proof Token, then marks it as used to prevent replay.
 func (s *ProofService) VerifyProofToken(ctx context.Context, tokenStr, expectedAudience string) (jwt.Token, error) {
+	// Reject alg=none / HS* before any further work — JWT-SVID §3.
+	if err := jwtalg.Validate(tokenStr); err != nil {
+		return nil, fmt.Errorf("proof token validation failed: %w", err)
+	}
 	parsed, err := jwt.Parse([]byte(tokenStr),
 		jwt.WithKey(jwa.ES256, s.jwksSvc.PublicKey()),
 		jwt.WithValidate(true),

--- a/pkg/authjwt/alg.go
+++ b/pkg/authjwt/alg.go
@@ -19,11 +19,11 @@ var allowedAlgs = map[string]struct{}{
 // signature work runs. Defense-in-depth — a bundle published without per-key
 // alg shouldn't widen what the verifier will accept.
 func validateAlg(tokenStr string) error {
-	dot := strings.IndexByte(tokenStr, '.')
-	if dot <= 0 {
+	header, _, found := strings.Cut(tokenStr, ".")
+	if !found || header == "" {
 		return fmt.Errorf("%w: token is not a compact JWS", ErrInvalidToken)
 	}
-	raw, err := base64.RawURLEncoding.DecodeString(tokenStr[:dot])
+	raw, err := base64.RawURLEncoding.DecodeString(header)
 	if err != nil {
 		return fmt.Errorf("%w: header is not valid base64url: %v", ErrInvalidToken, err)
 	}

--- a/pkg/authjwt/alg.go
+++ b/pkg/authjwt/alg.go
@@ -1,0 +1,43 @@
+package authjwt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// allowedAlgs is the JWT-SVID §3 allow-list. "none" and HMAC variants are
+// deliberately absent — presenting either MUST be rejected.
+var allowedAlgs = map[string]struct{}{
+	"ES256": {}, "ES384": {}, "ES512": {},
+	"RS256": {}, "RS384": {}, "RS512": {},
+	"PS256": {}, "PS384": {}, "PS512": {},
+}
+
+// validateAlg gates incoming tokens to the JWT-SVID §3 allow-list before any
+// signature work runs. Defense-in-depth — a bundle published without per-key
+// alg shouldn't widen what the verifier will accept.
+func validateAlg(tokenStr string) error {
+	dot := strings.IndexByte(tokenStr, '.')
+	if dot <= 0 {
+		return fmt.Errorf("%w: token is not a compact JWS", ErrInvalidToken)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(tokenStr[:dot])
+	if err != nil {
+		return fmt.Errorf("%w: header is not valid base64url: %v", ErrInvalidToken, err)
+	}
+	var hdr struct {
+		Alg string `json:"alg"`
+	}
+	if err := json.Unmarshal(raw, &hdr); err != nil {
+		return fmt.Errorf("%w: header is not valid JSON: %v", ErrInvalidToken, err)
+	}
+	if hdr.Alg == "" {
+		return fmt.Errorf("%w: alg header is missing", ErrInvalidToken)
+	}
+	if _, ok := allowedAlgs[hdr.Alg]; !ok {
+		return fmt.Errorf("%w: %q is not in the JWT-SVID allow-list", ErrInvalidToken, hdr.Alg)
+	}
+	return nil
+}

--- a/pkg/authjwt/verifier.go
+++ b/pkg/authjwt/verifier.go
@@ -131,6 +131,11 @@ func (v *Verifier) verify(ctx context.Context, tokenString string) (*Claims, err
 		return nil, ErrNoKeySet
 	}
 
+	// Reject alg=none / HS* before any further work — JWT-SVID §3.
+	if err := validateAlg(tokenString); err != nil {
+		return nil, err
+	}
+
 	// Parse and validate in one step. WithKeySet uses kid+alg to select the key.
 	parseOpts := []jwt.ParseOption{
 		jwt.WithKeySet(keySet),

--- a/tests/integration/jwt_alg_test.go
+++ b/tests/integration/jwt_alg_test.go
@@ -1,0 +1,60 @@
+package integration_test
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntrospectRejectsAlgNone is the alg-none / HS* defense-in-depth check.
+// We hand the introspect endpoint a token whose header advertises alg=none
+// and expect active:false. Without the JWT-SVID §3 allow-list this would
+// fall through to the verifier's alg-handling defaults — safe today, but a
+// future change to how keys are published could regress that.
+func TestIntrospectRejectsAlgNone(t *testing.T) {
+	cases := []struct {
+		name string
+		alg  string
+	}{
+		{"alg_none_lowercase", "none"},
+		{"alg_none_capitalized", "None"},
+		{"alg_hs256", "HS256"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token := craftUnsignedJWT(tc.alg, `{"sub":"attacker","iss":"https://attacker.example"}`)
+
+			result := introspect(t, token)
+			active, _ := result["active"].(bool)
+			assert.False(t, active, "introspect must return active:false for %s; got %#v", tc.alg, result)
+		})
+	}
+}
+
+// TestVerifyEndpointRejectsAlgNone covers the same path through the
+// reverse-proxy /oauth2/token/verify endpoint, which proxies tend to wire
+// up before any application code runs. A mistake here would let an attacker
+// bypass auth entirely.
+func TestVerifyEndpointRejectsAlgNone(t *testing.T) {
+	token := craftUnsignedJWT("none", `{"sub":"attacker"}`)
+
+	resp := get(t, "/oauth2/token/verify", map[string]string{
+		"Authorization": "Bearer " + token,
+	})
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"alg=none token must be rejected with 401 at the verify endpoint")
+}
+
+// craftUnsignedJWT builds a compact JWS with the given alg header and an
+// empty signature. The payload is the raw JSON literal supplied by the
+// caller — we don't sign anything, the whole point is the alg field.
+func craftUnsignedJWT(alg, payloadJSON string) string {
+	header := `{"alg":"` + alg + `","typ":"JWT"}`
+	enc := base64.RawURLEncoding.EncodeToString
+	return enc([]byte(header)) + "." + enc([]byte(payloadJSON)) + "."
+}


### PR DESCRIPTION
## Summary

- [JWT-SVID §3](https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#3-jwt-svid-format) requires ES/RS/PS-256/384/512 only and forbids \`alg=none\` and HS*. ZeroID was relying on jwx's defaults — safe in practice today (every published JWK carries an explicit \`alg\`, so jwx selects keys by the key's \`alg\` not the token's), but fragile.
- Adds \`internal/jwtalg.Validate\` and calls it before every jwx parse on a caller-supplied token: \`parseToken\` (introspect/revoke/verify), the \`jwt_bearer\` assertion, the \`token_exchange\` \`actor_token\`, the WIMSE proof token verifier, and the agent-auth middleware.
- Mirrors the gate in \`pkg/authjwt\` (separate Go module) so SDK consumers get the protection without depending on the server tree.
- Auth code (\`HS256\`, server-internal) is intentionally not gated — it's not a JWT-SVID.
- New regression test in \`tests/integration/jwt_alg_test.go\` covers \`alg=none\` / \`None\` / \`HS256\` against \`/oauth2/token/introspect\` and \`/oauth2/token/verify\`.

Fixes #45

## Test plan

- [x] \`go vet ./...\` clean (server + \`pkg/authjwt\`)
- [x] \`go build ./...\` clean (server + \`pkg/authjwt\`)
- [x] \`make test\` passes (full integration suite, ~42s)
- [x] \`pkg/authjwt\` unit tests pass