### PR TITLE
fix(jwt-svid): typ header on issued tokens + algorithm allowlist before parse

### DIFF
--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -323,16 +323,21 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	}
 
 	// Sign: RS256 for api_key grant (compatible), ES256 for all agent/NHI flows.
-	// kid is included in the JWS header so verifiers can select the correct key from JWKS.
+	// kid is included in the JWS header so verifiers can select the correct
+	// key from JWKS. typ="JWT" is set per JWT-SVID §3 (and RFC 7519 best
+	// practice) so verifiers that distinguish token types via the JOSE
+	// header can identify these as JWTs without parsing the claim set.
 	var signed []byte
 	var signErr error
 	if req.UseRS256 && s.jwksSvc.HasRSAKeys() {
 		hdrs := jws.NewHeaders()
 		_ = hdrs.Set(jws.KeyIDKey, s.jwksSvc.RSAKeyID())
+		_ = hdrs.Set(jws.TypeKey, "JWT")
 		signed, signErr = jwt.Sign(token, jwt.WithKey(jwa.RS256, s.jwksSvc.RSAPrivateKey(), jws.WithProtectedHeaders(hdrs)))
 	} else {
 		hdrs := jws.NewHeaders()
 		_ = hdrs.Set(jws.KeyIDKey, s.jwksSvc.KeyID())
+		_ = hdrs.Set(jws.TypeKey, "JWT")
 		signed, signErr = jwt.Sign(token, jwt.WithKey(jwa.ES256, s.jwksSvc.PrivateKey(), jws.WithProtectedHeaders(hdrs)))
 	}
 	if signErr != nil {

--- a/internal/signing/jwks.go
+++ b/internal/signing/jwks.go
@@ -64,7 +64,7 @@ func NewJWKSService(privateKeyPath, publicKeyPath, keyID string) (*JWKSService, 
 	}
 
 	keySet := jwk.NewSet()
-	if err := addToKeySet(keySet, pubKey, keyID, jwa.ES256); err != nil {
+	if err := addToKeySet(keySet, pubKey, keyID, jwa.ES256, "sig"); err != nil {
 		return nil, fmt.Errorf("failed to add EC key to JWKS: %w", err)
 	}
 
@@ -120,7 +120,7 @@ func (s *JWKSService) LoadRSAKeys(privateKeyPath, publicKeyPath, keyID string) e
 		return fmt.Errorf("public key is not RSA")
 	}
 
-	if err := addToKeySet(s.keySet, rsaPubKey, keyID, jwa.RS256); err != nil {
+	if err := addToKeySet(s.keySet, rsaPubKey, keyID, jwa.RS256, "sig"); err != nil {
 		return fmt.Errorf("failed to add RSA key to JWKS: %w", err)
 	}
 
@@ -172,8 +172,14 @@ func (s *JWKSService) KeySet() jwk.Set {
 	return s.keySet
 }
 
-// addToKeySet creates a JWK from a public key and adds it to the set.
-func addToKeySet(set jwk.Set, pubKey crypto.PublicKey, keyID string, alg jwa.SignatureAlgorithm) error {
+// addToKeySet creates a JWK from a public key and adds it to the set. The
+// use parameter is set verbatim. All current callers pass "sig" because
+// lestrrat-go/jwx's WithKeySet rejects keys with use != "" or "sig"
+// (AlgorithmsForKey check). The SPIFFE JWT-SVID §6 value "JWT-SVID" is the
+// spec-correct label for ES256 signers; we'd need to either patch jwx or
+// switch to manual key resolution before publishing it. Tracked as the
+// jwx-compatibility blocker on issue #43.
+func addToKeySet(set jwk.Set, pubKey crypto.PublicKey, keyID string, alg jwa.SignatureAlgorithm, use string) error {
 	jwkKey, err := jwk.FromRaw(pubKey)
 	if err != nil {
 		return fmt.Errorf("failed to create JWK from public key: %w", err)
@@ -184,7 +190,7 @@ func addToKeySet(set jwk.Set, pubKey crypto.PublicKey, keyID string, alg jwa.Sig
 	if err := jwkKey.Set(jwk.AlgorithmKey, alg); err != nil {
 		return fmt.Errorf("failed to set algorithm: %w", err)
 	}
-	if err := jwkKey.Set(jwk.KeyUsageKey, jwk.ForSignature); err != nil {
+	if err := jwkKey.Set(jwk.KeyUsageKey, use); err != nil {
 		return fmt.Errorf("failed to set key usage: %w", err)
 	}
 	if err := set.AddKey(jwkKey); err != nil {

--- a/pkg/authjwt/verifier.go
+++ b/pkg/authjwt/verifier.go
@@ -131,6 +131,17 @@ func (v *Verifier) verify(ctx context.Context, tokenString string) (*Claims, err
 		return nil, ErrNoKeySet
 	}
 
+	// JWT-SVID §3 requires explicit algorithm allowlisting BEFORE the token
+	// is handed to the JWT library. Peeking the JOSE header first means a
+	// token with alg=none or HS256 is rejected at the JWS layer, before any
+	// parse logic runs that might inadvertently trust header/claim data.
+	// This is defense-in-depth: lestrrat-go/jwx already enforces alg via
+	// WithKeySet's key-type matching, but we don't rely on that — we
+	// reject up front against our own allowlist.
+	if err := v.checkAlgorithm(tokenString); err != nil {
+		return nil, err
+	}
+
 	// Parse and validate in one step. WithKeySet uses kid+alg to select the key.
 	parseOpts := []jwt.ParseOption{
 		jwt.WithKeySet(keySet),
@@ -158,17 +169,14 @@ func (v *Verifier) verify(ctx context.Context, tokenString string) (*Claims, err
 		return nil, fmt.Errorf("%w: %v", ErrInvalidToken, err)
 	}
 
-	// Verify the algorithm is in our allowlist.
-	if err := v.checkAlgorithm(tokenString); err != nil {
-		return nil, err
-	}
-
 	return extractClaims(token), nil
 }
 
-// checkAlgorithm parses the JWS header to verify the algorithm is allowed.
-// This is defense-in-depth — lestrrat-go/jwx already validates the signature
-// against the key type, but we explicitly reject unexpected algorithms.
+// checkAlgorithm peeks the JWS header to verify the algorithm is in the
+// allowlist. Called BEFORE jwt.Parse so unsupported algorithms (alg=none,
+// HS256, etc.) are rejected without ever exercising the parse pipeline,
+// per JWT-SVID §3. lestrrat-go/jwx's WithKeySet would catch most of these
+// downstream — peeking up front is defense-in-depth, not a substitute.
 func (v *Verifier) checkAlgorithm(tokenString string) error {
 	msg, err := jws.Parse([]byte(tokenString))
 	if err != nil {

--- a/pkg/authjwt/verifier_test.go
+++ b/pkg/authjwt/verifier_test.go
@@ -6,7 +6,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -269,6 +271,59 @@ func TestVerifyGarbageToken(t *testing.T) {
 	_, err := v.Verify(context.Background(), "not.a.jwt")
 	if err == nil {
 		t.Fatal("expected error for garbage token")
+	}
+}
+
+// TestVerifyRejectsAlgNone covers the JWT-SVID §3 / RFC 7519 §6 requirement
+// that `alg: none` MUST be rejected by any compliant verifier. The token is
+// hand-crafted (no library will sign one for you) to guarantee the JOSE
+// header carries alg=none. Pre-fix #45, this would have been parsed by
+// jwt.Parse first; after #45, the alg peek rejects it before any parse logic
+// touches the token.
+func TestVerifyRejectsAlgNone(t *testing.T) {
+	ks := newTestKeySet(t)
+	v := newVerifier(t, ks, "")
+
+	// Build  base64url(header).base64url(payload).  with empty signature.
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"attacker","iss":"https://auth.test.com"}`))
+	token := header + "." + payload + "."
+
+	_, err := v.Verify(context.Background(), token)
+	if err == nil {
+		t.Fatal("alg=none token MUST be rejected (JWT-SVID §3)")
+	}
+	if !errors.Is(err, authjwt.ErrUnsupportedAlg) {
+		t.Errorf("expected ErrUnsupportedAlg, got: %v", err)
+	}
+}
+
+// TestVerifyRejectsHS256 covers the HS256-confusion attack class: an
+// attacker signs with HS256 using the RSA public key as the HMAC secret,
+// hoping a verifier that doesn't pin the algorithm will accept it. The
+// alg-peek added in #45 rejects HS256 outright before any signature
+// verification runs.
+func TestVerifyRejectsHS256(t *testing.T) {
+	ks := newTestKeySet(t)
+	v := newVerifier(t, ks, "")
+
+	// Sign with HS256 using an arbitrary symmetric secret. The actual key
+	// material doesn't matter — verifier.Verify must reject before checking
+	// the signature.
+	tok := jwt.New()
+	_ = tok.Set(jwt.IssuerKey, "https://auth.test.com")
+	_ = tok.Set(jwt.SubjectKey, "attacker")
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256, []byte("any-symmetric-key-will-do")))
+	if err != nil {
+		t.Fatalf("sign HS256: %v", err)
+	}
+
+	_, err = v.Verify(context.Background(), string(signed))
+	if err == nil {
+		t.Fatal("HS256 token MUST be rejected to prevent algorithm-confusion attacks")
+	}
+	if !errors.Is(err, authjwt.ErrUnsupportedAlg) {
+		t.Errorf("expected ErrUnsupportedAlg, got: %v", err)
 	}
 }
 

--- a/tests/integration/jwt_svid_typ_header_test.go
+++ b/tests/integration/jwt_svid_typ_header_test.go
@@ -1,0 +1,92 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssuedES256TokenHasTypHeader verifies that ES256 NHI tokens issued via
+// client_credentials carry typ="JWT" in the JOSE header per JWT-SVID §3 (and
+// RFC 7519 best practice). Verifiers that distinguish token kinds via the
+// header — including some SPIFFE-aware verifiers — rely on this signal.
+func TestIssuedES256TokenHasTypHeader(t *testing.T) {
+	agentID := uid("typ-header-es256")
+	scopes := []string{"data:read"}
+
+	registerIdentity(t, agentID, scopes)
+	client := registerOAuthClient(t, agentID, scopes)
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	accessToken := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	assertTypHeaderJWT(t, accessToken)
+}
+
+// TestIssuedRS256TokenHasTypHeader verifies that RS256 SDK/human-flow tokens
+// (api_key grant) also carry typ="JWT". Same spec requirement, separate code
+// path inside CredentialService.IssueCredential.
+func TestIssuedRS256TokenHasTypHeader(t *testing.T) {
+	headers := adminHeaders()
+	headers["X-User-ID"] = "test-user"
+
+	createResp := post(t, adminPath("/api-keys"), map[string]any{
+		"name":    "typ-header-rs256",
+		"product": "typ-header-rs256-product",
+	}, headers)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	apiKey := decode(t, createResp)["key"].(string)
+	require.NotEmpty(t, apiKey, "api-key creation must return the full key once")
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	accessToken := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	assertTypHeaderJWT(t, accessToken)
+}
+
+// assertTypHeaderJWT decodes the JOSE header of a JWT and asserts the typ
+// parameter is "JWT". Uses jws.Parse so the assertion is exact (rather than
+// a substring scan that could pick up "JWT" from base64-encoded payload).
+func assertTypHeaderJWT(t *testing.T, token string) {
+	t.Helper()
+	msg, err := jws.Parse([]byte(token))
+	require.NoError(t, err, "JWT must be a parseable JWS")
+	sigs := msg.Signatures()
+	require.NotEmpty(t, sigs, "JWS must have at least one signature")
+
+	hdr := sigs[0].ProtectedHeaders()
+	require.NotNil(t, hdr, "JWS must have protected headers")
+
+	typ := hdr.Type()
+	assert.Equalf(t, "JWT", typ,
+		"JOSE header must declare typ=JWT (JWT-SVID §3); got %q (full token: %s…)",
+		typ, truncate(token, 32))
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return strings.TrimRight(s[:n], "=") + "…"
+}


### PR DESCRIPTION
Two JWT-SVID §3 compliance gaps in the issuance + verification paths.

## #46 — typ JOSE header on issued tokens

Issued JWTs lacked the `typ="JWT"` JOSE header, breaking spec-compliant verifiers that distinguish token kinds via the header without parsing claims. Set `typ="JWT"` on the protected header for both the ES256 path (NHI/agent flows) and the RS256 path (api_key SDK/human flows).

## #45 — algorithm allowlist BEFORE jwt.Parse

The Verifier already pinned the allowlist to `{RS256, ES256}` via `checkAlgorithm()`, but the check ran AFTER `jwt.Parse`. JWT-SVID §3 requires the alg peek to happen first so a token with `alg=none` or an HS256-confusion attempt is rejected at the JWS layer before any parse logic touches it. Moved the call earlier in `verify()`; the allowlist itself is unchanged.

## Tests

- `pkg/authjwt`: `TestVerifyRejectsAlgNone`, `TestVerifyRejectsHS256`
- `tests/integration`: `TestIssuedES256TokenHasTypHeader`, `TestIssuedRS256TokenHasTypHeader`

## Sibling issues — status

- **#42** (default `aud` to issuer) — already fixed by PR #85; not part of this PR.
- **#43** (`use="JWT-SVID"` on JWKS) — **deferred**. lestrrat-go/jwx v2's `AlgorithmsForKey` rejects keys with `use != "" or "sig"`, which would break our own `pkg/authjwt` verifier and every Go consumer of our JWKS. Tracked as a jwx-compatibility blocker on #43; the `addToKeySet` helper now takes a `use` parameter so the eventual fix is a one-line change at each call site once we upgrade jwx (next PR).

## Test plan

- [x] `go test ./...` (full integration suite) — green
- [x] `go test ./...` in `pkg/authjwt/` — green
- [x] `go vet ./...` — clean
- [x] Rebased onto current `main` (post #93 merge); replays cleanly as a single commit.