### PR TITLE
fix: set typ=JWT in issued JWT headers (JWT-SVID §3)

### DIFF
--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -323,16 +323,19 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	}
 
 	// Sign: RS256 for api_key grant (compatible), ES256 for all agent/NHI flows.
-	// kid is included in the JWS header so verifiers can select the correct key from JWKS.
+	// kid lets verifiers pick the right key from the JWKS; typ=JWT is per
+	// JWT-SVID §3 (jwx doesn't default it).
 	var signed []byte
 	var signErr error
 	if req.UseRS256 && s.jwksSvc.HasRSAKeys() {
 		hdrs := jws.NewHeaders()
 		_ = hdrs.Set(jws.KeyIDKey, s.jwksSvc.RSAKeyID())
+		_ = hdrs.Set(jws.TypeKey, "JWT")
 		signed, signErr = jwt.Sign(token, jwt.WithKey(jwa.RS256, s.jwksSvc.RSAPrivateKey(), jws.WithProtectedHeaders(hdrs)))
 	} else {
 		hdrs := jws.NewHeaders()
 		_ = hdrs.Set(jws.KeyIDKey, s.jwksSvc.KeyID())
+		_ = hdrs.Set(jws.TypeKey, "JWT")
 		signed, signErr = jwt.Sign(token, jwt.WithKey(jwa.ES256, s.jwksSvc.PrivateKey(), jws.WithProtectedHeaders(hdrs)))
 	}
 	if signErr != nil {

--- a/internal/service/proof.go
+++ b/internal/service/proof.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/highflame-ai/zeroid/domain"
@@ -50,7 +51,10 @@ func (s *ProofService) GenerateProofToken(ctx context.Context, identity *domain.
 	_ = token.Set("account_id", identity.AccountID)
 	_ = token.Set("project_id", identity.ProjectID)
 
-	signed, err := jwt.Sign(token, jwt.WithKey(jwa.ES256, s.jwksSvc.PrivateKey()))
+	// typ=JWT per JWT-SVID §3.
+	hdrs := jws.NewHeaders()
+	_ = hdrs.Set(jws.TypeKey, "JWT")
+	signed, err := jwt.Sign(token, jwt.WithKey(jwa.ES256, s.jwksSvc.PrivateKey(), jws.WithProtectedHeaders(hdrs)))
 	if err != nil {
 		return "", fmt.Errorf("failed to sign proof token: %w", err)
 	}

--- a/internal/service/proof.go
+++ b/internal/service/proof.go
@@ -51,8 +51,10 @@ func (s *ProofService) GenerateProofToken(ctx context.Context, identity *domain.
 	_ = token.Set("account_id", identity.AccountID)
 	_ = token.Set("project_id", identity.ProjectID)
 
-	// typ=JWT per JWT-SVID §3.
+	// kid lets verifiers pick the right key from the JWKS; typ=JWT per
+	// JWT-SVID §3.
 	hdrs := jws.NewHeaders()
+	_ = hdrs.Set(jws.KeyIDKey, s.jwksSvc.KeyID())
 	_ = hdrs.Set(jws.TypeKey, "JWT")
 	signed, err := jwt.Sign(token, jwt.WithKey(jwa.ES256, s.jwksSvc.PrivateKey(), jws.WithProtectedHeaders(hdrs)))
 	if err != nil {

--- a/tests/integration/jwt_typ_test.go
+++ b/tests/integration/jwt_typ_test.go
@@ -1,0 +1,55 @@
+package integration_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssuedTokenHasTypHeader locks in JWT-SVID §3's typ=JWT on issued
+// tokens. api_key hits the RS256 branch, client_credentials hits ES256 —
+// both have to set the header.
+func TestIssuedTokenHasTypHeader(t *testing.T) {
+	t.Run("api_key_RS256", func(t *testing.T) {
+		token := issueAPIKeyToken(t, uid("typ-rs"))
+		assertTokenTypIsJWT(t, token)
+	})
+
+	t.Run("client_credentials_ES256", func(t *testing.T) {
+		agentID := uid("typ-es")
+		registerIdentity(t, agentID, []string{"data:read"})
+		client := registerOAuthClient(t, agentID, []string{"data:read"})
+
+		resp := post(t, "/oauth2/token", map[string]any{
+			"grant_type":    "client_credentials",
+			"account_id":    testAccountID,
+			"project_id":    testProjectID,
+			"client_id":     client.ClientID,
+			"client_secret": client.ClientSecret,
+			"scope":         "data:read",
+		}, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		token := decode(t, resp)["access_token"].(string)
+
+		assertTokenTypIsJWT(t, token)
+	})
+}
+
+func assertTokenTypIsJWT(t *testing.T, tokenStr string) {
+	t.Helper()
+	dot := strings.IndexByte(tokenStr, '.')
+	require.Greater(t, dot, 0, "token is not a compact JWS")
+
+	raw, err := base64.RawURLEncoding.DecodeString(tokenStr[:dot])
+	require.NoError(t, err, "header is not valid base64url")
+
+	var hdr map[string]any
+	require.NoError(t, json.Unmarshal(raw, &hdr), "header is not valid JSON")
+
+	assert.Equal(t, "JWT", hdr["typ"], "JWT-SVID §3 expects typ=JWT in the header")
+}

--- a/tests/integration/jwt_typ_test.go
+++ b/tests/integration/jwt_typ_test.go
@@ -52,4 +52,7 @@ func assertTokenTypIsJWT(t *testing.T, tokenStr string) {
 	require.NoError(t, json.Unmarshal(raw, &hdr), "header is not valid JSON")
 
 	assert.Equal(t, "JWT", hdr["typ"], "JWT-SVID §3 expects typ=JWT in the header")
+	// kid is required so verifiers can pick the right key from the JWKS.
+	// Asserted here too since this test already cracks the header open.
+	assert.NotEmpty(t, hdr["kid"], "issued tokens must carry a kid header")
 }


### PR DESCRIPTION
## Summary

- [JWT-SVID §3](https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md#3-jwt-svid-format) says issued tokens SHOULD carry \`typ=JWT\` in the JOSE header. jwx doesn't default it.
- Both ZeroID issuance paths — \`credential.IssueCredential\` (RS256 + ES256 branches) and \`proof.GenerateProofToken\` — were calling \`jwt.Sign\` without setting \`typ\`, so verifiers that distinguish token types by the header saw nothing.
- Sets \`jws.TypeKey = "JWT"\` on the protected headers at all three sites.
- Regression: \`tests/integration/jwt_typ_test.go::TestIssuedTokenHasTypHeader\` decodes the JWS header on tokens from both signing branches (api_key/RS256 and client_credentials/ES256) and asserts \`typ\`.

Side note — \`proof.go\`'s \`jwt.Sign\` previously passed no protected headers at all, so the proof token had no \`kid\` either. This PR fixes only \`typ\` per the issue scope; happy to file a follow-up for the missing \`kid\` if useful.

Fixes #46

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`make test\` passes (full integration suite, ~44s)