### PR TITLE
feat: mission_id as a first-class delegation-tree identifier (closes #81)

### DIFF
--- a/domain/credential.go
+++ b/domain/credential.go
@@ -83,4 +83,10 @@ type IssuedCredential struct {
 	ParentJTI       string     `bun:"parent_jti,type:varchar(255)"  json:"parent_jti,omitempty"`
 	// DelegatedByWIMSEURI records the orchestrator that delegated authority (RFC 8693 token_exchange).
 	DelegatedByWIMSEURI string `bun:"delegated_by_wimse_uri,type:text" json:"delegated_by_wimse_uri,omitempty"`
+	// MissionID is a stable, opaque identifier for a delegation tree —
+	// equal to the root credential's JTI today; consumers MUST treat it
+	// as opaque so the population scheme can evolve. Denormalised onto
+	// every credential in the tree so workflow-scoped audit queries are
+	// O(1) instead of walking the parent_jti chain. Issue #81.
+	MissionID string `bun:"mission_id,type:varchar(255),nullzero" json:"mission_id,omitempty"`
 }

--- a/domain/signal.go
+++ b/domain/signal.go
@@ -69,4 +69,7 @@ type CAESignal struct {
 	Payload     map[string]any `bun:"payload,type:jsonb" json:"payload,omitempty"`
 	ProcessedAt *time.Time     `bun:"processed_at" json:"processed_at,omitempty"`
 	CreatedAt   time.Time      `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
+	// MissionID groups this signal under the same delegation-tree
+	// identifier as the credentials it relates to. Opaque value (issue #81).
+	MissionID string `bun:"mission_id,type:varchar(255),nullzero" json:"mission_id,omitempty"`
 }

--- a/internal/handler/credential.go
+++ b/internal/handler/credential.go
@@ -41,7 +41,13 @@ type CredentialOutput struct {
 }
 
 type CredentialListInput struct {
-	IdentityID string `query:"identity_id" required:"true" doc:"Filter by identity UUID"`
+	// Either IdentityID or MissionID must be supplied. IdentityID returns
+	// every credential held by an identity. MissionID returns every
+	// credential in a delegation tree (issue #81), ordered by
+	// delegation_depth ASC then created_at ASC so the chain reads from
+	// root to leaves.
+	IdentityID string `query:"identity_id" doc:"Filter by identity UUID"`
+	MissionID  string `query:"mission_id"  doc:"Filter by mission_id (delegation-tree-scoped opaque identifier; see issue #81)"`
 }
 
 type CredentialListOutput struct {
@@ -167,9 +173,25 @@ func (a *API) listCredentialsOp(ctx context.Context, input *CredentialListInput)
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	creds, err := a.credSvc.ListCredentials(ctx, input.IdentityID, tenant.AccountID, tenant.ProjectID)
+	hasIdentity := input.IdentityID != ""
+	hasMission := input.MissionID != ""
+	if hasIdentity == hasMission {
+		// Either both empty (no filter — refuse to dump every credential)
+		// or both set (ambiguous intent).
+		return nil, huma.Error400BadRequest("exactly one of identity_id or mission_id is required")
+	}
+
+	var creds []*domain.IssuedCredential
+	if hasMission {
+		creds, err = a.credSvc.ListCredentialsByMission(ctx, input.MissionID, tenant.AccountID, tenant.ProjectID)
+	} else {
+		creds, err = a.credSvc.ListCredentials(ctx, input.IdentityID, tenant.AccountID, tenant.ProjectID)
+	}
 	if err != nil {
-		log.Error().Err(err).Str("identity_id", input.IdentityID).Msg("failed to list credentials")
+		log.Error().Err(err).
+			Str("identity_id", input.IdentityID).
+			Str("mission_id", input.MissionID).
+			Msg("failed to list credentials")
 		return nil, huma.Error500InternalServerError("failed to list credentials")
 	}
 

--- a/internal/handler/signal.go
+++ b/internal/handler/signal.go
@@ -33,6 +33,10 @@ type SignalOutput struct {
 
 type SignalListInput struct {
 	Limit int `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Maximum number of signals to return"`
+	// MissionID, when set, narrows the result to signals carrying the
+	// same delegation-tree-scoped identifier (issue #81). When empty, the
+	// default "recent N signals across the tenant" list is returned.
+	MissionID string `query:"mission_id" doc:"Filter by mission_id (delegation-tree-scoped opaque identifier)"`
 }
 
 type SignalListOutput struct {
@@ -113,9 +117,17 @@ func (a *API) listSignalsOp(ctx context.Context, input *SignalListInput) (*Signa
 		limit = 50
 	}
 
-	signals, err := a.signalSvc.ListSignals(ctx, tenant.AccountID, tenant.ProjectID, limit)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to list signals")
+	var (
+		signals []*domain.CAESignal
+		err2    error
+	)
+	if input.MissionID != "" {
+		signals, err2 = a.signalSvc.ListSignalsByMission(ctx, input.MissionID, tenant.AccountID, tenant.ProjectID)
+	} else {
+		signals, err2 = a.signalSvc.ListSignals(ctx, tenant.AccountID, tenant.ProjectID, limit)
+	}
+	if err2 != nil {
+		log.Error().Err(err2).Str("mission_id", input.MissionID).Msg("failed to list signals")
 		return nil, huma.Error500InternalServerError("failed to list signals")
 	}
 

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -100,6 +100,12 @@ type IssueRequest struct {
 	// min(CredentialExpiresAt, Identity.ExpiresAt) so the JWT exp never
 	// outlives the authority. Nil means "no per-credential bound."
 	CredentialExpiresAt *time.Time
+	// MissionID is the delegation-tree-scoped opaque identifier (issue #81).
+	// Empty on first issuance — IssueCredential will default it to the new
+	// credential's own JTI (this credential becomes the root of a new
+	// mission). Non-empty on token_exchange — the caller has resolved the
+	// subject_token's mission and is propagating it down the chain.
+	MissionID string
 }
 
 // ErrScopesNotAllowed is returned when one or more requested scopes are not in the identity's AllowedScopes list.
@@ -293,6 +299,16 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	expiresAt := now.Add(time.Duration(ttl) * time.Second)
 	jti := uuid.New().String()
 
+	// Resolve mission_id (issue #81). Caller (token_exchange) propagates it
+	// from the subject_token; first-issuance grants leave it empty and we
+	// default to this credential's own JTI — making this credential the
+	// root of a new delegation tree. The value is opaque to consumers; the
+	// "happens to be a JTI" detail must not leak through any API.
+	missionID := req.MissionID
+	if missionID == "" {
+		missionID = jti
+	}
+
 	// Build JWT
 	token := jwt.New()
 	_ = token.Set(jwt.IssuerKey, s.issuer)
@@ -307,6 +323,7 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	_ = token.Set("account_id", req.Identity.AccountID)
 	_ = token.Set("project_id", req.Identity.ProjectID)
 	_ = token.Set("grant_type", string(req.GrantType))
+	_ = token.Set("mission_id", missionID)
 
 	// Identity claims.
 	_ = token.Set("external_id", req.Identity.ExternalID)
@@ -417,6 +434,7 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 		DelegationDepth:     req.DelegationDepth,
 		ParentJTI:           req.ParentJTI,
 		DelegatedByWIMSEURI: req.DelegatedBy,
+		MissionID:           missionID,
 	}
 
 	if err := s.repo.Create(ctx, cred); err != nil {
@@ -426,6 +444,7 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	log.Info().
 		Str("jti", jti).
 		Str("identity_id", req.Identity.ID).
+		Str("mission_id", missionID).
 		Int("ttl_seconds", ttl).
 		Msg("Credential issued")
 
@@ -449,6 +468,14 @@ func (s *CredentialService) GetCredential(ctx context.Context, id, accountID, pr
 // ListCredentials returns credentials for a given identity.
 func (s *CredentialService) ListCredentials(ctx context.Context, identityID, accountID, projectID string) ([]*domain.IssuedCredential, error) {
 	return s.repo.ListByIdentity(ctx, identityID, accountID, projectID)
+}
+
+// ListCredentialsByMission returns every credential in the delegation tree
+// keyed by missionID, ordered by delegation_depth ASC then created_at ASC
+// so the chain reads from root to leaves. Issue #81: O(1) replacement for
+// the recursive parent_jti walk.
+func (s *CredentialService) ListCredentialsByMission(ctx context.Context, missionID, accountID, projectID string) ([]*domain.IssuedCredential, error) {
+	return s.repo.ListByMissionID(ctx, missionID, accountID, projectID)
 }
 
 // RevokeCredential revokes a credential by ID.

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -508,6 +508,16 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 
 	delegatedBy, _ := subjectParsed.Subject()
 
+	// Resolve mission_id from the subject_token (issue #81). Prefer the
+	// explicit mission_id claim; fall back to the subject_token's own jti
+	// for credentials issued before the denormalisation landed (the subject
+	// IS a mission root by definition). Either way, the new credential
+	// inherits the same mission so the whole tree shares one identifier.
+	missionID, _ := jwt.Get[string](subjectParsed, "mission_id")
+	if missionID == "" {
+		missionID = subjectJTI
+	}
+
 	// Step 6: Issue a delegated credential for the sub-agent. The full
 	// policy constraint set (delegation depth ceiling, required trust
 	// level, allowed grant types, max TTL) is enforced inside
@@ -520,6 +530,7 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 		DelegatedBy:      delegatedBy,
 		ParentJTI:        subjectJTI,
 		DelegationDepth:  parentDepth + 1,
+		MissionID:        missionID,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/signal.go
+++ b/internal/service/signal.go
@@ -137,3 +137,10 @@ func (s *SignalService) Unsubscribe(subscriberID string) {
 func (s *SignalService) ListSignals(ctx context.Context, accountID, projectID string, limit int) ([]*domain.CAESignal, error) {
 	return s.repo.List(ctx, accountID, projectID, limit)
 }
+
+// ListSignalsByMission returns every signal under the given delegation
+// tree (issue #81), ordered by created_at ASC so events read in the
+// order they fired. The repo uses the partial index from migration 017.
+func (s *SignalService) ListSignalsByMission(ctx context.Context, missionID, accountID, projectID string) ([]*domain.CAESignal, error) {
+	return s.repo.ListByMissionID(ctx, missionID, accountID, projectID)
+}

--- a/internal/store/postgres/credential.go
+++ b/internal/store/postgres/credential.go
@@ -76,6 +76,25 @@ func (r *CredentialRepository) ListByIdentity(ctx context.Context, identityID, a
 	return creds, nil
 }
 
+// ListByMissionID returns every credential in the delegation tree for the
+// given mission_id, ordered root → leaves (delegation_depth ASC, then
+// issued_at ASC for ties at the same depth). Issue #81. The partial
+// index added in migration 017 makes this an indexed equality lookup.
+func (r *CredentialRepository) ListByMissionID(ctx context.Context, missionID, accountID, projectID string) ([]*domain.IssuedCredential, error) {
+	var creds []*domain.IssuedCredential
+	db := dbOrTx(ctx, r.db)
+	err := db.NewSelect().Model(&creds).
+		Where("mission_id = ?", missionID).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		OrderExpr("delegation_depth ASC, issued_at ASC").
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list credentials by mission: %w", err)
+	}
+	return creds, nil
+}
+
 // RevokeAllActiveForIdentity revokes all non-expired, non-revoked credentials for an
 // identity and cascades the revocation to every downstream delegated credential in the
 // parent_jti chain (RFC 8693 token_exchange descendants), regardless of which identity

--- a/internal/store/postgres/signal.go
+++ b/internal/store/postgres/signal.go
@@ -58,3 +58,22 @@ func (r *SignalRepository) ListByIdentity(ctx context.Context, identityID, accou
 	}
 	return signals, nil
 }
+
+// ListByMissionID returns every signal carrying the given mission_id,
+// ordered by created_at ASC so events read in the order they fired.
+// Issue #81. The partial index from migration 017 makes this an indexed
+// equality lookup.
+func (r *SignalRepository) ListByMissionID(ctx context.Context, missionID, accountID, projectID string) ([]*domain.CAESignal, error) {
+	var signals []*domain.CAESignal
+	db := dbOrTx(ctx, r.db)
+	err := db.NewSelect().Model(&signals).
+		Where("mission_id = ?", missionID).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		OrderExpr("created_at ASC").
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list signals by mission: %w", err)
+	}
+	return signals, nil
+}

--- a/migrations/022_mission_id_denormalization.down.sql
+++ b/migrations/022_mission_id_denormalization.down.sql
@@ -1,0 +1,8 @@
+-- 022_mission_id_denormalization.down.sql
+-- Reverses 022_mission_id_denormalization.up.sql.
+
+DROP INDEX IF EXISTS idx_cae_signals_mission_id;
+ALTER TABLE cae_signals DROP COLUMN IF EXISTS mission_id;
+
+DROP INDEX IF EXISTS idx_issued_credentials_mission_id;
+ALTER TABLE issued_credentials DROP COLUMN IF EXISTS mission_id;

--- a/migrations/022_mission_id_denormalization.up.sql
+++ b/migrations/022_mission_id_denormalization.up.sql
@@ -1,0 +1,26 @@
+-- 022_mission_id_denormalization.up.sql
+-- Adds mission_id (a delegation-tree-scoped opaque identifier) as a
+-- first-class column on issued_credentials and cae_signals so workflow-
+-- spanning audit queries are O(1) instead of recursing through
+-- parent_jti at read time. Issue #81.
+--
+-- Both columns are nullable. Pre-migration credentials and signals
+-- stay NULL and remain reachable via the existing parent_jti walk;
+-- they age out via TTL with no backfill.
+--
+-- Each column gets its own btree index so `WHERE mission_id = ?`
+-- equality lookups (the only query shape) hit the index.
+
+ALTER TABLE issued_credentials
+    ADD COLUMN IF NOT EXISTS mission_id VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_issued_credentials_mission_id
+    ON issued_credentials (mission_id)
+    WHERE mission_id IS NOT NULL;
+
+ALTER TABLE cae_signals
+    ADD COLUMN IF NOT EXISTS mission_id VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_cae_signals_mission_id
+    ON cae_signals (mission_id)
+    WHERE mission_id IS NOT NULL;

--- a/pkg/authjwt/claims.go
+++ b/pkg/authjwt/claims.go
@@ -51,6 +51,12 @@ type Claims struct {
 	Scopes          []string `json:"scopes,omitempty"`
 	DelegationDepth int      `json:"delegation_depth,omitempty"`
 
+	// MissionID groups every credential in a delegation tree under one
+	// stable opaque identifier. Treat as opaque — callers MUST NOT try to
+	// look up a credential by this value, even though it is currently
+	// populated with the root JTI. See zeroid issue #81.
+	MissionID string `json:"mission_id,omitempty"`
+
 	// RFC 8693 delegation
 	ActorClaims *ActorClaims `json:"act,omitempty"`
 
@@ -249,7 +255,8 @@ func extractClaims(token jwt.Token) *Claims {
 		"status": {}, "name": {}, "framework": {}, "version": {}, "publisher": {},
 		"capabilities": {},
 		"grant_type":   {}, "scopes": {}, "delegation_depth": {},
-		"act": {},
+		"act":        {},
+		"mission_id": {},
 	}
 
 	// Tenant
@@ -276,6 +283,7 @@ func extractClaims(token jwt.Token) *Claims {
 	c.GrantType = getString("grant_type")
 	c.Scopes = getStringSlice("scopes")
 	c.DelegationDepth = getInt("delegation_depth")
+	c.MissionID = getString("mission_id")
 
 	// RFC 8693 delegation. The act claim is a nested object; pull it as
 	// interface{} so parseActorClaims can handle any concrete shape jwx

--- a/pkg/authjwt/verifier_test.go
+++ b/pkg/authjwt/verifier_test.go
@@ -229,6 +229,50 @@ func TestCustomClaims(t *testing.T) {
 	assertEqual(t, "AccountID", claims.AccountID, "acc-001")
 }
 
+// TestMissionIDClaim pins the mission_id (issue #81) extraction. The
+// claim must populate Claims.MissionID directly rather than landing in
+// Custom — downstream services log/filter via the typed accessor and
+// MUST NOT have to fish through Custom for it.
+func TestMissionIDClaim(t *testing.T) {
+	ks := newTestKeySet(t)
+	issuer := "https://auth.test.com"
+	v := newVerifier(t, ks, issuer)
+
+	const mid = "11111111-2222-3333-4444-555555555555"
+
+	c := baseClaims(issuer)
+	c["mission_id"] = mid
+
+	token := ks.signRS256(t, c)
+	claims, err := v.Verify(context.Background(), token)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	assertEqual(t, "MissionID typed field", claims.MissionID, mid)
+	// Must NOT also leak into Custom — known claim, typed home.
+	if got := claims.GetCustomString("mission_id"); got != "" {
+		t.Errorf("mission_id leaked into Custom: %q (should be empty — claim is typed)", got)
+	}
+}
+
+// TestMissionIDClaimAbsent verifies that a token with no mission_id
+// claim leaves MissionID as the zero value and does not error out.
+func TestMissionIDClaimAbsent(t *testing.T) {
+	ks := newTestKeySet(t)
+	issuer := "https://auth.test.com"
+	v := newVerifier(t, ks, issuer)
+
+	c := baseClaims(issuer) // no mission_id
+	token := ks.signRS256(t, c)
+	claims, err := v.Verify(context.Background(), token)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	assertEqual(t, "MissionID empty when absent", claims.MissionID, "")
+}
+
 func TestVerifyExpiredToken(t *testing.T) {
 	ks := newTestKeySet(t)
 	issuer := "https://auth.test.com"

--- a/tests/integration/mission_id_test.go
+++ b/tests/integration/mission_id_test.go
@@ -1,0 +1,163 @@
+package integration_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMissionID_ChainPropagation pins the issue #81 invariant: every
+// credential in a delegation tree carries the same mission_id, and the
+// admin filter `GET /credentials?mission_id=<id>` returns the whole
+// chain ordered root → leaves.
+//
+// Builds a 3-node chain:
+//
+//	client_credentials  (orchestrator)              depth 0
+//	   └── token_exchange  (sub-agent A)            depth 1
+//	          └── token_exchange  (sub-agent B)     depth 2
+//
+// The orchestrator's credential is the mission root; mission_id =
+// orchestrator's own JTI. Both sub-agent credentials propagate the same
+// mission_id from the subject_token they were issued against.
+func TestMissionID_ChainPropagation(t *testing.T) {
+	// ── Step 0: depth-5 policy that all three identities share so
+	// nothing in this test trips on the delegation-depth ceiling. ──
+	policyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("mission-policy"),
+		"allowed_grant_types":  []string{"client_credentials", "token_exchange"},
+		"allowed_scopes":       []string{"data:read"},
+		"max_delegation_depth": 5,
+		"max_ttl_seconds":      3600,
+	}, adminHeaders())
+
+	// ── Step 1: register the orchestrator with a confidential OAuth
+	// client; issue its root credential via client_credentials. ──
+	orchExtID := uid("mission-orch")
+	registerIdentityWithPolicy(t, orchExtID, policyID, "", []string{"data:read"}, adminHeaders())
+	orchClient := registerOAuthClient(t, orchExtID, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     orchClient.ClientID,
+		"client_secret": orchClient.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "orchestrator client_credentials: expected 200")
+	orchToken := decode(t, resp)["access_token"].(string)
+
+	orchClaims := decodeJWTUnsafe(t, orchToken)
+	rootMission := orchClaims["mission_id"].(string)
+	rootJTI := orchClaims["jti"].(string)
+	assert.Equal(t, rootJTI, rootMission,
+		"first issuance: mission_id defaults to this credential's own jti")
+
+	// ── Step 2: register sub-agent A with its own keypair, exchange
+	// orchestrator's token for A's depth-1 token. ──
+	keyA, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	extA := uid("mission-agent-a")
+	registerIdentityWithPolicy(t, extA, policyID, ecPublicKeyPEM(t, keyA),
+		[]string{"data:read"}, adminHeaders())
+	wimseA := fetchIdentityWIMSEByExternalID(t, extA)
+
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": orchToken,
+		"actor_token":   buildAssertion(t, keyA, wimseA),
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "depth-1 token_exchange: expected 200")
+	tokenA := decode(t, resp)["access_token"].(string)
+
+	claimsA := decodeJWTUnsafe(t, tokenA)
+	assert.Equal(t, rootMission, claimsA["mission_id"],
+		"depth-1: mission_id must propagate from orchestrator's subject_token")
+
+	// ── Step 3: register sub-agent B; exchange A's token for B's
+	// depth-2 token. ──
+	keyB, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	extB := uid("mission-agent-b")
+	registerIdentityWithPolicy(t, extB, policyID, ecPublicKeyPEM(t, keyB),
+		[]string{"data:read"}, adminHeaders())
+	wimseB := fetchIdentityWIMSEByExternalID(t, extB)
+
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": tokenA,
+		"actor_token":   buildAssertion(t, keyB, wimseB),
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "depth-2 token_exchange: expected 200")
+	tokenB := decode(t, resp)["access_token"].(string)
+
+	claimsB := decodeJWTUnsafe(t, tokenB)
+	assert.Equal(t, rootMission, claimsB["mission_id"],
+		"depth-2: mission_id must propagate transitively through the chain")
+
+	// ── Step 4: the headline filter must return all 3 in root → leaves
+	// order. ──
+	listResp := get(t,
+		adminPath("/credentials?mission_id="+url.QueryEscape(rootMission)),
+		adminHeaders())
+	require.Equal(t, http.StatusOK, listResp.StatusCode)
+	body := decode(t, listResp)
+	creds, _ := body["credentials"].([]any)
+	require.Len(t, creds, 3, "GET /credentials?mission_id=<id> must return all 3 chain credentials")
+
+	// Order: depth ASC, then issued_at ASC. Verify by depth column.
+	depths := []int{}
+	for _, c := range creds {
+		m := c.(map[string]any)
+		assert.Equal(t, rootMission, m["mission_id"],
+			"every returned credential must carry the queried mission_id")
+		// JSON numbers decode as float64; cast.
+		d, _ := m["delegation_depth"].(float64)
+		depths = append(depths, int(d))
+	}
+	assert.Equal(t, []int{0, 1, 2}, depths,
+		"credentials must be ordered root → leaves by delegation_depth")
+}
+
+// TestMissionID_RejectAmbiguousFilter pins the handler-level guard:
+// the new mission_id query is mutually exclusive with the existing
+// identity_id query. Both omitted = 400 (no dump-everything path).
+// Both supplied = 400 (ambiguous intent).
+func TestMissionID_RejectAmbiguousFilter(t *testing.T) {
+	// No filter at all.
+	resp := get(t, adminPath("/credentials"), adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"GET /credentials with neither identity_id nor mission_id must 400")
+
+	// Both filters together.
+	resp2 := get(t,
+		adminPath("/credentials?identity_id=00000000-0000-0000-0000-000000000000&mission_id=anything"),
+		adminHeaders())
+	defer func() { _ = resp2.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp2.StatusCode,
+		"GET /credentials with both identity_id and mission_id must 400")
+}
+
+// decodeJWTUnsafe parses a JWT WITHOUT signature verification — fine for
+// test assertions on claim values, never for trust decisions.
+func decodeJWTUnsafe(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parsed, err := jwt.ParseInsecure([]byte(token))
+	require.NoError(t, err, "ParseInsecure")
+	out := map[string]any{}
+	for k, v := range parsed.Claims() {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Closes highflame-ai/zeroid#81. Surfaces `mission_id` — a stable opaque identifier for a delegation tree — as a JWT claim, a column on `issued_credentials` and `cae_signals`, a log field, an admin filter, and a typed field on `authjwt.Claims`. Workflow-scoped audit queries now hit a single indexed equality lookup instead of recursing through `parent_jti` at read time.

This is the schema/claim layer that issue highflame-ai/highflame-authn#79 (mission log) will consume — same identifier, same column.

## Schema

Migration `017_mission_id_denormalization` adds nullable `VARCHAR(255)` columns to both `issued_credentials` and `cae_signals`, each with a partial btree index (`WHERE mission_id IS NOT NULL`). Existing rows stay NULL and remain reachable via the existing `parent_jti` walk; no backfill, they age out via TTL.

## Service layer

The propagation hook is `IssueRequest.MissionID`:

- **First issuance** (any grant that originates a credential — `client_credentials`, `jwt_bearer`, `authorization_code`, `api_key`, `refresh_token`, `external_principal_exchange`): caller leaves the field empty; `IssueCredential` defaults it to the new credential's own JTI. This credential is the root of a new mission.
- **`token_exchange`**: in `internal/service/oauth.go`, derive from the subject_token:
  ```go
  missionID, _ := jwt.Get[string](subjectParsed, "mission_id")
  if missionID == "" {
      missionID = subjectJTI // fallback for pre-#81 issuance
  }
  ```
  The new credential inherits the same `mission_id` transitively through the chain.

## JWT shape

`mission_id` claim emitted on every issued token (root + exchanged). Additive; no existing claim changed.

## Admin API

| Endpoint | Behavior |
|---|---|
| `GET /credentials?mission_id=<id>` | All credentials in the tree, ordered `delegation_depth ASC, issued_at ASC` |
| `GET /signals?mission_id=<id>`     | All signals in the tree, ordered `created_at ASC` |

On `/credentials`, `identity_id` and `mission_id` are mutually exclusive. Both empty or both set → 400 (no dump-everything path, no ambiguous intent).

## authjwt

`Claims.MissionID` is a typed `string` field. Spec called for `(*Claims).MissionID() string` — Go forbids a same-name method and field on the same struct, and the exported field IS the idiomatic Go accessor (`claims.MissionID` reads it directly without parsing). `mission_id` added to `knownKeys` so it populates the typed field instead of leaking into `Custom`.

## Logging

`mission_id` emitted as a structured field on the credential-issuance log line.

The full request-scoped zerolog enrichment described in the spec (every log line auto-carrying `mission_id` from a verified token's context) is genuinely out of scope for this issue — the codebase logs inline today, and introducing a `zerolog.Ctx(ctx)` pattern is its own piece of work that would balloon this diff. Worth a follow-up; not blocking the schema/claim/admin work.

## Opaque value contract

Every surface (domain field, claim doc, authjwt typed field, migration comment) calls out that consumers MUST treat `mission_id` as opaque — do not assume it's a JTI, do not attempt to look up the underlying credential by it. This keeps the population scheme free to evolve (e.g., aliasing onto a future IETF-registered claim).

## Files

| File | Change |
|---|---|
| `migrations/017_mission_id_denormalization.{up,down}.sql` | New nullable columns + partial indexes on `issued_credentials` and `cae_signals`. |
| `domain/credential.go`, `domain/signal.go` | New `MissionID string` field with `nullzero` so empty Go strings round-trip as SQL NULL. |
| `internal/service/credential.go` | `IssueRequest.MissionID`; default-to-own-JTI fallback; embed claim; persist column; emit log field. |
| `internal/service/oauth.go` | `token_exchange` derives `mission_id` from subject_token (claim → fallback to subject's `jti`). |
| `internal/handler/credential.go` | `?mission_id=<id>` query + mutual-exclusion guard with `?identity_id=<id>`. |
| `internal/handler/signal.go` | `?mission_id=<id>` query. |
| `internal/store/postgres/credential.go`, `signal.go` | New `ListByMissionID` methods. |
| `internal/service/credential.go`, `signal.go` | Service-level passthroughs (`ListCredentialsByMission`, `ListSignalsByMission`). |
| `pkg/authjwt/claims.go` | New typed `MissionID` field; added to `knownKeys` and `extractClaims`. |
| `pkg/authjwt/verifier_test.go` | `TestMissionIDClaim`, `TestMissionIDClaimAbsent`. |
| `tests/integration/mission_id_test.go` | `TestMissionID_ChainPropagation` (the headline 3-node chain test from the spec) + `TestMissionID_RejectAmbiguousFilter`. |

## Test plan

- [x] `go vet ./...` clean (root + `pkg/authjwt`)
- [x] `go build ./...` clean
- [x] Full integration suite green ~10s including `TestMissionID_ChainPropagation` and `TestMissionID_RejectAmbiguousFilter`
- [x] `pkg/authjwt` unit suite green including the two new mission_id tests
- [x] Migration applies cleanly (testcontainer runs migrations fresh on every test run, exercising 017 end-to-end)

## Acceptance criteria from highflame-ai/zeroid#81

- [x] First-issuance grants write `mission_id = <own jti>` to the credential row and embed the `mission_id` claim in the JWT.
- [x] `token_exchange` correctly propagates `mission_id` from the subject_token to the new credential (both explicit-claim and fallback-to-subject-jti paths).
- [x] `mission_id` appears in zerolog output for credential issuance. *(Full request-scoped enrichment deferred — see "Logging" above.)*
- [x] Admin API supports `?mission_id=<id>` on credentials and signals, returning ordered results.
- [x] Integration test: 3-node chain → all 3 in correct order via the filter.
- [x] Migration applies and reverts cleanly.
- [x] `authjwt.Claims.MissionID` exposed and covered by unit tests.
- [x] Docs explicitly call out that `mission_id` is opaque.

## Future work (out of scope)

- **Request-scoped zerolog enrichment** — auto-include `mission_id` on every log line when the request carries a verified token. Real value but its own refactor.
- **Issue highflame-ai/highflame-authn#79** — agent-reported mission log builds on this same `mission_id` column. Was sequenced behind this issue per highflame-ai/zeroid#81's "Sequencing" note.