### PR TITLE
fix: delegate OTLP endpoint and TLS handling to OTel SDK

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,10 +127,9 @@ type TokenConfig struct {
 }
 
 // TelemetryConfig holds OpenTelemetry settings.
+// Endpoint and TLS are delegated to the OTel SDK via standard env vars
 type TelemetryConfig struct {
 	Enabled      bool    `koanf:"enabled"`
-	Endpoint     string  `koanf:"endpoint"`
-	Insecure     bool    `koanf:"insecure"`
 	ServiceName  string  `koanf:"service_name"`
 	SamplingRate float64 `koanf:"sampling_rate"`
 }
@@ -278,8 +277,6 @@ func loadDefaults(k *koanf.Koanf) error {
 
 		// Telemetry
 		"telemetry.enabled":       false,
-		"telemetry.endpoint":      "localhost:4317",
-		"telemetry.insecure":      true,
 		"telemetry.service_name":  "zeroid",
 		"telemetry.sampling_rate": 1.0,
 
@@ -341,10 +338,9 @@ func loadEnvVars(k *koanf.Koanf) error {
 		// Attestation
 		"ZEROID_ALLOW_UNSAFE_DEV_STUB": "attestation.allow_unsafe_dev_stub",
 
-		// Telemetry
-		"OTEL_EXPORTER_OTLP_ENDPOINT": "telemetry.endpoint",
-		"OTEL_ENABLED":                "telemetry.enabled",
-		"OTEL_INSECURE":               "telemetry.insecure",
+		// Telemetry — only OTEL_ENABLED is mapped here. OTEL_EXPORTER_OTLP_ENDPOINT
+		// and TLS settings are read directly by the OTel SDK (spec-compliant).
+		"OTEL_ENABLED": "telemetry.enabled",
 
 		// Logging
 		"ZEROID_LOG_LEVEL": "logging.level",
@@ -358,7 +354,6 @@ func loadEnvVars(k *koanf.Koanf) error {
 
 		switch {
 		case strings.HasSuffix(configPath, ".enabled") ||
-			strings.HasSuffix(configPath, ".insecure") ||
 			strings.HasSuffix(configPath, ".allow_unsafe_dev_stub"):
 			if boolVal, err := strconv.ParseBool(value); err == nil {
 				_ = k.Set(configPath, boolVal)

--- a/config.go
+++ b/config.go
@@ -338,9 +338,10 @@ func loadEnvVars(k *koanf.Koanf) error {
 		// Attestation
 		"ZEROID_ALLOW_UNSAFE_DEV_STUB": "attestation.allow_unsafe_dev_stub",
 
-		// Telemetry — only OTEL_ENABLED is mapped here. OTEL_EXPORTER_OTLP_ENDPOINT
-		// and TLS settings are read directly by the OTel SDK (spec-compliant).
-		"OTEL_ENABLED": "telemetry.enabled",
+		// Telemetry — OTEL_EXPORTER_OTLP_ENDPOINT and TLS settings are read
+		// directly by the OTel SDK (spec-compliant).
+		"OTEL_ENABLED":            "telemetry.enabled",
+		"OTEL_TRACES_SAMPLER_ARG": "telemetry.sampling_rate",
 
 		// Logging
 		"ZEROID_LOG_LEVEL": "logging.level",

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -17,15 +17,13 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Config mirrors the telemetry section of the service config.
+// Endpoint and TLS are read by the OTel SDK from standard env vars
+// (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, etc.).
 type Config struct {
 	Enabled      bool
-	Endpoint     string
-	Insecure     bool
 	ServiceName  string
 	SamplingRate float64
 }
@@ -83,16 +81,6 @@ func Init(cfg Config) error {
 
 	ctx := context.Background()
 
-	// Shared gRPC connection to the OTEL Collector.
-	var dialOpts []grpc.DialOption
-	if cfg.Insecure {
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	}
-	conn, err := grpc.NewClient(cfg.Endpoint, dialOpts...)
-	if err != nil {
-		return fmt.Errorf("otel grpc dial: %w", err)
-	}
-
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(cfg.ServiceName),
@@ -103,8 +91,9 @@ func Init(cfg Config) error {
 		return fmt.Errorf("otel resource: %w", err)
 	}
 
-	// Traces
-	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
+	// Traces — the SDK reads OTEL_EXPORTER_OTLP_ENDPOINT (with scheme)
+	// and handles TLS negotiation per the OTel spec.
+	traceExporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
 		return fmt.Errorf("otel trace exporter: %w", err)
 	}
@@ -121,8 +110,8 @@ func Init(cfg Config) error {
 	)
 	otel.SetTracerProvider(tracerProvider)
 
-	// Metrics
-	metricExporter, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithGRPCConn(conn))
+	// Metrics — same SDK-managed env var handling as traces.
+	metricExporter, err := otlpmetricgrpc.New(ctx)
 	if err != nil {
 		return fmt.Errorf("otel metric exporter: %w", err)
 	}

--- a/server.go
+++ b/server.go
@@ -99,8 +99,6 @@ func NewServer(cfg Config) (*Server, error) {
 	// Initialize OpenTelemetry.
 	if err := telemetry.Init(telemetry.Config{
 		Enabled:      cfg.Telemetry.Enabled,
-		Endpoint:     cfg.Telemetry.Endpoint,
-		Insecure:     cfg.Telemetry.Insecure,
 		ServiceName:  cfg.Telemetry.ServiceName,
 		SamplingRate: cfg.Telemetry.SamplingRate,
 	}); err != nil {


### PR DESCRIPTION
## Summary

https://github.com/highflame-ai/highflame-authn/issues/56

Removes manual gRPC dialing with Endpoint/Insecure config in favor of letting the OTel SDK read `OTEL_EXPORTER_OTLP_ENDPOINT` directly. The SDK handles scheme-based TLS negotiation per the OTel spec, fixing a latent bug where URLs with https:// scheme would cause "too many colons" errors.

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

---

## Testing
- [ ] Manually tested
- [ ] Unit tests added/updated
- [ ] No tests required

---

## Impact / Risks

---

## 📸 Screenshots / Logs (if applicable)

---

