### PR TITLE
fix: drop unused oauth_tokens table from 003 (closes #97)

### DIFF
--- a/migrations/003_oauth_clients.down.sql
+++ b/migrations/003_oauth_clients.down.sql
@@ -1,12 +1,5 @@
 -- 003_oauth_clients.down.sql
 -- Reverses 003_oauth_clients.up.sql
--- Drop oauth_tokens first (references oauth_clients.client_id)
-
-DROP INDEX IF EXISTS idx_oauth_tokens_tenant;
-DROP INDEX IF EXISTS idx_oauth_tokens_expires_at;
-DROP INDEX IF EXISTS idx_oauth_tokens_client_id;
-DROP INDEX IF EXISTS idx_oauth_tokens_jti;
-DROP TABLE IF EXISTS oauth_tokens;
 
 DROP INDEX IF EXISTS idx_oauth_clients_client_id;
 DROP TABLE IF EXISTS oauth_clients;

--- a/migrations/003_oauth_clients.up.sql
+++ b/migrations/003_oauth_clients.up.sql
@@ -1,5 +1,5 @@
 -- 003_oauth_clients.up.sql
--- Creates oauth_clients and oauth_tokens tables
+-- Creates the oauth_clients table.
 
 CREATE TABLE IF NOT EXISTS oauth_clients (
     id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -46,31 +46,3 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_oauth_clients_client_id
     ON oauth_clients (client_id);
-
-CREATE TABLE IF NOT EXISTS oauth_tokens (
-    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    client_id     VARCHAR(255) NOT NULL,
-    account_id    VARCHAR(255) NOT NULL,
-    project_id    VARCHAR(255) NOT NULL,
-    identity_id   UUID REFERENCES identities(id) ON DELETE SET NULL,
-    jti           VARCHAR(255) NOT NULL UNIQUE,
-    token_type    VARCHAR(50) NOT NULL DEFAULT 'Bearer',
-    scopes        TEXT[] NOT NULL DEFAULT '{}',
-    issued_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    expires_at    TIMESTAMPTZ NOT NULL,
-    is_revoked    BOOLEAN NOT NULL DEFAULT FALSE,
-    revoked_at    TIMESTAMPTZ,
-    grant_type    VARCHAR(50) NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_oauth_tokens_jti
-    ON oauth_tokens (jti);
-
-CREATE INDEX IF NOT EXISTS idx_oauth_tokens_client_id
-    ON oauth_tokens (client_id);
-
-CREATE INDEX IF NOT EXISTS idx_oauth_tokens_expires_at
-    ON oauth_tokens (expires_at);
-
-CREATE INDEX IF NOT EXISTS idx_oauth_tokens_tenant
-    ON oauth_tokens (account_id, project_id);


### PR DESCRIPTION
## Summary

Closes #97. Removes the never-wired `oauth_tokens` table directly from `migrations/003_oauth_clients.up.sql` (and the matching `DROP` statements from the down file), instead of layering a separate drop migration on top.

## Approach changed mid-PR (per @saucam's review)

The original commit added `015_drop_oauth_tokens.{up,down}.sql`. Saucam asked: *"can we just drop these directly without adding a new migration?"* — and in this case, **yes**: ZeroID has not been deployed to any persistent environment yet, so every install runs migrations from scratch on the current SQL. Editing `003` in place produces the same end state everywhere.

If/when a real deployment exists, future cleanups of unused tables MUST use the layered-migration pattern. Migration files become append-only the moment any deployment runs them, because `schema_migrations.version` says "this version was applied" while the actual rows behave however the contemporaneous SQL dictated. Two deployments at the same `migration_version` with different SQL = silent schema divergence.

## Diff

- `migrations/003_oauth_clients.up.sql` — removed the `CREATE TABLE oauth_tokens` block and its four `CREATE INDEX` statements (`idx_oauth_tokens_jti`, `_client_id`, `_expires_at`, `_tenant`). Header comment updated.
- `migrations/003_oauth_clients.down.sql` — removed the corresponding `DROP INDEX` / `DROP TABLE` statements.

Net: `2 files changed, 1 insertion(+), 36 deletions(-)`.

## Verified

```
$ grep -rn "oauth_tokens" --include="*.go" .
$ grep -rn "OauthToken\|OAuthToken" domain/ internal/
```

Zero hits in either. No Go domain model binds to the table; no repository references it.

## Test plan

- [x] `go vet ./...` — clean
- [x] Full integration suite green ~10s. Migrations run fresh in the testcontainer on every test run, so this exercises the trimmed 003 end-to-end (no `oauth_tokens` is ever created).