### PR TITLE
fix(authjwt): tolerate startup races; lazy JWKS fetch on first verify

### DIFF
--- a/pkg/authjwt/jwks.go
+++ b/pkg/authjwt/jwks.go
@@ -37,6 +37,10 @@ type JWKSClient struct {
 	keySet jwk.Set
 	kids   map[string]struct{} // known key IDs for fast miss detection
 
+	// loadMu serializes first-fetch attempts when the cache is cold so
+	// concurrent verify() calls don't each issue a separate JWKS request.
+	loadMu sync.Mutex
+
 	cancel context.CancelFunc
 	done   chan struct{}
 }
@@ -79,9 +83,20 @@ func WithLogger(logger zerolog.Logger) JWKSOption {
 }
 
 // NewJWKSClient creates a JWKS client that fetches keys from the given URL.
-// It performs an initial fetch synchronously and starts a background refresh goroutine.
-// Call Close() to stop the background refresh.
+//
+// It attempts a best-effort initial fetch with the configured request timeout,
+// but does NOT fail if the endpoint is unreachable: a transient cross-service
+// startup race (e.g., the issuer's pod hasn't bound its TCP listener yet) used
+// to crash callers and is now papered over by the background refresh loop and
+// by EnsureLoaded(), which is invoked lazily on the first Verify() call.
+//
+// Returns an error only for config-level problems (empty URL). Call Close()
+// to stop the background refresh.
 func NewJWKSClient(jwksURL string, opts ...JWKSOption) (*JWKSClient, error) {
+	if jwksURL == "" {
+		return nil, fmt.Errorf("authjwt: JWKSURL is required")
+	}
+
 	c := &JWKSClient{
 		jwksURL:         jwksURL,
 		refreshInterval: defaultRefreshInterval,
@@ -96,9 +111,15 @@ func NewJWKSClient(jwksURL string, opts ...JWKSOption) (*JWKSClient, error) {
 		opt(c)
 	}
 
-	// Initial synchronous fetch — fail fast if JWKS is unreachable.
+	// Best-effort warm-up. A failure here is not fatal: the issuer may be
+	// starting in parallel (kind/CI bootstrap, regional failover, simultaneous
+	// rolling restart). EnsureLoaded() will retry synchronously on the first
+	// Verify() and the background refresh loop will catch it on its next tick.
 	if err := c.refresh(context.Background()); err != nil {
-		return nil, fmt.Errorf("authjwt: initial JWKS fetch from %s failed: %w", jwksURL, err)
+		c.logger.Warn().
+			Err(err).
+			Str("url", jwksURL).
+			Msg("initial JWKS fetch failed; continuing — will retry on first verify and via background refresh")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -121,6 +142,38 @@ func (c *JWKSClient) HasKID(kid string) bool {
 	defer c.mu.RUnlock()
 	_, ok := c.kids[kid]
 	return ok
+}
+
+// EnsureLoaded fetches the JWKS synchronously if the local cache is empty.
+// This is the lazy path used on the first Verify() call when the initial
+// fetch from NewJWKSClient failed (e.g., the issuer's pod was still starting).
+//
+// Concurrent callers coalesce on a single fetch via loadMu so the cold path
+// issues at most one JWKS request even under verify-storms.
+//
+// Returns nil if the cache is populated (already, or by this call).
+func (c *JWKSClient) EnsureLoaded(ctx context.Context) error {
+	if c.populated() {
+		return nil
+	}
+
+	c.loadMu.Lock()
+	defer c.loadMu.Unlock()
+
+	// Re-check under the lock — another goroutine may have populated the
+	// cache while we were queued.
+	if c.populated() {
+		return nil
+	}
+
+	return c.refresh(ctx)
+}
+
+// populated reports whether the cache currently holds at least one key.
+func (c *JWKSClient) populated() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.keySet != nil && c.keySet.Len() > 0
 }
 
 // RefreshIfMissing triggers an immediate JWKS refresh if the given kid is not

--- a/pkg/authjwt/jwks.go
+++ b/pkg/authjwt/jwks.go
@@ -37,12 +37,23 @@ type JWKSClient struct {
 	keySet jwk.Set
 	kids   map[string]struct{} // known key IDs for fast miss detection
 
-	// loadMu serializes first-fetch attempts when the cache is cold so
-	// concurrent verify() calls don't each issue a separate JWKS request.
-	loadMu sync.Mutex
+	// loadMu guards loadInFlight so concurrent EnsureLoaded callers either
+	// elect a single leader (cold cache, no fetch in flight) or attach to
+	// an existing leader's broadcast channel.
+	loadMu       sync.Mutex
+	loadInFlight *jwksFetch
 
 	cancel context.CancelFunc
 	done   chan struct{}
+}
+
+// jwksFetch is the broadcast handle for an in-flight cold-cache fetch.
+// The leader runs the fetch with its own fresh context; followers wait on
+// done with their own ctx so they can return on their own deadline rather
+// than blocking on whatever timeout the leader chose.
+type jwksFetch struct {
+	done chan struct{} // closed when the fetch completes
+	err  error         // populated before close(done); read-only after
 }
 
 // JWKSOption configures a JWKSClient.
@@ -148,8 +159,12 @@ func (c *JWKSClient) HasKID(kid string) bool {
 // This is the lazy path used on the first Verify() call when the initial
 // fetch from NewJWKSClient failed (e.g., the issuer's pod was still starting).
 //
-// Concurrent callers coalesce on a single fetch via loadMu so the cold path
-// issues at most one JWKS request even under verify-storms.
+// Concurrent callers coalesce on a single fetch: exactly one leader runs the
+// network request, the rest wait on a broadcast channel. Each waiter respects
+// its own ctx — a caller with a 100ms deadline returns on its deadline rather
+// than blocking up to requestTimeout for the leader. The fetch itself runs
+// with a fresh context so one caller's cancellation doesn't break the result
+// for the others.
 //
 // Returns nil if the cache is populated (already, or by this call).
 func (c *JWKSClient) EnsureLoaded(ctx context.Context) error {
@@ -158,15 +173,48 @@ func (c *JWKSClient) EnsureLoaded(ctx context.Context) error {
 	}
 
 	c.loadMu.Lock()
-	defer c.loadMu.Unlock()
-
-	// Re-check under the lock — another goroutine may have populated the
-	// cache while we were queued.
 	if c.populated() {
+		c.loadMu.Unlock()
 		return nil
 	}
 
-	return c.refresh(ctx)
+	leader := c.loadInFlight == nil
+	if leader {
+		c.loadInFlight = &jwksFetch{done: make(chan struct{})}
+	}
+	fetch := c.loadInFlight
+	c.loadMu.Unlock()
+
+	if leader {
+		// Run with a fresh context detached from any single caller. If the
+		// caller that triggered the fetch cancels mid-flight, the result is
+		// still useful to every other waiter, so we use requestTimeout as
+		// the upper bound and let net/http handle cancellation cleanly.
+		fetchCtx, cancel := context.WithTimeout(context.Background(), c.requestTimeout)
+		fetch.err = c.refresh(fetchCtx)
+		cancel()
+
+		// Clear in-flight before broadcasting so a subsequent cold-start
+		// (e.g., this fetch failed and a later caller retries) elects a
+		// fresh leader instead of attaching to the stale handle.
+		c.loadMu.Lock()
+		c.loadInFlight = nil
+		c.loadMu.Unlock()
+
+		close(fetch.done)
+		return fetch.err
+	}
+
+	// Follower path. Wait for the leader, but only as long as our own ctx
+	// allows. Returning early here does NOT cancel the leader's fetch —
+	// the leader keeps going on its detached context and serves whichever
+	// other followers are still around to consume the result.
+	select {
+	case <-fetch.done:
+		return fetch.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // populated reports whether the cache currently holds at least one key.

--- a/pkg/authjwt/verifier.go
+++ b/pkg/authjwt/verifier.go
@@ -72,7 +72,11 @@ type VerifierConfig struct {
 }
 
 // NewVerifier creates a Verifier that validates tokens against a remote JWKS.
-// Performs an initial synchronous JWKS fetch — returns error if unreachable.
+//
+// Returns an error only for config-level problems (empty JWKSURL). The initial
+// JWKS fetch is best-effort — if the issuer is briefly unreachable at startup
+// (cross-service race during cluster bootstrap), the verifier still returns
+// successfully and the JWKS will be fetched lazily on the first Verify() call.
 // Call Close() to release resources.
 func NewVerifier(cfg VerifierConfig) (*Verifier, error) {
 	if cfg.JWKSURL == "" {
@@ -128,7 +132,17 @@ func (v *Verifier) Verify(ctx context.Context, tokenString string) (*Claims, err
 func (v *Verifier) verify(ctx context.Context, tokenString string) (*Claims, error) {
 	keySet := v.jwks.KeySet()
 	if keySet == nil || keySet.Len() == 0 {
-		return nil, ErrNoKeySet
+		// Cold path: the initial fetch failed (or hasn't run yet) and no
+		// background refresh has populated the cache. Try once synchronously
+		// before failing the verification — this is the lazy fetch that lets
+		// startup races resolve themselves on first use.
+		if err := v.jwks.EnsureLoaded(ctx); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrNoKeySet, err)
+		}
+		keySet = v.jwks.KeySet()
+		if keySet == nil || keySet.Len() == 0 {
+			return nil, ErrNoKeySet
+		}
 	}
 
 	// Reject alg=none / HS* before any further work — JWT-SVID §3.

--- a/pkg/authjwt/verifier_test.go
+++ b/pkg/authjwt/verifier_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -687,6 +688,71 @@ func TestVerifyRealTime(t *testing.T) {
 		}
 		assertEqual(t, "AccountID", claims.AccountID, "acc-001")
 	})
+}
+
+// TestNewVerifier_StartsWithUnreachableJWKS verifies that a transient
+// startup race (issuer not yet listening) no longer crashes the caller.
+// NewVerifier must succeed; the verifier is usable once the issuer
+// comes up.
+func TestNewVerifier_StartsWithUnreachableJWKS(t *testing.T) {
+	// Stand up a server, capture its URL, then close it so the URL is dead.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	v, err := authjwt.NewVerifier(authjwt.VerifierConfig{JWKSURL: deadURL})
+	if err != nil {
+		t.Fatalf("NewVerifier with unreachable JWKS should not error, got: %v", err)
+	}
+	t.Cleanup(v.Close)
+}
+
+// TestVerify_LazyFetchOnFirstUse simulates the cluster-bootstrap race:
+// NewVerifier is called while the issuer is still starting (server returns
+// errors), then the issuer comes up and the first Verify() call must
+// succeed via lazy fetch — no restart required.
+func TestVerify_LazyFetchOnFirstUse(t *testing.T) {
+	ks := newTestKeySet(t)
+	issuer := "https://auth.test.com"
+
+	// Wrap the test JWKS server in a switchable proxy: 503 until ready=true.
+	var ready atomic.Bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !ready.Load() {
+			http.Error(w, "starting", http.StatusServiceUnavailable)
+			return
+		}
+		// Forward to the real test JWKS server.
+		w.Header().Set("Content-Type", "application/json")
+		// Re-encode the keyset directly — cheaper than chaining through net/http.
+		_ = json.NewEncoder(w).Encode(ks.set)
+	}))
+	defer proxy.Close()
+
+	v, err := authjwt.NewVerifier(authjwt.VerifierConfig{
+		JWKSURL: proxy.URL,
+		Issuer:  issuer,
+	})
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	defer v.Close()
+
+	// Issuer is still "starting" — verify must fail cleanly with ErrNoKeySet,
+	// not crash, not hang past the request timeout.
+	token := ks.signRS256(t, baseClaims(issuer))
+	if _, err := v.Verify(context.Background(), token); !errors.Is(err, authjwt.ErrNoKeySet) {
+		t.Fatalf("expected ErrNoKeySet while issuer down, got: %v", err)
+	}
+
+	// Issuer comes up. The next Verify() must lazy-fetch and succeed
+	// without any external trigger (no Close+New, no manual refresh).
+	ready.Store(true)
+	claims, err := v.Verify(context.Background(), token)
+	if err != nil {
+		t.Fatalf("verify after issuer up: %v", err)
+	}
+	assertEqual(t, "AccountID", claims.AccountID, "acc-001")
 }
 
 // Helpers

--- a/pkg/authjwt/verifier_test.go
+++ b/pkg/authjwt/verifier_test.go
@@ -755,6 +755,65 @@ func TestVerify_LazyFetchOnFirstUse(t *testing.T) {
 	assertEqual(t, "AccountID", claims.AccountID, "acc-001")
 }
 
+// TestEnsureLoaded_FollowersRespectContext verifies that when one caller is
+// already running the cold-cache fetch, a second caller with a tighter
+// deadline returns on its own deadline rather than blocking up to the full
+// fetch timeout.
+func TestEnsureLoaded_FollowersRespectContext(t *testing.T) {
+	// Server: first request fails fast (503) so NewJWKSClient's best-effort
+	// warmup doesn't block the test setup. Subsequent requests — the
+	// leader's lazy fetch — hang on `block` until cleanup unblocks them.
+	block := make(chan struct{})
+	served := atomic.Int32{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if served.Add(1) == 1 {
+			http.Error(w, "warming up", http.StatusServiceUnavailable)
+			return
+		}
+		<-block
+	}))
+	// Cleanups run LIFO; we register srv.Close first so close(block) runs
+	// before it — otherwise srv.Close blocks forever on the hanging handler's
+	// goroutine and the test deadlocks.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(block) })
+
+	c, err := authjwt.NewJWKSClient(srv.URL, authjwt.WithRequestTimeout(2*time.Second))
+	if err != nil {
+		t.Fatalf("NewJWKSClient: %v", err)
+	}
+	t.Cleanup(c.Close)
+
+	// Leader: starts the (now-hanging) lazy fetch in a goroutine.
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		_ = c.EnsureLoaded(context.Background())
+	}()
+
+	// Beat to let the leader actually issue its HTTP request and register
+	// loadInFlight before the follower joins.
+	time.Sleep(50 * time.Millisecond)
+
+	// Follower: 100ms deadline. Must return on its own deadline, not block
+	// for the leader's full requestTimeout (2s here, 10s in production).
+	followerCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = c.EnsureLoaded(followerCtx)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded, got: %v", err)
+	}
+	// Generous upper bound to absorb CI jitter while still ruling out the
+	// "stuck behind leader's full fetch timeout" failure mode.
+	if elapsed > 1*time.Second {
+		t.Fatalf("follower stuck for %s; expected ~100ms (leader's fetch should not block follower's ctx)", elapsed)
+	}
+}
+
 // Helpers
 
 func assertEqual(t *testing.T, field, got, want string) {


### PR DESCRIPTION
## Summary

`authjwt.NewJWKSClient` / `NewVerifier` previously did a synchronous initial JWKS fetch and treated **any** error as fatal. Consumers (highflame-shield, highflame-observatory, highflame-admin) wrap that in `os.Exit`, so a transient `connection refused` from the issuer — the exact thing that happens when authn and its dependents start in the same window — crashloops the dependent service.

This shifts the contract to match what Envoy, Auth0/Okta SDKs, Spring Security OAuth2, and most production JWKS verifiers already do:

- **Best-effort warm-up** at startup. `NewJWKSClient` still attempts a fetch, but logs WARN and returns successfully on failure. The background refresh loop continues to retry on its tick.
- **Lazy fetch on first verify.** `verify()` calls a new `EnsureLoaded(ctx)` when the cache is cold; concurrent verify-storms coalesce on a single fetch via a dedicated `loadMu` so we don't stampede the issuer.
- **Genuine misconfig still surfaces.** If the JWKS endpoint is permanently unreachable, every verify returns `ErrNoKeySet` (translated to 401/503 by middleware). Operators see the failure on the auth path, not as a startup crashloop.

## Why now

Last night's Highflame kind nightly regression ([run 25421438031](https://github.com/highflame-ai/highflame-regression/actions/runs/25421438031)) exposed this. From the artifact's `previous` (crashed) container logs:

```
shield 02:28:04: {"level":"fatal","component":"auth","msg":"failed to initialize JWKS verifier",
  "error":"authjwt: initial JWKS fetch from http://highflame-authn:8051/v1/auth/.well-known/jwks.json failed:
   ... dial tcp 10.96.150.182:8051: connect: connection refused"}

observatory 02:28:07: same error, fatal exit

authn 02:28:08: first /v1/auth/ready 200 (process bound listener after this point)
```

The pods crashlooped (shield 3×, observatory 4×) until authn's listener came up, then recovered. Most tests passed once everything was warm — but \`test_cerberus_agent_event_lands_in_observatory\`, which polls observatory for an event with a 45s budget, fell into the recovery window and timed out.

This race exists in every cluster, not just kind. It just usually hides because authn has been up for hours when downstream services restart. Cold-start, failover, and coordinated rolling restart all reproduce it.

## Changes

- \`pkg/authjwt/jwks.go\`
  - \`NewJWKSClient\`: best-effort initial fetch, no fatal on transient failure.
  - New \`EnsureLoaded(ctx)\` method (mutex-coalesced lazy fetch).
  - New \`populated()\` helper (single source of truth for "is the cache hot").
- \`pkg/authjwt/verifier.go\`
  - \`verify()\` calls \`EnsureLoaded\` before returning \`ErrNoKeySet\`.
  - \`NewVerifier\` doc updated to reflect the new contract.
- \`pkg/authjwt/verifier_test.go\`
  - \`TestNewVerifier_StartsWithUnreachableJWKS\` — constructor must not error when issuer is dead.
  - \`TestVerify_LazyFetchOnFirstUse\` — issuer comes up after construction; first \`Verify\` must succeed without restart.
  - Existing \`TestJWKSClientRefreshOnUnknownKID\` and \`TestVerifyRS256Token\` still pass — no behavior regression on the warm path.

## Operational note

\`/readyz\` semantics shift slightly for consumers: a pod can be Ready before its first JWT can be verified. Acceptable trade — readiness already doesn't guarantee every downstream is reachable, and the alternative is the crashloop class this removes.

## Test plan

- [x] \`go test ./...\` in \`pkg/authjwt\` — all pass (\`TestNewVerifier_StartsWithUnreachableJWKS\`, \`TestVerify_LazyFetchOnFirstUse\`, plus existing suite).
- [x] \`go vet ./...\` clean.
- [ ] After merge: tag \`pkg/authjwt/v1.3.0\` and bump in \`highflame-shield\`, \`highflame-observatory\`, \`highflame-admin\`, \`highflame-authn\`.
- [ ] Re-run kind nightly regression with the bumped consumer images and confirm shield/observatory restart counts stay at 0 across the whole run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)