### PR TITLE
refactor: go fix ./... — modernize to Go 1.25 idioms

### DIFF
--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -238,10 +238,7 @@ func (a *API) listIdentitiesOp(ctx context.Context, input *ListIdentitiesInput) 
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
-	offset := input.Offset
-	if offset < 0 {
-		offset = 0
-	}
+	offset := max(input.Offset, 0)
 
 	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, limit, offset)
 	if err != nil {

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -19,17 +19,17 @@ type AuditLogFilter struct {
 // AuditLogResponse is the wire type for audit log entries returned to clients.
 // It matches the AuditLog interface in packages/registry/src/types.ts.
 type AuditLogResponse struct {
-	AuditID     string                 `json:"audit_id"`
-	AccountID   string                 `json:"account_id"`
-	TableName   string                 `json:"table_name"`
-	Action      string                 `json:"action"`
-	Status      string                 `json:"status"`
-	UserID      string                 `json:"user_id"`
-	Timestamp   string                 `json:"timestamp"`
-	OldData     map[string]interface{} `json:"old_data"`
-	NewData     map[string]interface{} `json:"new_data"`
-	ChangedData interface{}            `json:"changed_data"`
-	EntityName  string                 `json:"entity_name"`
+	AuditID     string         `json:"audit_id"`
+	AccountID   string         `json:"account_id"`
+	TableName   string         `json:"table_name"`
+	Action      string         `json:"action"`
+	Status      string         `json:"status"`
+	UserID      string         `json:"user_id"`
+	Timestamp   string         `json:"timestamp"`
+	OldData     map[string]any `json:"old_data"`
+	NewData     map[string]any `json:"new_data"`
+	ChangedData any            `json:"changed_data"`
+	EntityName  string         `json:"entity_name"`
 }
 
 // AuditService handles audit log queries.
@@ -55,7 +55,7 @@ func (s *AuditService) ListAuditLogs(ctx context.Context, accountID, projectID s
 }
 
 func toAuditLogResponse(e postgres.AuditLogEntry) AuditLogResponse {
-	var oldData, newData map[string]interface{}
+	var oldData, newData map[string]any
 	if len(e.OldData) > 0 {
 		_ = json.Unmarshal(e.OldData, &oldData)
 	}

--- a/internal/service/authcode.go
+++ b/internal/service/authcode.go
@@ -69,7 +69,7 @@ func decodeAuthCodeJWT(code, hmacSecret, expectedIssuer string) (*AuthCodeClaims
 
 	// Extract scopes array.
 	if scopesRaw, ok := token.Get("scp"); ok {
-		if scopes, ok := scopesRaw.([]interface{}); ok {
+		if scopes, ok := scopesRaw.([]any); ok {
 			for _, s := range scopes {
 				if str, ok := s.(string); ok {
 					claims.Scopes = append(claims.Scopes, str)

--- a/internal/service/credential_policy.go
+++ b/internal/service/credential_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -261,7 +262,7 @@ func (s *CredentialPolicyService) EnforcePolicy(ctx context.Context, policy *dom
 
 	// 2. Grant type in policy.allowed_grant_types (normalize for comparison)
 	normalizedGT := string(domain.NormalizeGrantType(string(req.GrantType)))
-	if !containsString(policy.AllowedGrantTypes, normalizedGT) {
+	if !slices.Contains(policy.AllowedGrantTypes, normalizedGT) {
 		return fmt.Errorf("%w: grant type %q is not permitted by policy (allowed: %v)", ErrPolicyViolation, req.GrantType, policy.AllowedGrantTypes)
 	}
 
@@ -431,13 +432,4 @@ func normalizeGrantTypes(gts []string) []string {
 		out[i] = string(domain.NormalizeGrantType(gt))
 	}
 	return out
-}
-
-func containsString(slice []string, s string) bool {
-	for _, v := range slice {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -197,13 +198,7 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 	}
 
 	// Ensure client_credentials grant is permitted.
-	allowed := false
-	for _, gt := range client.GrantTypes {
-		if gt == "client_credentials" {
-			allowed = true
-			break
-		}
-	}
+	allowed := slices.Contains(client.GrantTypes, "client_credentials")
 	if !allowed {
 		return nil, oauthBadRequest("unauthorized_client", "client not authorized for client_credentials grant")
 	}
@@ -750,13 +745,7 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 	}
 
 	// Verify the client is authorised to use the authorization_code grant.
-	grantAllowed := false
-	for _, g := range oauthClient.GrantTypes {
-		if g == string(domain.GrantTypeAuthorizationCode) {
-			grantAllowed = true
-			break
-		}
-	}
+	grantAllowed := slices.Contains(oauthClient.GrantTypes, string(domain.GrantTypeAuthorizationCode))
 	if !grantAllowed {
 		return nil, oauthBadRequest("unauthorized_client", "client is not authorized for authorization_code grant")
 	}
@@ -797,13 +786,7 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 
 	// Determine access token TTL.
 	// Priority: per-client config > grant-type-based default > server default.
-	hasRefreshGrant := false
-	for _, g := range oauthClient.GrantTypes {
-		if g == string(domain.GrantTypeRefreshToken) {
-			hasRefreshGrant = true
-			break
-		}
-	}
+	hasRefreshGrant := slices.Contains(oauthClient.GrantTypes, string(domain.GrantTypeRefreshToken))
 
 	ttl := oauthClient.AccessTokenTTL
 	if ttl <= 0 {

--- a/pkg/authjwt/claims.go
+++ b/pkg/authjwt/claims.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -57,7 +58,7 @@ type Claims struct {
 	// Custom holds any additional claims not mapped to typed fields.
 	// Consuming services can use this for deployment-specific claims
 	// (e.g., application_id, gateway_id, product, user_email).
-	Custom map[string]interface{} `json:"-"`
+	Custom map[string]any `json:"-"`
 }
 
 // ActorClaims represents the "act" claim in a delegated token (RFC 8693).
@@ -84,7 +85,7 @@ func (c *Claims) GetCustomString(key string) string {
 }
 
 // GetCustom returns a custom claim value as interface{}.
-func (c *Claims) GetCustom(key string) (interface{}, bool) {
+func (c *Claims) GetCustom(key string) (any, bool) {
 	if c.Custom == nil {
 		return nil, false
 	}
@@ -94,12 +95,7 @@ func (c *Claims) GetCustom(key string) (interface{}, bool) {
 
 // HasScope returns true if the token's scopes include the given scope.
 func (c *Claims) HasScope(scope string) bool {
-	for _, s := range c.Scopes {
-		if s == scope {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.Scopes, scope)
 }
 
 // RequireScope returns ErrInsufficientScope if the token does not have the
@@ -230,7 +226,7 @@ func extractClaims(token jwt.Token) *Claims {
 		switch s := v.(type) {
 		case []string:
 			return s
-		case []interface{}:
+		case []any:
 			result := make([]string, 0, len(s))
 			for _, item := range s {
 				if str, ok := item.(string); ok {
@@ -289,7 +285,7 @@ func extractClaims(token jwt.Token) *Claims {
 	}
 
 	// Collect all unrecognized claims into Custom for deployment-specific use.
-	c.Custom = make(map[string]interface{})
+	c.Custom = make(map[string]any)
 	for iter := token.Iterate(context.Background()); iter.Next(context.Background()); {
 		pair := iter.Pair()
 		key, ok := pair.Key.(string)
@@ -307,9 +303,9 @@ func extractClaims(token jwt.Token) *Claims {
 	return c
 }
 
-func parseActorClaims(raw interface{}) *ActorClaims {
+func parseActorClaims(raw any) *ActorClaims {
 	switch v := raw.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		act := &ActorClaims{}
 		if sub, ok := v["sub"].(string); ok {
 			act.Subject = sub

--- a/pkg/authjwt/verifier_test.go
+++ b/pkg/authjwt/verifier_test.go
@@ -75,7 +75,7 @@ func makeHeaders(kid string) jws.Headers {
 	return h
 }
 
-func (ks *testKeySet) signES256(t *testing.T, claims map[string]interface{}) string {
+func (ks *testKeySet) signES256(t *testing.T, claims map[string]any) string {
 	t.Helper()
 	token := jwt.New()
 	for k, v := range claims {
@@ -88,7 +88,7 @@ func (ks *testKeySet) signES256(t *testing.T, claims map[string]interface{}) str
 	return string(signed)
 }
 
-func (ks *testKeySet) signRS256(t *testing.T, claims map[string]interface{}) string {
+func (ks *testKeySet) signRS256(t *testing.T, claims map[string]any) string {
 	t.Helper()
 	token := jwt.New()
 	for k, v := range claims {
@@ -101,9 +101,9 @@ func (ks *testKeySet) signRS256(t *testing.T, claims map[string]interface{}) str
 	return string(signed)
 }
 
-func baseClaims(issuer string) map[string]interface{} {
+func baseClaims(issuer string) map[string]any {
 	now := time.Now()
-	return map[string]interface{}{
+	return map[string]any{
 		"iss":        issuer,
 		"sub":        "user-123",
 		"aud":        []string{"https://shield.example.com"},
@@ -116,7 +116,7 @@ func baseClaims(issuer string) map[string]interface{} {
 	}
 }
 
-func agentClaims(issuer string) map[string]interface{} {
+func agentClaims(issuer string) map[string]any {
 	c := baseClaims(issuer)
 	c["external_id"] = "agent-smith"
 	c["identity_type"] = "agent"
@@ -127,7 +127,7 @@ func agentClaims(issuer string) map[string]interface{} {
 	c["publisher"] = "acme-corp"
 	c["capabilities"] = []string{"read_file", "call_tool"}
 	c["delegation_depth"] = 1
-	c["act"] = map[string]interface{}{
+	c["act"] = map[string]any{
 		"sub": "orchestrator-1",
 		"iss": issuer,
 	}

--- a/tests/integration/attestation_oidc_test.go
+++ b/tests/integration/attestation_oidc_test.go
@@ -388,14 +388,14 @@ func TestAttestationPolicyUpsertIsConcurrencySafe(t *testing.T) {
 			"issuers": []map[string]any{{"url": iss.URL}},
 		},
 	}
-	for i := 0; i < parallelism; i++ {
+	for range parallelism {
 		go func() {
 			resp := doRequest(t, http.MethodPut, adminPath("/attestation-policies"), body, tenant)
 			_ = resp.Body.Close()
 			results <- resp.StatusCode
 		}()
 	}
-	for i := 0; i < parallelism; i++ {
+	for range parallelism {
 		status := <-results
 		assert.Equal(t, http.StatusOK, status,
 			"every concurrent upsert must succeed; atomic INSERT ... ON CONFLICT has no race window")

--- a/tests/integration/deactivation_test.go
+++ b/tests/integration/deactivation_test.go
@@ -108,7 +108,7 @@ func TestDeactivationRevokesExistingCredentials(t *testing.T) {
 
 	// Mint two tokens so we can verify both get swept on deactivation.
 	tokens := make([]string, 0, 2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		r := post(t, "/oauth2/token", map[string]any{
 			"grant_type": "api_key",
 			"api_key":    reg.APIKey,

--- a/tests/integration/identity_test.go
+++ b/tests/integration/identity_test.go
@@ -410,7 +410,7 @@ func TestListAgentsPagination(t *testing.T) {
 	paginationLabel := uid("page")
 
 	// Register 5 agents with a unique label.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		post(t, adminPath("/agents/register"), map[string]any{
 			"external_id":   uid(fmt.Sprintf("page-%d", i)),
 			"identity_type": "agent",

--- a/tests/integration/refresh_token_race_test.go
+++ b/tests/integration/refresh_token_race_test.go
@@ -56,10 +56,8 @@ func TestRefreshTokenConcurrentRotation(t *testing.T) {
 	)
 	start := make(chan struct{})
 
-	for i := 0; i < concurrency; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range concurrency {
+		wg.Go(func() {
 			<-start
 			status, body := rotateRaw(t, refreshToken)
 			if status == http.StatusOK {
@@ -76,7 +74,7 @@ func TestRefreshTokenConcurrentRotation(t *testing.T) {
 			} else {
 				atomic.AddInt32(&failures, 1)
 			}
-		}()
+		})
 	}
 
 	close(start)


### PR DESCRIPTION
## Summary

Mechanical output of `go fix ./...` on both the root module and `pkg/authjwt`. Five categories of pure-form modernization to Go 1.21–1.25 idioms. **No API or semantic changes.** Net code reduction: 11 files, +41/−71.

## What changed

| Pattern                                                                                      | Before → After                    | Sites                                                                                                                                                                                                                   |
| -------------------------------------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **`interface{}` → `any`** _(Go 1.18+)_                                                       | type-alias modernization          | `internal/service/{audit,authcode}.go`, `pkg/authjwt/{claims,verifier_test}.go`                                                                                                                                         |
| **`for i := 0; i < N; i++` → `for range N`** _(Go 1.22+)_                                    | integer-range loops               | `tests/integration/{attestation_oidc,deactivation,identity,refresh_token_race}_test.go`                                                                                                                                 |
| **manual loop → `slices.Contains`** _(Go 1.21+)_                                             | adds `"slices"` import in 3 files | `internal/service/credential_policy.go::containsString`, `internal/service/oauth.go` (3 sites: `client_credentials` / `authorization_code` / `refresh_token` grant-allowlist checks), `pkg/authjwt/claims.go::HasScope` |
| **`if x < 0 { x = 0 }` → `max(x, 0)`** _(Go 1.21+ builtins)_                                 | offset clamp                      | `internal/handler/identity.go::listIdentitiesOp`                                                                                                                                                                        |
| **`wg.Add(1) + go func() { defer wg.Done(); ... }()` → `wg.Go(func() { ... })`** _(Go 1.25)_ | new `WaitGroup.Go` method         | `tests/integration/refresh_token_race_test.go::TestRefreshTokenConcurrentRotation`                                                                                                                                      |

The `slices.Contains` swaps add `"slices"` to imports in three files — no other import changes.

## Test plan

- [x] `go vet ./...` — clean (root + `pkg/authjwt`)
- [x] `go test ./... -count=1 -timeout=180s` — green, ~9.8s
- [x] No semantic changes — pure mechanical output of `go fix`

## Scope and ordering

- **Independent of #114 and #115.** Either order can merge; the only file overlap with #114 (jwx v2 → v4) is `pkg/authjwt/claims.go`. Both edits are mechanical (`go fix` here changes `interface{}` → `any` + `slices.Contains`; #114 changes the v4 token accessors). Whichever lands second needs a small rebase.
- **Mergeable on Go 1.25.8** (the current `GO_VER`). The `wg.Go` change requires Go 1.25 which the repo's already on.

## Why this is worth doing

- Removes language-version-tax noise from future diffs (every `interface{}` you see in a future PR review will now be there because someone wrote it post-fix, not because it predates the alias).
- `slices.Contains` is more grep-able than ad-hoc loops and harder to get subtly wrong.
- `wg.Go` removes the `Add(1)` / `defer Done()` pairing footgun in concurrent test code.
- `for range N` matches what the project already uses for newer code; consistency.
