### PR TITLE
fix: tolerate transient db unreachability at zeroid startup

### DIFF
--- a/internal/database/wait.go
+++ b/internal/database/wait.go
@@ -92,8 +92,12 @@ func waitForPing(ctx context.Context, ping func(context.Context) error, opts Wai
 			Dur("next_retry", backoff).
 			Msg("dependency not yet reachable, retrying")
 
+		// time.NewTimer + Stop (not time.After) so we don't leak the
+		// underlying timer when waitCtx fires before the backoff elapses.
+		t := time.NewTimer(backoff)
 		select {
 		case <-waitCtx.Done():
+			t.Stop()
 			// Distinguish "we ran out of budget" from "caller cancelled us"
 			// for a clearer fatal log line at the call site.
 			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
@@ -101,7 +105,7 @@ func waitForPing(ctx context.Context, ping func(context.Context) error, opts Wai
 					attempt, opts.Budget, lastErr)
 			}
 			return fmt.Errorf("aborted while waiting for dependency: %w", waitCtx.Err())
-		case <-time.After(backoff):
+		case <-t.C:
 		}
 
 		backoff *= 2

--- a/internal/database/wait.go
+++ b/internal/database/wait.go
@@ -1,0 +1,119 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// WaitOptions configures WaitForReachable.
+type WaitOptions struct {
+	// Budget is the total time we'll wait for the dependency to start
+	// accepting connections before giving up. Default 60s — long enough
+	// to absorb a kind/CI cluster bootstrap, short enough that a genuine
+	// misconfig surfaces in under a minute.
+	Budget time.Duration
+
+	// InitialBackoff is the delay before the first retry. Default 500ms.
+	InitialBackoff time.Duration
+
+	// MaxBackoff caps each individual retry delay. Default 5s. Without
+	// the cap exponential growth would put a 30s gap between attempts
+	// late in the budget; capping keeps the retry cadence responsive.
+	MaxBackoff time.Duration
+
+	// AttemptTimeout caps each ping. Default 5s. A hung TCP connect
+	// would otherwise burn the whole budget on a single attempt.
+	AttemptTimeout time.Duration
+}
+
+func (o WaitOptions) withDefaults() WaitOptions {
+	if o.Budget == 0 {
+		o.Budget = 60 * time.Second
+	}
+	if o.InitialBackoff == 0 {
+		o.InitialBackoff = 500 * time.Millisecond
+	}
+	if o.MaxBackoff == 0 {
+		o.MaxBackoff = 5 * time.Second
+	}
+	if o.AttemptTimeout == 0 {
+		o.AttemptTimeout = 5 * time.Second
+	}
+	return o
+}
+
+// waitForPing calls ping with bounded exponential backoff until it succeeds
+// or the budget runs out. It exists to absorb cross-service startup races —
+// services often start in parallel and the dependency (postgres, clickhouse,
+// authn JWKS, ...) hasn't bound its port yet when we first try to connect.
+//
+// Genuine misconfig (wrong DSN, bad credentials, unreachable host) still
+// surfaces — the budget is the safety valve. After Budget elapsed, the
+// last error is returned and the caller can fatal-quit with a clean cause.
+//
+// This is the underlying primitive; most callers want WaitForReachable
+// which binds it to *sql.DB.PingContext.
+func waitForPing(ctx context.Context, ping func(context.Context) error, opts WaitOptions) error {
+	opts = opts.withDefaults()
+
+	deadline := time.Now().Add(opts.Budget)
+	waitCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	backoff := opts.InitialBackoff
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		// Per-attempt timeout so a hung connect can't burn the whole budget.
+		pingCtx, pingCancel := context.WithTimeout(waitCtx, opts.AttemptTimeout)
+		err := ping(pingCtx)
+		pingCancel()
+		if err == nil {
+			if attempt > 1 {
+				log.Info().Int("attempts", attempt).Msg("dependency reachable, proceeding")
+			}
+			return nil
+		}
+		lastErr = err
+
+		// If the parent context is already done (or budget is up), stop.
+		if waitCtx.Err() != nil {
+			return fmt.Errorf("dependency not reachable after %d attempts within %s: %w",
+				attempt, opts.Budget, lastErr)
+		}
+
+		log.Warn().
+			Err(err).
+			Int("attempt", attempt).
+			Dur("next_retry", backoff).
+			Msg("dependency not yet reachable, retrying")
+
+		select {
+		case <-waitCtx.Done():
+			// Distinguish "we ran out of budget" from "caller cancelled us"
+			// for a clearer fatal log line at the call site.
+			if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("dependency not reachable after %d attempts within %s: %w",
+					attempt, opts.Budget, lastErr)
+			}
+			return fmt.Errorf("aborted while waiting for dependency: %w", waitCtx.Err())
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > opts.MaxBackoff {
+			backoff = opts.MaxBackoff
+		}
+	}
+}
+
+// WaitForReachable pings db with bounded exponential backoff until it
+// succeeds or the budget runs out. See waitForPing for the underlying
+// semantics.
+func WaitForReachable(ctx context.Context, db *sql.DB, opts WaitOptions) error {
+	return waitForPing(ctx, db.PingContext, opts)
+}

--- a/internal/database/wait_test.go
+++ b/internal/database/wait_test.go
@@ -1,0 +1,117 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWaitForPing_SucceedsImmediately(t *testing.T) {
+	calls := atomic.Int32{}
+	ping := func(ctx context.Context) error {
+		calls.Add(1)
+		return nil
+	}
+	if err := waitForPing(context.Background(), ping, WaitOptions{}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected 1 ping, got %d", got)
+	}
+}
+
+func TestWaitForPing_RetriesUntilSuccess(t *testing.T) {
+	calls := atomic.Int32{}
+	ping := func(ctx context.Context) error {
+		// Simulate "connection refused" for the first 3 attempts, then succeed.
+		// This mirrors the kind-cluster cold-start where postgres binds 5432
+		// a few seconds after authn comes up.
+		if calls.Add(1) <= 3 {
+			return errors.New("connection refused")
+		}
+		return nil
+	}
+	opts := WaitOptions{
+		Budget:         5 * time.Second,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+		AttemptTimeout: 1 * time.Second,
+	}
+	start := time.Now()
+	if err := waitForPing(context.Background(), ping, opts); err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if got := calls.Load(); got != 4 {
+		t.Fatalf("expected 4 pings (3 fails + success), got %d", got)
+	}
+	// 10 + 20 + 40 = 70ms of backoff, plus a few ms of test overhead.
+	// The test would fail at >2s if budget logic is wrong.
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("retries took %s; expected ~70ms", elapsed)
+	}
+}
+
+func TestWaitForPing_GivesUpAfterBudget(t *testing.T) {
+	calls := atomic.Int32{}
+	pingErr := errors.New("connection refused")
+	ping := func(ctx context.Context) error {
+		calls.Add(1)
+		return pingErr
+	}
+	opts := WaitOptions{
+		Budget:         200 * time.Millisecond,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     30 * time.Millisecond,
+		AttemptTimeout: 50 * time.Millisecond,
+	}
+	start := time.Now()
+	err := waitForPing(context.Background(), ping, opts)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after budget exhausted, got nil")
+	}
+	// Final error must wrap the last ping error so call sites can log a
+	// clean cause.
+	if !errors.Is(err, pingErr) {
+		t.Fatalf("expected error to wrap %q, got: %v", pingErr, err)
+	}
+	// We give up around the budget; allow modest CI jitter on either side.
+	if elapsed < 150*time.Millisecond || elapsed > 600*time.Millisecond {
+		t.Fatalf("budget enforcement off: elapsed=%s budget=200ms", elapsed)
+	}
+	// Should have made several attempts before giving up.
+	if got := calls.Load(); got < 3 {
+		t.Fatalf("expected at least 3 attempts, got %d", got)
+	}
+}
+
+func TestWaitForPing_RespectsParentCancellation(t *testing.T) {
+	ping := func(ctx context.Context) error {
+		return errors.New("connection refused")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	opts := WaitOptions{
+		Budget:         10 * time.Second, // long budget — would mask cancel if not respected
+		InitialBackoff: 5 * time.Millisecond,
+		MaxBackoff:     20 * time.Millisecond,
+		AttemptTimeout: 100 * time.Millisecond,
+	}
+	start := time.Now()
+	err := waitForPing(ctx, ping, opts)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("did not honor parent cancellation: elapsed=%s", elapsed)
+	}
+}

--- a/migrate.go
+++ b/migrate.go
@@ -1,6 +1,7 @@
 package zeroid
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/fs"
@@ -18,11 +19,23 @@ import (
 // CI/CD step, init container, or CLI command before starting the server with
 // AutoMigrate: false.
 //
+// Migrate tolerates a transient cross-service startup race: if postgres is
+// briefly unreachable (e.g., the DB pod is still binding 5432 while authn
+// boots in parallel), Migrate retries the connection with bounded
+// exponential backoff for up to 60 seconds before giving up.
+//
 //	zeroid.Migrate("postgres://user:pass@host:5432/zeroid?sslmode=disable")
 func Migrate(databaseURL string) error {
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(databaseURL)))
 	db := bun.NewDB(sqldb, pgdialect.New())
 	defer func() { _ = db.Close() }()
+
+	// Wait for postgres to actually accept connections before we let
+	// golang-migrate's WithInstance try (it Pings internally and treats
+	// any error as fatal — no retries).
+	if err := database.WaitForReachable(context.Background(), sqldb, database.WaitOptions{}); err != nil {
+		return fmt.Errorf("zeroid migration: %w", err)
+	}
 
 	if err := database.RunMigrations(db); err != nil {
 		return fmt.Errorf("zeroid migration failed: %w", err)

--- a/server.go
+++ b/server.go
@@ -618,7 +618,11 @@ func initLogging(logLevel string) {
 func initDatabase(databaseURL string, maxOpenConns, maxIdleConns int) (*bun.DB, error) {
 	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(databaseURL)))
 
-	if err := sqldb.Ping(); err != nil {
+	// Tolerate transient cross-service startup races (postgres still
+	// binding 5432 while we boot in parallel) instead of fatal-quitting
+	// on first Ping. Bounded retry; genuine misconfig still surfaces
+	// after the budget elapses.
+	if err := database.WaitForReachable(context.Background(), sqldb, database.WaitOptions{}); err != nil {
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

\`zeroid.Migrate()\` and the embedded server's \`initDatabase()\` both fatal-quit the moment \`sqldb.Ping\` returns \`connection refused\` — even when postgres is just slow to bind its port (cluster bootstrap, regional failover, coordinated rolling restart). authn's kind nightly regression has been crashlooping on this for two consecutive nights:

\`\`\`
fatal: zeroid migration failed: failed to create postgres driver:
dial tcp 10.96.200.88:5432: connect: connection refused
\`\`\`

Same shape as the JWKS race fixed in PR #125 — different code path, same fix.

## Why now

This is one of four expressions of the same startup-ordering bug class observed in [highflame-regression run 25481606055](https://github.com/highflame-ai/highflame-regression/actions/runs/25481606055):

| Service | Fail-fast on | Status |
|---------|-------------|--------|
| highflame-shield (authjwt) | initial JWKS fetch from authn | fixed in PR #125 |
| **highflame-authn (this PR)** | **postgres Ping during zeroid migration** | **this PR** |
| highflame-authz | postgres Ping in main.go | follow-up |
| highflame-observatory | clickhouse Ping during migration | follow-up |

After all four ship, \`connection refused\` from any in-cluster dep becomes a 60s warning, not a fatal exit — fixes the nightly *and* removes a real production failure mode (failover, coordinated restart).

## Changes

- New \`internal/database/wait.go\`
  - \`waitForPing(ctx, ping func(context.Context) error, opts WaitOptions)\` — generic primitive, composes with anything that has a Ping.
  - \`WaitForReachable(ctx, *sql.DB, opts)\` — \`*sql.DB\` binding.
  - Defaults: 60s budget, 500ms → 5s exponential backoff, 5s per-attempt timeout.
- \`migrate.go\`: \`Migrate()\` waits before running golang-migrate.
- \`server.go\`: \`initDatabase()\` waits in place of the bare \`sqldb.Ping()\`.

## Test plan

- [x] New \`internal/database/wait_test.go\` covers: immediate success, retries-then-success, budget exhaustion (last error wraps cleanly), parent-ctx cancellation.
- [x] \`go test ./...\` green including \`tests/integration\` (179s real-postgres suite — confirms warm path isn't slowed).
- [x] \`go vet ./...\` clean.
- [ ] After merge: bump zeroid in highflame-authn and re-run the kind nightly. Authn restart count should drop from 3 to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)