### PR TITLE
fix: enforce SPIFFE 2048-byte ID cap at URI construction (§2.4)

### DIFF
--- a/domain/identity.go
+++ b/domain/identity.go
@@ -441,10 +441,28 @@ func GetIdentitySchema() *IdentitySchema {
 	}
 }
 
-// BuildWIMSEURI constructs the WIMSE URI for an identity.
-// Format: spiffe://{domain}/{account_id}/{project_id}/{identity_type}/{external_id}
-func BuildWIMSEURI(wimseDomain, accountID, projectID string, identityType IdentityType, externalID string) string {
-	return fmt.Sprintf("spiffe://%s/%s/%s/%s/%s", wimseDomain, accountID, projectID, identityType, externalID)
+// MaxSPIFFEIDBytes is the SPIFFE §2.4 hard cap. The spec says SPIFFE IDs
+// MUST NOT exceed 2048 bytes. Today's varchar(255) schema caps the
+// assembled URI at ~1080 bytes so this is unreachable through the API
+// surface, but the invariant belongs at the construction site so a future
+// schema relaxation can't silently mint non-conformant SPIFFE IDs.
+const MaxSPIFFEIDBytes = 2048
+
+// ErrSPIFFEIDTooLong is returned by BuildWIMSEURI when the assembled URI
+// exceeds MaxSPIFFEIDBytes. Callers can branch on this with errors.Is to
+// distinguish the cap-exceeded case from generic build failures.
+var ErrSPIFFEIDTooLong = errors.New("SPIFFE ID exceeds maximum length")
+
+// BuildWIMSEURI constructs the WIMSE URI for an identity:
+// spiffe://{domain}/{account_id}/{project_id}/{identity_type}/{external_id}.
+// Returns ErrSPIFFEIDTooLong if the result exceeds MaxSPIFFEIDBytes — once
+// persisted, every downstream system inherits a non-conformant subject claim.
+func BuildWIMSEURI(wimseDomain, accountID, projectID string, identityType IdentityType, externalID string) (string, error) {
+	uri := fmt.Sprintf("spiffe://%s/%s/%s/%s/%s", wimseDomain, accountID, projectID, identityType, externalID)
+	if n := len(uri); n > MaxSPIFFEIDBytes {
+		return "", fmt.Errorf("%w: got %d bytes, max %d: %.64q", ErrSPIFFEIDTooLong, n, MaxSPIFFEIDBytes, uri)
+	}
+	return uri, nil
 }
 
 // ValidateSPIFFEPathSegment rejects values that wouldn't survive a round-trip

--- a/domain/identity_test.go
+++ b/domain/identity_test.go
@@ -1,0 +1,46 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestBuildWIMSEURI_LengthCap pins the SPIFFE §2.4 invariant: any URI that
+// would exceed MaxSPIFFEIDBytes is rejected at construction time, returning
+// ErrSPIFFEIDTooLong so callers can errors.Is. Three cases — happy path, the
+// inclusive boundary at exactly 2048 bytes, and the rejection just past it.
+func TestBuildWIMSEURI_LengthCap(t *testing.T) {
+	// Happy path: a typical URI is well under the cap.
+	uri, err := BuildWIMSEURI("highflame.dev", "acc_test", "proj_test", IdentityTypeAgent, "orchestrator-1")
+	if err != nil {
+		t.Fatalf("happy path returned error: %v", err)
+	}
+	if !strings.HasPrefix(uri, "spiffe://highflame.dev/acc_test/proj_test/agent/") {
+		t.Fatalf("unexpected URI shape: %q", uri)
+	}
+
+	// Inclusive boundary: assemble an external_id that brings the total to
+	// exactly MaxSPIFFEIDBytes. The fixed prefix
+	// "spiffe://highflame.dev/acc/proj/agent/" plus the external_id must
+	// equal 2048 bytes — anything ≤ 2048 must succeed.
+	prefix := "spiffe://highflame.dev/acc/proj/agent/"
+	exactExternalID := strings.Repeat("a", MaxSPIFFEIDBytes-len(prefix))
+	uri, err = BuildWIMSEURI("highflame.dev", "acc", "proj", IdentityTypeAgent, exactExternalID)
+	if err != nil {
+		t.Fatalf("boundary case (exactly %d bytes) returned error: %v", MaxSPIFFEIDBytes, err)
+	}
+	if got, want := len(uri), MaxSPIFFEIDBytes; got != want {
+		t.Fatalf("boundary URI length = %d, want %d", got, want)
+	}
+
+	// Rejection: one byte over the cap must fail with ErrSPIFFEIDTooLong.
+	overExternalID := exactExternalID + "a"
+	_, err = BuildWIMSEURI("highflame.dev", "acc", "proj", IdentityTypeAgent, overExternalID)
+	if err == nil {
+		t.Fatal("URI 1 byte over the cap was accepted; want ErrSPIFFEIDTooLong")
+	}
+	if !errors.Is(err, ErrSPIFFEIDTooLong) {
+		t.Fatalf("error not ErrSPIFFEIDTooLong: %v", err)
+	}
+}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -190,13 +190,18 @@ func (s *IdentityService) RegisterIdentity(ctx context.Context, req RegisterIden
 		return nil, err
 	}
 
+	wimseURI, err := domain.BuildWIMSEURI(s.wimseDomain, req.AccountID, req.ProjectID, req.IdentityType, req.ExternalID)
+	if err != nil {
+		return nil, err
+	}
+
 	identity := &domain.Identity{
 		ID:                 uuid.New().String(),
 		AccountID:          req.AccountID,
 		ProjectID:          req.ProjectID,
 		ExternalID:         req.ExternalID,
 		Name:               req.Name,
-		WIMSEURI:           domain.BuildWIMSEURI(s.wimseDomain, req.AccountID, req.ProjectID, req.IdentityType, req.ExternalID),
+		WIMSEURI:           wimseURI,
 		IdentityType:       req.IdentityType,
 		SubType:            req.SubType,
 		TrustLevel:         req.TrustLevel,


### PR DESCRIPTION
## Summary

- \`domain.BuildWIMSEURI\` was a \`Sprintf\` with no length check, so [SPIFFE §2.4](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE.md#24-maximum-spiffe-id-length) ("MUST NOT exceed 2048 bytes") was unenforced.
- Today's \`varchar(255)\` schema caps the assembled URI at ~1080 bytes, so this isn't reachable through the API surface — but the invariant belongs at the construction site so a future schema relaxation can't silently mint non-conformant SPIFFE IDs.
- Changes \`BuildWIMSEURI\` to return \`(string, error)\`, introduces \`domain.MaxSPIFFEIDBytes = 2048\`, and propagates the error from \`RegisterIdentity\`.
- Three domain tests cover rejection, the happy path, and the inclusive boundary at exactly 2048 bytes.

### Caveat — public API signature change

\`BuildWIMSEURI\` is a top-level \`domain\` function, which \`CONTRIBUTING.md\` calls out as part of the public API. The single in-repo caller is updated; there are no other consumers (\`pkg/authjwt\` does not call it). Surfacing this so the maintainers can decide whether to ship the signature change or wrap with a \`Must\`-style helper.

Fixes #48

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./domain/\` (3 tests: rejection, happy path, inclusive boundary)
- [x] \`make test\` passes (full integration suite, ~42s)