### PR TITLE
feat: time-bound identities, policies, and credentials 

### DIFF
--- a/domain/apikey.go
+++ b/domain/apikey.go
@@ -54,3 +54,12 @@ type APIKey struct {
 	CreatedAt          time.Time       `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
 	UpdatedAt          time.Time       `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updated_at"`
 }
+
+// IsExpired reports whether the API key has aged out. A nil ExpiresAt
+// means "no expiry" and is never expired.
+func (k *APIKey) IsExpired() bool {
+	if k == nil || k.ExpiresAt == nil {
+		return false
+	}
+	return !time.Now().Before(*k.ExpiresAt)
+}

--- a/domain/credential_policy.go
+++ b/domain/credential_policy.go
@@ -49,18 +49,31 @@ func DefaultAllowedGrantTypes() []string {
 type CredentialPolicy struct {
 	bun.BaseModel `bun:"table:credential_policies,alias:cp"`
 
-	ID                  string    `bun:"id,pk,type:uuid"                  json:"id"`
-	AccountID           string    `bun:"account_id,type:varchar(255)"     json:"account_id"`
-	ProjectID           string    `bun:"project_id,type:varchar(255)"     json:"project_id"`
-	Name                string    `bun:"name,type:varchar(255)"           json:"name"`
-	Description         string    `bun:"description,type:text"            json:"description,omitempty"`
-	MaxTTLSeconds       int       `bun:"max_ttl_seconds"                  json:"max_ttl_seconds"`
-	AllowedGrantTypes   []string  `bun:"allowed_grant_types,array"        json:"allowed_grant_types"`
-	AllowedScopes       []string  `bun:"allowed_scopes,array"             json:"allowed_scopes,omitempty"`
-	RequiredTrustLevel  string    `bun:"required_trust_level,type:varchar(50)"  json:"required_trust_level,omitempty"`
-	RequiredAttestation string    `bun:"required_attestation,type:varchar(50)"  json:"required_attestation,omitempty"`
-	MaxDelegationDepth  int       `bun:"max_delegation_depth"             json:"max_delegation_depth"`
-	IsActive            bool      `bun:"is_active"                        json:"is_active"`
-	CreatedAt           time.Time `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
-	UpdatedAt           time.Time `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updated_at"`
+	ID                  string   `bun:"id,pk,type:uuid"                  json:"id"`
+	AccountID           string   `bun:"account_id,type:varchar(255)"     json:"account_id"`
+	ProjectID           string   `bun:"project_id,type:varchar(255)"     json:"project_id"`
+	Name                string   `bun:"name,type:varchar(255)"           json:"name"`
+	Description         string   `bun:"description,type:text"            json:"description,omitempty"`
+	MaxTTLSeconds       int      `bun:"max_ttl_seconds"                  json:"max_ttl_seconds"`
+	AllowedGrantTypes   []string `bun:"allowed_grant_types,array"        json:"allowed_grant_types"`
+	AllowedScopes       []string `bun:"allowed_scopes,array"             json:"allowed_scopes,omitempty"`
+	RequiredTrustLevel  string   `bun:"required_trust_level,type:varchar(50)"  json:"required_trust_level,omitempty"`
+	RequiredAttestation string   `bun:"required_attestation,type:varchar(50)"  json:"required_attestation,omitempty"`
+	MaxDelegationDepth  int      `bun:"max_delegation_depth"             json:"max_delegation_depth"`
+	IsActive            bool     `bun:"is_active"                        json:"is_active"`
+	// ExpiresAt time-bounds the policy. EnforcePolicy treats an expired
+	// policy the same as an inactive one — identity policy, per-key policy,
+	// or both. NULL means "no expiry".
+	ExpiresAt *time.Time `bun:"expires_at"                       json:"expires_at,omitempty"`
+	CreatedAt time.Time  `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
+	UpdatedAt time.Time  `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updated_at"`
+}
+
+// IsExpired reports whether the policy has aged out. A nil ExpiresAt
+// means "no expiry" and is never expired.
+func (p *CredentialPolicy) IsExpired() bool {
+	if p == nil || p.ExpiresAt == nil {
+		return false
+	}
+	return !time.Now().Before(*p.ExpiresAt)
 }

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -317,11 +317,37 @@ type Identity struct {
 	RiskTier       string `bun:"risk_tier,type:varchar(20),nullzero"       json:"risk_tier,omitempty"`
 	IAL            string `bun:"ial,type:varchar(20),nullzero"             json:"ial,omitempty"`
 
+	// ExpiresAt time-bounds the grant of authority itself (NOT the JWT it
+	// issues). NULL means "no expiry" — the historical default. When set,
+	// IssueCredential rejects new tokens past this time and the cleanup
+	// worker sweeps the identity into status=deactivated.
+	ExpiresAt *time.Time `bun:"expires_at" json:"expires_at,omitempty"`
+
 	// Lifecycle
 	CreatedBy  string    `bun:"created_by,type:varchar(255)"   json:"created_by,omitempty"`
 	ModifiedBy string    `bun:"modified_by,type:varchar(255)"  json:"modified_by,omitempty"`
 	CreatedAt  time.Time `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
 	UpdatedAt  time.Time `bun:"updated_at,nullzero,notnull,default:current_timestamp" json:"updated_at"`
+}
+
+// IsExpired reports whether the identity's authority has aged out. A nil
+// ExpiresAt means "no expiry" and is never expired.
+func (i *Identity) IsExpired() bool {
+	if i == nil || i.ExpiresAt == nil {
+		return false
+	}
+	return !time.Now().Before(*i.ExpiresAt)
+}
+
+// IsActiveAndUnexpired is the combined gate used at every token-issuance
+// entry point: status must be usable AND the grant of authority must not
+// have expired. Both are required — either alone is insufficient because
+// the cleanup worker may not have run yet.
+func (i *Identity) IsActiveAndUnexpired() bool {
+	if i == nil {
+		return false
+	}
+	return i.Status.IsUsable() && !i.IsExpired()
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -339,17 +339,6 @@ func (i *Identity) IsExpired() bool {
 	return !time.Now().Before(*i.ExpiresAt)
 }
 
-// IsActiveAndUnexpired is the combined gate used at every token-issuance
-// entry point: status must be usable AND the grant of authority must not
-// have expired. Both are required — either alone is insufficient because
-// the cleanup worker may not have run yet.
-func (i *Identity) IsActiveAndUnexpired() bool {
-	if i == nil {
-		return false
-	}
-	return i.Status.IsUsable() && !i.IsExpired()
-}
-
 // ──────────────────────────────────────────────────────────────────────────────
 // Identity Schema — describes valid types, sub-types, trust levels, and statuses.
 // Served by GET {AdminPathPrefix}/identities/schema so frontends stay in sync.

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -4,11 +4,23 @@ package domain
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/uptrace/bun"
 )
+
+// ErrIdentityExpired is returned by every issuance path (chokepoint
+// IssueCredential, GenerateProofToken, attestation post-issuance, agent
+// rotate-key) when the target identity has aged out. Service-layer
+// callers wrap with %w so handlers can errors.Is and consistently map to
+// a 4xx — OAuth flows emit invalid_grant, admin endpoints emit 400.
+var ErrIdentityExpired = errors.New("identity_expired")
+
+// ErrIdentityNotUsable is returned by the same paths when the identity
+// is suspended or deactivated. Same handler-mapping pattern.
+var ErrIdentityNotUsable = errors.New("identity is not usable")
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Trust Level

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -22,6 +22,12 @@ var ErrIdentityExpired = errors.New("identity_expired")
 // is suspended or deactivated. Same handler-mapping pattern.
 var ErrIdentityNotUsable = errors.New("identity is not usable")
 
+// ErrCredentialExpired is returned by IssueCredential when a per-credential
+// time bound (typically API key sk.ExpiresAt) has already passed. Same
+// handler-mapping pattern as the identity sentinels above — wrap with %w
+// at the service layer so handlers can errors.Is and map to 4xx.
+var ErrCredentialExpired = errors.New("credential_expired")
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Trust Level
 // ──────────────────────────────────────────────────────────────────────────────

--- a/domain/signal.go
+++ b/domain/signal.go
@@ -17,6 +17,12 @@ const (
 	SignalTypePolicyViolation   SignalType = "policy_violation"
 	SignalTypeRetirement        SignalType = "retirement"
 	SignalTypeOwnerChange       SignalType = "owner_change"
+	// SignalTypeIdentityExpired fires when the cleanup worker deactivates
+	// an identity whose expires_at has passed. Kept distinct from
+	// SignalTypeRetirement (admin-initiated deactivation) so subscribers
+	// can filter the indexed signal_type column directly instead of
+	// destructuring the payload.
+	SignalTypeIdentityExpired SignalType = "identity_expired"
 )
 
 // SignalSeverity indicates the severity level of a CAE signal.
@@ -42,7 +48,8 @@ func (s SignalSeverity) Valid() bool {
 func (t SignalType) Valid() bool {
 	switch t {
 	case SignalTypeCredentialChange, SignalTypeSessionRevoked, SignalTypeIPChange,
-		SignalTypeAnomalousBehavior, SignalTypePolicyViolation, SignalTypeRetirement, SignalTypeOwnerChange:
+		SignalTypeAnomalousBehavior, SignalTypePolicyViolation, SignalTypeRetirement,
+		SignalTypeOwnerChange, SignalTypeIdentityExpired:
 		return true
 	}
 	return false

--- a/domain/token.go
+++ b/domain/token.go
@@ -106,6 +106,14 @@ type OAuthClient struct {
 	// Extensibility
 	Metadata json.RawMessage `bun:"metadata,type:jsonb" json:"metadata,omitempty"`
 
+	// IdentityID optionally binds this OAuth client to an agent identity.
+	// When set, authorization_code and refresh_token grants issued through
+	// this client carry the identity_id forward (refresh_tokens.identity_id
+	// already exists) and gate token issuance on the linked identity's
+	// status + expires_at — same fail-closed semantics jwt_bearer and
+	// api_key paths have. Nil for plain human-session clients (CLI, MCP).
+	IdentityID *string `bun:"identity_id,type:uuid,nullzero" json:"identity_id,omitempty"`
+
 	// Lifecycle
 	IsActive  bool      `bun:"is_active"   json:"is_active"`
 	CreatedAt time.Time `bun:"created_at"  json:"created_at"`

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -30,6 +30,10 @@ func mapErr(err error) error {
 		return huma.Error409Conflict("resource already exists")
 	case strings.Contains(msg, "invalid status transition"):
 		return huma.Error400BadRequest("invalid status transition")
+	case strings.Contains(msg, "identity_expired"), strings.Contains(msg, "identity is not usable"):
+		// Identity is past its expires_at or in a non-usable status —
+		// caller cannot proceed, but it's a 4xx not a 5xx.
+		return huma.Error400BadRequest(msg)
 	default:
 		log.Error().Err(err).Msg("unexpected agent service error")
 		return huma.Error500InternalServerError("internal server error")

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -22,6 +22,11 @@ func mapErr(err error) error {
 	if err == nil {
 		return nil
 	}
+	// Typed sentinels first. Service-layer callers wrap with these so
+	// callers see a 400 instead of a 500 on caller-fixable states.
+	if errors.Is(err, domain.ErrIdentityExpired) || errors.Is(err, domain.ErrIdentityNotUsable) {
+		return huma.Error400BadRequest(err.Error())
+	}
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "no rows in result set"), strings.Contains(msg, "not found"):
@@ -30,10 +35,6 @@ func mapErr(err error) error {
 		return huma.Error409Conflict("resource already exists")
 	case strings.Contains(msg, "invalid status transition"):
 		return huma.Error400BadRequest("invalid status transition")
-	case strings.Contains(msg, "identity_expired"), strings.Contains(msg, "identity is not usable"):
-		// Identity is past its expires_at or in a non-usable status —
-		// caller cannot proceed, but it's a 4xx not a 5xx.
-		return huma.Error400BadRequest(msg)
 	default:
 		log.Error().Err(err).Msg("unexpected agent service error")
 		return huma.Error500InternalServerError("internal server error")

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/rs/zerolog/log"
@@ -56,6 +57,9 @@ type RegisterAgentInput struct {
 		PublicKeyPEM             string          `json:"public_key_pem,omitempty" doc:"PEM-encoded EC P-256 public key for JWT bearer and token_exchange grants"`
 		CredentialPolicyID       string          `json:"credential_policy_id,omitempty" doc:"Identity policy — authority ceiling. Also applied to the auto-created API key unless api_key_credential_policy_id is set. Defaults to the tenant default policy."`
 		APIKeyCredentialPolicyID string          `json:"api_key_credential_policy_id,omitempty" doc:"Optional narrower policy for the auto-created API key. Must be a subset of the identity policy (scopes, TTL, grant types, delegation depth, trust level, attestation). When empty, the API key inherits the identity policy."`
+		// ExpiresAt time-bounds the grant of authority and propagates to the
+		// auto-created API key. RFC3339. Omit for no expiry.
+		ExpiresAt *time.Time `json:"expires_at,omitempty" doc:"RFC3339 timestamp after which the agent and its bootstrap API key are auto-deactivated"`
 		// Fields injected by management API from trusted headers (overridden server-side):
 		AccountID string `json:"account_id,omitempty"`
 		ProjectID string `json:"project_id,omitempty"`
@@ -220,6 +224,7 @@ func (a *API) registerAgentOp(ctx context.Context, input *RegisterAgentInput) (*
 		PublicKeyPEM:             input.Body.PublicKeyPEM,
 		CredentialPolicyID:       input.Body.CredentialPolicyID,
 		APIKeyCredentialPolicyID: input.Body.APIKeyCredentialPolicyID,
+		ExpiresAt:                input.Body.ExpiresAt,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrIdentityAlreadyExists) {

--- a/internal/handler/attestation.go
+++ b/internal/handler/attestation.go
@@ -121,6 +121,11 @@ func (a *API) verifyAttestationOp(ctx context.Context, input *VerifyAttestationI
 			log.Info().Err(err).Str("attestation_id", input.Body.AttestationID).Msg("attestation already verified")
 			return nil, huma.Error409Conflict(err.Error())
 		}
+		// Identity is expired or otherwise non-usable at the post-attestation
+		// issuance step — caller-visible state, not a server fault.
+		if errors.Is(err, domain.ErrIdentityExpired) || errors.Is(err, domain.ErrIdentityNotUsable) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		log.Error().Err(err).Str("attestation_id", input.Body.AttestationID).Msg("attestation verification failed")
 		return nil, huma.Error500InternalServerError("attestation verification failed")
 	}

--- a/internal/handler/credential_policy.go
+++ b/internal/handler/credential_policy.go
@@ -196,6 +196,9 @@ func (a *API) updatePolicyOp(ctx context.Context, input *UpdatePolicyInput) (*Po
 		if errors.Is(err, service.ErrPolicyNotFound) {
 			return nil, huma.Error404NotFound("credential policy not found")
 		}
+		if errors.Is(err, service.ErrInvalidPolicyField) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		log.Error().Err(err).Str("policy_id", input.ID).Msg("failed to update credential policy")
 		return nil, huma.Error500InternalServerError("failed to update credential policy")
 	}

--- a/internal/handler/credential_policy.go
+++ b/internal/handler/credential_policy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/rs/zerolog/log"
@@ -17,14 +18,15 @@ import (
 
 type CreatePolicyInput struct {
 	Body struct {
-		Name                string   `json:"name" required:"true" minLength:"1" doc:"Policy name (unique per tenant)"`
-		Description         string   `json:"description,omitempty" doc:"Policy description"`
-		MaxTTLSeconds       int      `json:"max_ttl_seconds,omitempty" doc:"Maximum token TTL in seconds"`
-		AllowedGrantTypes   []string `json:"allowed_grant_types,omitempty" doc:"Permitted OAuth grant types"`
-		AllowedScopes       []string `json:"allowed_scopes,omitempty" doc:"Permitted OAuth scopes"`
-		RequiredTrustLevel  string   `json:"required_trust_level,omitempty" doc:"Minimum trust level required"`
-		RequiredAttestation string   `json:"required_attestation,omitempty" doc:"Minimum attestation level required"`
-		MaxDelegationDepth  int      `json:"max_delegation_depth,omitempty" doc:"Maximum delegation chain depth"`
+		Name                string     `json:"name" required:"true" minLength:"1" doc:"Policy name (unique per tenant)"`
+		Description         string     `json:"description,omitempty" doc:"Policy description"`
+		MaxTTLSeconds       int        `json:"max_ttl_seconds,omitempty" doc:"Maximum token TTL in seconds"`
+		AllowedGrantTypes   []string   `json:"allowed_grant_types,omitempty" doc:"Permitted OAuth grant types"`
+		AllowedScopes       []string   `json:"allowed_scopes,omitempty" doc:"Permitted OAuth scopes"`
+		RequiredTrustLevel  string     `json:"required_trust_level,omitempty" doc:"Minimum trust level required"`
+		RequiredAttestation string     `json:"required_attestation,omitempty" doc:"Minimum attestation level required"`
+		MaxDelegationDepth  int        `json:"max_delegation_depth,omitempty" doc:"Maximum delegation chain depth"`
+		ExpiresAt           *time.Time `json:"expires_at,omitempty" doc:"RFC3339 timestamp after which the policy is no longer valid"`
 	}
 }
 
@@ -55,6 +57,9 @@ type UpdatePolicyInput struct {
 		RequiredAttestation *string  `json:"required_attestation,omitempty" doc:"Required attestation level"`
 		MaxDelegationDepth  *int     `json:"max_delegation_depth,omitempty" doc:"Max delegation depth"`
 		IsActive            *bool    `json:"is_active,omitempty" doc:"Active status"`
+		// ExpiresAt tri-state: omit to leave unchanged, "" to clear (no expiry),
+		// RFC3339 string to set.
+		ExpiresAt *string `json:"expires_at,omitempty" doc:"RFC3339 expiry, or empty string to clear"`
 	}
 }
 
@@ -121,6 +126,7 @@ func (a *API) createPolicyOp(ctx context.Context, input *CreatePolicyInput) (*Po
 		RequiredTrustLevel:  input.Body.RequiredTrustLevel,
 		RequiredAttestation: input.Body.RequiredAttestation,
 		MaxDelegationDepth:  input.Body.MaxDelegationDepth,
+		ExpiresAt:           input.Body.ExpiresAt,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrPolicyNameConflict) {
@@ -184,6 +190,7 @@ func (a *API) updatePolicyOp(ctx context.Context, input *UpdatePolicyInput) (*Po
 		RequiredAttestation: input.Body.RequiredAttestation,
 		MaxDelegationDepth:  input.Body.MaxDelegationDepth,
 		IsActive:            input.Body.IsActive,
+		ExpiresAt:           input.Body.ExpiresAt,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrPolicyNotFound) {

--- a/internal/handler/expiring_soon.go
+++ b/internal/handler/expiring_soon.go
@@ -74,7 +74,7 @@ func (a *API) registerExpiringSoonRoute(api huma.API) {
 		Method:      http.MethodGet,
 		Path:        "/expiring-soon",
 		Summary:     "List identities, policies, and API keys expiring within a window",
-		Description: "Returns active rows whose expires_at falls between now and now+within. Default window is 168h (one week).",
+		Description: "Returns active rows whose expires_at falls between now and now+within. Default window is 7d (168h).",
 		Tags:        []string{"Identities", "Credential Policies", "API Keys"},
 	}, a.expiringSoonOp)
 }

--- a/internal/handler/expiring_soon.go
+++ b/internal/handler/expiring_soon.go
@@ -95,7 +95,11 @@ func (a *API) expiringSoonOp(ctx context.Context, input *ExpiringSoonInput) (*Ex
 			return nil, huma.Error400BadRequest("within must be positive")
 		}
 		if parsed > maxExpiringSoonWindow {
-			parsed = maxExpiringSoonWindow
+			// Reject (not clamp) so behavior is consistent across input
+			// formats. parseLookaheadDuration already rejects out-of-range
+			// "Nd"/"Nw"; clamping a Go duration silently would let
+			// "?within=9600h" succeed while "?within=400d" returns 400.
+			return nil, huma.Error400BadRequest(fmt.Sprintf("within exceeds maximum window (%s)", maxExpiringSoonWindow))
 		}
 		within = parsed
 	}

--- a/internal/handler/expiring_soon.go
+++ b/internal/handler/expiring_soon.go
@@ -18,40 +18,30 @@ import (
 // parseLookaheadDuration extends time.ParseDuration with the human-friendly
 // "Nd" (days) and "Nw" (weeks) suffixes the spec uses (?within=7d). Plain
 // Go durations like "168h" or "30m" are passed through unchanged.
-//
-// Bounds-checks N against the unit's mathematical ceiling before
-// multiplying so a caller submitting "9999999d" gets a clean 400 instead
-// of a silently truncated int64-overflow result. The handler-side cap
-// (maxExpiringSoonWindow) trims any survivor that's still beyond the
-// product's policy window, but that cap only fires if the multiply
-// itself doesn't wrap.
 func parseLookaheadDuration(s string) (time.Duration, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return 0, fmt.Errorf("empty duration")
 	}
 	last := s[len(s)-1]
-	if last == 'd' || last == 'w' {
-		n, err := strconv.Atoi(s[:len(s)-1])
-		if err != nil {
-			return 0, fmt.Errorf("invalid number before %q: %w", string(last), err)
-		}
-		if n < 0 {
-			return 0, fmt.Errorf("negative duration: %s", s)
-		}
-		unit := 24 * time.Hour
-		if last == 'w' {
-			unit = 7 * 24 * time.Hour
-		}
-		// Reject any N that would overflow int64 when multiplied by unit.
-		// Stays well clear of math.MaxInt64; the handler caps the result
-		// at maxExpiringSoonWindow regardless.
-		if int64(n) > int64(time.Duration(1<<62)/unit) {
-			return 0, fmt.Errorf("duration overflow: %s", s)
-		}
-		return time.Duration(n) * unit, nil
+	if last != 'd' && last != 'w' {
+		return time.ParseDuration(s)
 	}
-	return time.ParseDuration(s)
+	n, err := strconv.Atoi(s[:len(s)-1])
+	if err != nil {
+		return 0, fmt.Errorf("invalid number before %q: %w", string(last), err)
+	}
+	unit := 24 * time.Hour
+	if last == 'w' {
+		unit = 7 * 24 * time.Hour
+	}
+	// Reject anything past the handler's policy cap up-front. Cheaper than
+	// multiplying first and clamping after, and avoids any int64 wrap.
+	maxN := int(maxExpiringSoonWindow / unit)
+	if n < 0 || n > maxN {
+		return 0, fmt.Errorf("within %s out of range (max %d%c)", s, maxN, last)
+	}
+	return time.Duration(n) * unit, nil
 }
 
 // defaultExpiringSoonWindow is used when the caller omits ?within. One week

--- a/internal/handler/expiring_soon.go
+++ b/internal/handler/expiring_soon.go
@@ -100,7 +100,7 @@ func (a *API) expiringSoonOp(ctx context.Context, input *ExpiringSoonInput) (*Ex
 		within = parsed
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 	identities, err := a.identitySvc.ListExpiringSoon(ctx, tenant.AccountID, tenant.ProjectID, now, within)
 	if err != nil {
 		log.Error().Err(err).Msg("expiring-soon: identity scan failed")

--- a/internal/handler/expiring_soon.go
+++ b/internal/handler/expiring_soon.go
@@ -1,0 +1,146 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
+)
+
+// parseLookaheadDuration extends time.ParseDuration with the human-friendly
+// "Nd" (days) and "Nw" (weeks) suffixes the spec uses (?within=7d). Plain
+// Go durations like "168h" or "30m" are passed through unchanged.
+//
+// Bounds-checks N against the unit's mathematical ceiling before
+// multiplying so a caller submitting "9999999d" gets a clean 400 instead
+// of a silently truncated int64-overflow result. The handler-side cap
+// (maxExpiringSoonWindow) trims any survivor that's still beyond the
+// product's policy window, but that cap only fires if the multiply
+// itself doesn't wrap.
+func parseLookaheadDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	last := s[len(s)-1]
+	if last == 'd' || last == 'w' {
+		n, err := strconv.Atoi(s[:len(s)-1])
+		if err != nil {
+			return 0, fmt.Errorf("invalid number before %q: %w", string(last), err)
+		}
+		if n < 0 {
+			return 0, fmt.Errorf("negative duration: %s", s)
+		}
+		unit := 24 * time.Hour
+		if last == 'w' {
+			unit = 7 * 24 * time.Hour
+		}
+		// Reject any N that would overflow int64 when multiplied by unit.
+		// Stays well clear of math.MaxInt64; the handler caps the result
+		// at maxExpiringSoonWindow regardless.
+		if int64(n) > int64(time.Duration(1<<62)/unit) {
+			return 0, fmt.Errorf("duration overflow: %s", s)
+		}
+		return time.Duration(n) * unit, nil
+	}
+	return time.ParseDuration(s)
+}
+
+// defaultExpiringSoonWindow is used when the caller omits ?within. One week
+// matches the Studio "expiring this week" stat card.
+const defaultExpiringSoonWindow = 7 * 24 * time.Hour
+
+// maxExpiringSoonWindow caps the lookahead to one year. Anything past that
+// is more usefully answered by a Studio report, not the inbox endpoint.
+const maxExpiringSoonWindow = 365 * 24 * time.Hour
+
+type ExpiringSoonInput struct {
+	// Within accepts a Go duration string (e.g. "168h", "30m") OR a short
+	// human form using "d" for days or "w" for weeks (e.g. "7d", "2w").
+	// Defaults to 7d when omitted.
+	Within string `query:"within" doc:"Lookahead window. Accepts Go duration syntax (e.g. 168h, 30m) or human shorthand (7d, 2w). Defaults to 7d."`
+}
+
+type ExpiringSoonOutput struct {
+	Body struct {
+		Within             string                     `json:"within"`
+		Identities         []*domain.Identity         `json:"identities"`
+		CredentialPolicies []*domain.CredentialPolicy `json:"credential_policies"`
+		APIKeys            []*domain.APIKey           `json:"api_keys"`
+	}
+}
+
+func (a *API) registerExpiringSoonRoute(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "expiring-soon",
+		Method:      http.MethodGet,
+		Path:        "/expiring-soon",
+		Summary:     "List identities, policies, and API keys expiring within a window",
+		Description: "Returns active rows whose expires_at falls between now and now+within. Default window is 168h (one week).",
+		Tags:        []string{"Identities", "Credential Policies", "API Keys"},
+	}, a.expiringSoonOp)
+}
+
+func (a *API) expiringSoonOp(ctx context.Context, input *ExpiringSoonInput) (*ExpiringSoonOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	within := defaultExpiringSoonWindow
+	if input.Within != "" {
+		parsed, err := parseLookaheadDuration(input.Within)
+		if err != nil {
+			return nil, huma.Error400BadRequest("invalid within duration: " + err.Error())
+		}
+		if parsed <= 0 {
+			return nil, huma.Error400BadRequest("within must be positive")
+		}
+		if parsed > maxExpiringSoonWindow {
+			parsed = maxExpiringSoonWindow
+		}
+		within = parsed
+	}
+
+	now := time.Now()
+	identities, err := a.identitySvc.ListExpiringSoon(ctx, tenant.AccountID, tenant.ProjectID, now, within)
+	if err != nil {
+		log.Error().Err(err).Msg("expiring-soon: identity scan failed")
+		return nil, huma.Error500InternalServerError("failed to list expiring identities")
+	}
+	policies, err := a.credentialPolicySvc.ListExpiringSoon(ctx, tenant.AccountID, tenant.ProjectID, now, within)
+	if err != nil {
+		log.Error().Err(err).Msg("expiring-soon: policy scan failed")
+		return nil, huma.Error500InternalServerError("failed to list expiring credential policies")
+	}
+	keys, err := a.apiKeySvc.ListExpiringSoon(ctx, tenant.AccountID, tenant.ProjectID, now, within)
+	if err != nil {
+		log.Error().Err(err).Msg("expiring-soon: api-key scan failed")
+		return nil, huma.Error500InternalServerError("failed to list expiring api keys")
+	}
+
+	if identities == nil {
+		identities = []*domain.Identity{}
+	}
+	if policies == nil {
+		policies = []*domain.CredentialPolicy{}
+	}
+	if keys == nil {
+		keys = []*domain.APIKey{}
+	}
+
+	out := &ExpiringSoonOutput{}
+	out.Body.Within = within.String()
+	out.Body.Identities = identities
+	out.Body.CredentialPolicies = policies
+	out.Body.APIKeys = keys
+	return out, nil
+}

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/rs/zerolog/log"
@@ -39,6 +40,9 @@ type CreateIdentityInput struct {
 		CapabilityTier string `json:"capability_tier,omitempty" enum:"low,high" doc:"CoSAI §3.2 capability tier"`
 		RiskTier       string `json:"risk_tier,omitempty" enum:"low,high" doc:"CoSAI §3.2 risk tier"`
 		IAL            string `json:"ial,omitempty" enum:"ial1,ial2,ial3" doc:"NIST SP 800-63 Identity Assurance Level"`
+		// ExpiresAt time-bounds the grant of authority. RFC3339. Omit for
+		// no expiry (the historical default).
+		ExpiresAt *time.Time `json:"expires_at,omitempty" doc:"RFC3339 timestamp after which the identity is auto-deactivated"`
 	}
 }
 
@@ -93,6 +97,10 @@ type UpdateIdentityInput struct {
 		CapabilityTier *string `json:"capability_tier,omitempty" enum:"low,high" doc:"CoSAI §3.2 capability tier"`
 		RiskTier       *string `json:"risk_tier,omitempty" enum:"low,high" doc:"CoSAI §3.2 risk tier"`
 		IAL            *string `json:"ial,omitempty" enum:"ial1,ial2,ial3" doc:"NIST SP 800-63 Identity Assurance Level"`
+		// ExpiresAt tri-state: omit to leave unchanged, "" to clear (remove
+		// expiry), RFC3339 timestamp to set. The "Extend access" flow PATCHes
+		// a new RFC3339 value here.
+		ExpiresAt *string `json:"expires_at,omitempty" doc:"RFC3339 expiry, or empty string to clear"`
 	}
 }
 
@@ -207,6 +215,7 @@ func (a *API) createIdentityOp(ctx context.Context, input *CreateIdentityInput) 
 		CapabilityTier:     input.Body.CapabilityTier,
 		RiskTier:           input.Body.RiskTier,
 		IAL:                input.Body.IAL,
+		ExpiresAt:          input.Body.ExpiresAt,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrIdentityAlreadyExists) {
@@ -320,6 +329,7 @@ func (a *API) updateIdentityOp(ctx context.Context, input *UpdateIdentityInput) 
 		CapabilityTier:     input.Body.CapabilityTier,
 		RiskTier:           input.Body.RiskTier,
 		IAL:                input.Body.IAL,
+		ExpiresAt:          input.Body.ExpiresAt,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrPolicyNotFound) {

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -72,10 +72,17 @@ func extractOAuthError(err error) (code, description string, status int) {
 		return "insufficient_scope", err.Error(), http.StatusBadRequest
 	}
 	// Identity gates can fire at the chokepoint after the per-grant
-	// check passed (TOCTOU window). Map them to invalid_grant so callers
-	// don't see a generic 500 server_error.
-	if errors.Is(err, domain.ErrIdentityExpired) || errors.Is(err, domain.ErrIdentityNotUsable) {
-		return "invalid_grant", err.Error(), http.StatusBadRequest
+	// check passed (TOCTOU window). Map to stable error_description
+	// strings — the per-grant checks emit the exact same values, so
+	// callers see a consistent hint regardless of which code path fired.
+	// Using err.Error() here would leak the wrapped chain (which includes
+	// the literal expires_at timestamp) and produce a different string
+	// shape than the per-grant path.
+	if errors.Is(err, domain.ErrIdentityExpired) {
+		return "invalid_grant", "identity_expired", http.StatusBadRequest
+	}
+	if errors.Is(err, domain.ErrIdentityNotUsable) {
+		return "invalid_grant", "identity is suspended or deactivated", http.StatusBadRequest
 	}
 	return "server_error", "an unexpected error occurred", http.StatusInternalServerError
 }
@@ -110,8 +117,13 @@ func (a *API) registerOAuthRoutes(api huma.API) {
 		Method:      http.MethodPost,
 		Path:        "/oauth2/token",
 		Summary:     "OAuth 2.0 Token Endpoint (client_credentials, jwt_bearer, token_exchange)",
-		Description: "Publicly accessible — tenant is derived from credential material, not headers.",
-		Tags:        []string{"OAuth"},
+		Description: "Publicly accessible — tenant is derived from credential material, not headers.\n\n" +
+			"**TTL narrowing:** the returned `expires_in` (and the JWT `exp` claim) may be **less** than what the caller requested. " +
+			"This happens — silently, RFC 6749 §3.3-style — when the issued token's lifetime would otherwise outlive a bound that " +
+			"constrains it. Effective TTL is `min(requested_ttl, service_max_ttl, policy.max_ttl_seconds, time_until(identity.expires_at), time_until(credential.expires_at))`. " +
+			"Callers MUST use `expires_in` from the response (not the value they requested) when scheduling refresh. " +
+			"Server-side logs name the clamp reason; the chokepoint emits a structured log line with `requested_ttl` and the remaining lifetime that won.",
+		Tags: []string{"OAuth"},
 	}, a.tokenOp)
 
 	huma.Register(api, huma.Operation{

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -84,6 +84,9 @@ func extractOAuthError(err error) (code, description string, status int) {
 	if errors.Is(err, domain.ErrIdentityNotUsable) {
 		return "invalid_grant", "identity is suspended or deactivated", http.StatusBadRequest
 	}
+	if errors.Is(err, domain.ErrCredentialExpired) {
+		return "invalid_grant", "credential_expired", http.StatusBadRequest
+	}
 	return "server_error", "an unexpected error occurred", http.StatusInternalServerError
 }
 

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/rs/zerolog/log"
 
+	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/service"
 )
 
@@ -69,6 +70,12 @@ func extractOAuthError(err error) (code, description string, status int) {
 	}
 	if errors.Is(err, service.ErrScopesNotAllowed) {
 		return "insufficient_scope", err.Error(), http.StatusBadRequest
+	}
+	// Identity gates can fire at the chokepoint after the per-grant
+	// check passed (TOCTOU window). Map them to invalid_grant so callers
+	// don't see a generic 500 server_error.
+	if errors.Is(err, domain.ErrIdentityExpired) || errors.Is(err, domain.ErrIdentityNotUsable) {
+		return "invalid_grant", err.Error(), http.StatusBadRequest
 	}
 	return "server_error", "an unexpected error occurred", http.StatusInternalServerError
 }

--- a/internal/handler/oauth_client.go
+++ b/internal/handler/oauth_client.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -145,7 +146,15 @@ func (a *API) createOAuthClientOp(ctx context.Context, input *CreateOAuthClientI
 			return nil, huma.Error401Unauthorized("missing tenant context")
 		}
 		if _, err := a.identitySvc.GetIdentity(ctx, input.Body.IdentityID, tenant.AccountID, tenant.ProjectID); err != nil {
-			return nil, huma.Error400BadRequest("identity_id not found in this tenant")
+			// Distinguish caller-fixable not-found-in-tenant (400) from
+			// transient DB errors (500). The repo wraps sql.ErrNoRows in
+			// its "failed to get identity" string, so unwrap to get the
+			// underlying sentinel.
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, huma.Error400BadRequest("identity_id not found in this tenant")
+			}
+			log.Error().Err(err).Str("identity_id", input.Body.IdentityID).Msg("identity lookup failed during oauth client create")
+			return nil, huma.Error500InternalServerError("failed to validate identity_id")
 		}
 	}
 

--- a/internal/handler/oauth_client.go
+++ b/internal/handler/oauth_client.go
@@ -135,9 +135,10 @@ func (a *API) registerOAuthClientRoutes(api huma.API) {
 
 func (a *API) createOAuthClientOp(ctx context.Context, input *CreateOAuthClientInput) (*OAuthClientCreatedOutput, error) {
 	// Tenant-scoped IDOR guard on identity_id: a caller who tries to bind
-	// the new client to an identity outside their tenant is rejected with
-	// 404 — the same shape GetIdentity emits for a not-found ID. Performed
-	// at the handler boundary so the service layer stays tenant-agnostic.
+	// the new client to an identity outside their tenant gets a 400 with
+	// "not found in this tenant" — same response shape we use for any
+	// caller-supplied foreign reference. Performed at the handler
+	// boundary so the service layer stays tenant-agnostic.
 	if input.Body.IdentityID != "" {
 		tenant, terr := internalMiddleware.GetTenant(ctx)
 		if terr != nil {

--- a/internal/handler/oauth_client.go
+++ b/internal/handler/oauth_client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/highflame-ai/zeroid/domain"
+	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
 	"github.com/highflame-ai/zeroid/internal/service"
 )
 
@@ -48,6 +49,12 @@ type CreateOAuthClientInput struct {
 
 		// Extensibility
 		Metadata json.RawMessage `json:"metadata,omitempty" doc:"Arbitrary JSON metadata"`
+
+		// IdentityID optionally binds this client to an agent identity.
+		// When set, authorization_code and refresh_token grants gate token
+		// issuance on the linked identity's status + expires_at. The
+		// identity must exist in the caller's tenant (validated below).
+		IdentityID string `json:"identity_id,omitempty" doc:"Optional identity UUID to bind this client to — gates authorization_code and refresh_token grants on the linked identity's status and expires_at"`
 	}
 }
 
@@ -127,6 +134,20 @@ func (a *API) registerOAuthClientRoutes(api huma.API) {
 }
 
 func (a *API) createOAuthClientOp(ctx context.Context, input *CreateOAuthClientInput) (*OAuthClientCreatedOutput, error) {
+	// Tenant-scoped IDOR guard on identity_id: a caller who tries to bind
+	// the new client to an identity outside their tenant is rejected with
+	// 404 — the same shape GetIdentity emits for a not-found ID. Performed
+	// at the handler boundary so the service layer stays tenant-agnostic.
+	if input.Body.IdentityID != "" {
+		tenant, terr := internalMiddleware.GetTenant(ctx)
+		if terr != nil {
+			return nil, huma.Error401Unauthorized("missing tenant context")
+		}
+		if _, err := a.identitySvc.GetIdentity(ctx, input.Body.IdentityID, tenant.AccountID, tenant.ProjectID); err != nil {
+			return nil, huma.Error400BadRequest("identity_id not found in this tenant")
+		}
+	}
+
 	client, plainSecret, err := a.oauthClientSvc.RegisterClient(ctx, service.RegisterClientRequest{
 		ClientID:                input.Body.ClientID,
 		Name:                    input.Body.Name,
@@ -144,6 +165,7 @@ func (a *API) createOAuthClientOp(ctx context.Context, input *CreateOAuthClientI
 		SoftwareVersion:         input.Body.SoftwareVersion,
 		Contacts:                input.Body.Contacts,
 		Metadata:                input.Body.Metadata,
+		IdentityID:              input.Body.IdentityID,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrOAuthClientAlreadyExists) {

--- a/internal/handler/proof.go
+++ b/internal/handler/proof.go
@@ -8,6 +8,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/rs/zerolog/log"
 
+	"github.com/highflame-ai/zeroid/domain"
 	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
 	"github.com/highflame-ai/zeroid/internal/service"
 )
@@ -81,6 +82,9 @@ func (a *API) generateProofOp(ctx context.Context, input *GenerateProofInput) (*
 
 	proofToken, err := a.proofSvc.GenerateProofToken(ctx, identity, input.Body.Audience, input.Body.Nonce)
 	if err != nil {
+		if errors.Is(err, domain.ErrIdentityExpired) || errors.Is(err, domain.ErrIdentityNotUsable) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		log.Error().Err(err).Str("identity_id", input.Body.IdentityID).Msg("failed to generate proof token")
 		return nil, huma.Error500InternalServerError("failed to generate proof token")
 	}

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -121,6 +121,7 @@ func (a *API) RegisterAdmin(api huma.API, router chi.Router) {
 	a.registerSignalRoutes(api, router)
 	a.registerProofVerifyRoute(api)
 	a.registerAuditRoutes(api)
+	a.registerExpiringSoonRoute(api)
 }
 
 // RegisterAgentAuth registers endpoints requiring agent-auth middleware (proof generation).

--- a/internal/middleware/management_auth.go
+++ b/internal/middleware/management_auth.go
@@ -43,10 +43,12 @@ func TenantContextMiddleware(next http.Handler) http.Handler {
 		// X-User-ID is informational and flows into audit modified_by stamps.
 		// Reserved system:* prefix is silently dropped so an authenticated
 		// admin caller can't impersonate the cleanup worker or any other
-		// server-internal actor in the audit trail. SetCallerName from
-		// server-side code (via context, not headers) bypasses this filter.
+		// server-internal actor in the audit trail. Case-insensitive match
+		// so "System:" / "SYSTEM:" can't sneak past a downstream log query
+		// that filters with ILIKE 'system:%'. SetCallerName from server-
+		// side code (via context, not headers) bypasses this filter.
 		userID := r.Header.Get(HeaderUserID)
-		if userID != "" && !strings.HasPrefix(userID, SystemCallerPrefix) {
+		if userID != "" && !strings.HasPrefix(strings.ToLower(userID), SystemCallerPrefix) {
 			ctx = SetCallerName(ctx, userID)
 		}
 

--- a/internal/middleware/management_auth.go
+++ b/internal/middleware/management_auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"strings"
 )
 
 type adminContextKey string
@@ -13,6 +14,12 @@ const (
 	HeaderUserID    = "X-User-ID"
 
 	callerNameKey adminContextKey = "caller_name"
+
+	// SystemCallerPrefix is reserved for server-internal actors that need
+	// to stamp audit records (e.g. the cleanup worker's expired-identity
+	// sweep). Caller-supplied X-User-ID values with this prefix are
+	// silently dropped so an admin can't forge attribution to a worker.
+	SystemCallerPrefix = "system:"
 )
 
 // TenantContextMiddleware extracts tenant context (X-Account-ID, X-Project-ID)
@@ -33,8 +40,13 @@ func TenantContextMiddleware(next http.Handler) http.Handler {
 			ctx = SetTenant(ctx, accountID, projectID)
 		}
 
+		// X-User-ID is informational and flows into audit modified_by stamps.
+		// Reserved system:* prefix is silently dropped so an authenticated
+		// admin caller can't impersonate the cleanup worker or any other
+		// server-internal actor in the audit trail. SetCallerName from
+		// server-side code (via context, not headers) bypasses this filter.
 		userID := r.Header.Get(HeaderUserID)
-		if userID != "" {
+		if userID != "" && !strings.HasPrefix(userID, SystemCallerPrefix) {
 			ctx = SetCallerName(ctx, userID)
 		}
 

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -59,6 +59,9 @@ type RegisterAgentRequest struct {
 	// inside APIKeyService.CreateKey. When empty, the API key inherits the
 	// identity policy verbatim (common case).
 	APIKeyCredentialPolicyID string
+	// ExpiresAt time-bounds both the identity and (if non-nil) the auto-
+	// created API key. Nil means "no expiry".
+	ExpiresAt *time.Time
 }
 
 // AgentResponse is the API response for a single agent identity.
@@ -147,6 +150,7 @@ func (s *AgentService) RegisterAgent(ctx context.Context, req RegisterAgentReque
 		CreatedBy:          req.CreatedBy,
 		PublicKeyPEM:       req.PublicKeyPEM,
 		CredentialPolicyID: req.CredentialPolicyID,
+		ExpiresAt:          req.ExpiresAt,
 	})
 	if err != nil {
 		return nil, err
@@ -168,6 +172,7 @@ func (s *AgentService) RegisterAgent(ctx context.Context, req RegisterAgentReque
 		Name:               fmt.Sprintf("Agent: %s", req.Name),
 		IdentityID:         identity.ID,
 		CredentialPolicyID: apiKeyPolicyID,
+		ExpiresAt:          req.ExpiresAt,
 	})
 	if err != nil {
 		// Compensating action — deactivate the identity if key creation fails.

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -331,10 +331,10 @@ func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID s
 		return nil, err
 	}
 	if !identity.Status.IsUsable() {
-		return nil, fmt.Errorf("identity is not usable (status: %s)", identity.Status)
+		return nil, fmt.Errorf("%w (status: %s)", domain.ErrIdentityNotUsable, identity.Status)
 	}
 	if identity.IsExpired() {
-		return nil, fmt.Errorf("identity_expired: identity %s expired at %s", identity.ID, identity.ExpiresAt.Format(time.RFC3339))
+		return nil, fmt.Errorf("%w: identity %s expired at %s", domain.ErrIdentityExpired, identity.ID, identity.ExpiresAt.Format(time.RFC3339))
 	}
 
 	// Revoke existing keys.

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -321,23 +321,34 @@ func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, proje
 	return &resp, nil
 }
 
-// RotateKey revokes the old key and creates a new one.
+// RotateKey revokes the old key and creates a new one. Inherits the
+// identity's expires_at so a rotated key on a time-bound agent expires
+// alongside its parent — without this, rotation silently extends the
+// key's lifetime past the agent's authority window.
 func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID string) (*AgentRegistrationResponse, error) {
 	identity, err := s.identitySvc.GetIdentity(ctx, id, accountID, projectID)
 	if err != nil {
 		return nil, err
 	}
+	if !identity.Status.IsUsable() {
+		return nil, fmt.Errorf("identity is not usable (status: %s)", identity.Status)
+	}
+	if identity.IsExpired() {
+		return nil, fmt.Errorf("identity_expired: identity %s expired at %s", identity.ID, identity.ExpiresAt.Format(time.RFC3339))
+	}
 
 	// Revoke existing keys.
 	s.revokeKeysByIdentity(ctx, identity.ID)
 
-	// Create new key.
+	// Create new key. ExpiresAt propagates from the identity so the
+	// rotated key inherits the parent's time-bound window.
 	skResp, err := s.apiKeySvc.CreateKey(ctx, CreateAPIKeyRequest{
 		AccountID:  identity.AccountID,
 		ProjectID:  identity.ProjectID,
 		CreatedBy:  "system:key_rotation",
 		Name:       fmt.Sprintf("Agent: %s", identity.Name),
 		IdentityID: identity.ID,
+		ExpiresAt:  identity.ExpiresAt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rotated key: %w", err)

--- a/internal/service/apikey.go
+++ b/internal/service/apikey.go
@@ -45,8 +45,14 @@ type CreateAPIKeyRequest struct {
 	Product            string
 	Scopes             []string
 	Environment        string
-	ExpiresInDays      *int
-	Metadata           json.RawMessage
+	// ExpiresInDays sets expires_at = now + N days. Mutually exclusive with
+	// ExpiresAt — when both are set, ExpiresAt wins. ExpiresInDays kept for
+	// backward compat with existing callers.
+	ExpiresInDays *int
+	// ExpiresAt sets the absolute expiry. Used by the time-bound authority
+	// flow so agent + linked key expire at the same moment.
+	ExpiresAt *time.Time
+	Metadata  json.RawMessage
 }
 
 // CreateAPIKeyResponse is returned once on creation — contains the full key (shown once).
@@ -149,6 +155,12 @@ func (s *APIKeyService) CreateKey(ctx context.Context, req CreateAPIKeyRequest) 
 		t := time.Now().AddDate(0, 0, *req.ExpiresInDays)
 		expiresAt = &t
 	}
+	// ExpiresAt wins when both are supplied — callers using the absolute
+	// form (time-bound authority flow) usually want the key to expire at
+	// the same instant as its identity, not after a rounded N-day window.
+	if req.ExpiresAt != nil {
+		expiresAt = req.ExpiresAt
+	}
 
 	scopes := req.Scopes
 	if scopes == nil {
@@ -201,6 +213,12 @@ func (s *APIKeyService) CreateKey(ctx context.Context, req CreateAPIKeyRequest) 
 		ExpiresAt:   expiresAt,
 		CreatedAt:   sk.CreatedAt,
 	}, nil
+}
+
+// ListExpiringSoon returns active API keys whose expires_at falls within
+// now..now+within. Used by GET /expiring-soon.
+func (s *APIKeyService) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.APIKey, error) {
+	return s.repo.ListExpiringSoon(ctx, accountID, projectID, now, within)
 }
 
 // ListKeys returns paginated API keys for an account/project.

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -264,10 +264,10 @@ func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountI
 		// "identity_expired" error rather than a generic post-attestation
 		// issuance failure.
 		if !identity.Status.IsUsable() {
-			return fmt.Errorf("identity is not usable (status: %s)", identity.Status)
+			return fmt.Errorf("%w (status: %s)", domain.ErrIdentityNotUsable, identity.Status)
 		}
 		if identity.IsExpired() {
-			return fmt.Errorf("identity_expired: identity %s expired at %s", identity.ID, identity.ExpiresAt.Format(time.RFC3339))
+			return fmt.Errorf("%w: identity %s expired at %s", domain.ErrIdentityExpired, identity.ID, identity.ExpiresAt.Format(time.RFC3339))
 		}
 
 		issued, issuedCred, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -258,6 +258,17 @@ func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountI
 		if err != nil {
 			return fmt.Errorf("failed to load identity for verified attestation: %w", err)
 		}
+		// Fail-fast on time-bound authority before any signing work. The
+		// chokepoint inside IssueCredential is the authoritative gate, but
+		// catching expired identities here gives operators a precise
+		// "identity_expired" error rather than a generic post-attestation
+		// issuance failure.
+		if !identity.Status.IsUsable() {
+			return fmt.Errorf("identity is not usable (status: %s)", identity.Status)
+		}
+		if identity.IsExpired() {
+			return fmt.Errorf("identity_expired: identity %s expired at %s", identity.ID, identity.ExpiresAt.Format(time.RFC3339))
+		}
 
 		issued, issuedCred, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 			Identity:  identity,

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -165,7 +165,7 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	if req.CredentialExpiresAt != nil {
 		remaining := int(req.CredentialExpiresAt.Sub(clampNow).Seconds())
 		if remaining <= 0 {
-			return nil, nil, fmt.Errorf("credential expired at %s", req.CredentialExpiresAt.Format(time.RFC3339))
+			return nil, nil, fmt.Errorf("%w: credential expired at %s", domain.ErrCredentialExpired, req.CredentialExpiresAt.Format(time.RFC3339))
 		}
 		if ttl > remaining {
 			log.Info().

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -94,6 +94,12 @@ type IssueRequest struct {
 	// CustomClaims allows callers to add arbitrary key-value pairs to the JWT.
 	// This is the extensibility hook for deployment-specific claims.
 	CustomClaims map[string]any
+	// CredentialExpiresAt is the upper bound on the issued token's exp claim
+	// derived from the credential material itself — typically the API key's
+	// expires_at for api_key grants. The chokepoint clamps TTL by
+	// min(CredentialExpiresAt, Identity.ExpiresAt) so the JWT exp never
+	// outlives the authority. Nil means "no per-credential bound."
+	CredentialExpiresAt *time.Time
 }
 
 // ErrScopesNotAllowed is returned when one or more requested scopes are not in the identity's AllowedScopes list.
@@ -128,6 +134,47 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	}
 	if ttl > s.maxTTL {
 		ttl = s.maxTTL
+	}
+	// Clamp TTL by the authority's remaining lifetime. A JWT whose exp
+	// claim outlives its authority window would still verify locally
+	// (tokens.verify() doesn't check revocation) for the gap between
+	// authority-expiry and JWT-exp. Clamping here makes time-bound
+	// authority an enforced invariant on the issued token itself, not
+	// just on the cascade-revocation side.
+	//
+	// Both bounds (identity + per-credential) are min-combined with the
+	// requested TTL. Already-expired authority short-circuits to error
+	// — the IsExpired() check above caught the identity case; here we
+	// defend against per-credential expiry that the chokepoint doesn't
+	// otherwise see.
+	clampNow := time.Now()
+	if req.Identity.ExpiresAt != nil {
+		remaining := int(req.Identity.ExpiresAt.Sub(clampNow).Seconds())
+		if remaining <= 0 {
+			return nil, nil, fmt.Errorf("%w: identity expired at %s", domain.ErrIdentityExpired, req.Identity.ExpiresAt.Format(time.RFC3339))
+		}
+		if ttl > remaining {
+			log.Info().
+				Str("identity_id", req.Identity.ID).
+				Int("requested_ttl", ttl).
+				Int("identity_remaining_seconds", remaining).
+				Msg("clamping token TTL to identity remaining lifetime")
+			ttl = remaining
+		}
+	}
+	if req.CredentialExpiresAt != nil {
+		remaining := int(req.CredentialExpiresAt.Sub(clampNow).Seconds())
+		if remaining <= 0 {
+			return nil, nil, fmt.Errorf("credential expired at %s", req.CredentialExpiresAt.Format(time.RFC3339))
+		}
+		if ttl > remaining {
+			log.Info().
+				Str("identity_id", req.Identity.ID).
+				Int("requested_ttl", ttl).
+				Int("credential_remaining_seconds", remaining).
+				Msg("clamping token TTL to credential remaining lifetime")
+			ttl = remaining
+		}
 	}
 	if req.GrantType == "" {
 		req.GrantType = domain.GrantTypeClientCredentials

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -112,14 +112,14 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 		return nil, nil, fmt.Errorf("identity is required")
 	}
 	if !req.Identity.Status.IsUsable() {
-		return nil, nil, fmt.Errorf("identity is not usable (status: %s)", req.Identity.Status)
+		return nil, nil, fmt.Errorf("%w (status: %s)", domain.ErrIdentityNotUsable, req.Identity.Status)
 	}
 	if req.Identity.IsExpired() {
 		// Fail-closed even when the cleanup worker hasn't yet swept the
 		// identity into status=deactivated. The check at this chokepoint
 		// is what guarantees no grant path can mint a token past the
 		// authority's expiry window, regardless of worker timing.
-		return nil, nil, fmt.Errorf("identity expired at %s", req.Identity.ExpiresAt.Format(time.RFC3339))
+		return nil, nil, fmt.Errorf("%w: identity expired at %s", domain.ErrIdentityExpired, req.Identity.ExpiresAt.Format(time.RFC3339))
 	}
 
 	ttl := req.TTL

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -114,6 +114,13 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	if !req.Identity.Status.IsUsable() {
 		return nil, nil, fmt.Errorf("identity is not usable (status: %s)", req.Identity.Status)
 	}
+	if req.Identity.IsExpired() {
+		// Fail-closed even when the cleanup worker hasn't yet swept the
+		// identity into status=deactivated. The check at this chokepoint
+		// is what guarantees no grant path can mint a token past the
+		// authority's expiry window, regardless of worker timing.
+		return nil, nil, fmt.Errorf("identity expired at %s", req.Identity.ExpiresAt.Format(time.RFC3339))
+	}
 
 	ttl := req.TTL
 	if ttl <= 0 {

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -154,7 +154,12 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 			return nil, nil, fmt.Errorf("%w: identity expired at %s", domain.ErrIdentityExpired, req.Identity.ExpiresAt.Format(time.RFC3339))
 		}
 		if ttl > remaining {
-			log.Info().
+			// Debug level: a busy agent making frequent requests near its
+			// expiry would emit this on every issuance — that's normal
+			// near-end-of-life behavior, not something operators need
+			// flagged at Info. Enable debug logging when diagnosing
+			// surprises about shorter-than-expected token lifetimes.
+			log.Debug().
 				Str("identity_id", req.Identity.ID).
 				Int("requested_ttl", ttl).
 				Int("identity_remaining_seconds", remaining).
@@ -168,7 +173,7 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 			return nil, nil, fmt.Errorf("%w: credential expired at %s", domain.ErrCredentialExpired, req.CredentialExpiresAt.Format(time.RFC3339))
 		}
 		if ttl > remaining {
-			log.Info().
+			log.Debug().
 				Str("identity_id", req.Identity.ID).
 				Int("requested_ttl", ttl).
 				Int("credential_remaining_seconds", remaining).

--- a/internal/service/credential_policy.go
+++ b/internal/service/credential_policy.go
@@ -95,6 +95,8 @@ type CreatePolicyRequest struct {
 	RequiredTrustLevel  string
 	RequiredAttestation string
 	MaxDelegationDepth  int
+	// ExpiresAt time-bounds the policy. Nil means "no expiry".
+	ExpiresAt *time.Time
 }
 
 // CreatePolicy creates a new credential policy.
@@ -135,6 +137,7 @@ func (s *CredentialPolicyService) CreatePolicy(ctx context.Context, req CreatePo
 		RequiredAttestation: req.RequiredAttestation,
 		MaxDelegationDepth:  req.MaxDelegationDepth,
 		IsActive:            true,
+		ExpiresAt:           req.ExpiresAt,
 		CreatedAt:           time.Now(),
 		UpdatedAt:           time.Now(),
 	}
@@ -169,6 +172,12 @@ func (s *CredentialPolicyService) ListPolicies(ctx context.Context, accountID, p
 	return s.repo.List(ctx, accountID, projectID)
 }
 
+// ListExpiringSoon returns active credential policies whose expires_at falls
+// within now..now+within. Used by GET /expiring-soon.
+func (s *CredentialPolicyService) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.CredentialPolicy, error) {
+	return s.repo.ListExpiringSoon(ctx, accountID, projectID, now, within)
+}
+
 // UpdatePolicyRequest holds parameters for updating a credential policy.
 type UpdatePolicyRequest struct {
 	Name                string
@@ -180,6 +189,11 @@ type UpdatePolicyRequest struct {
 	RequiredAttestation *string
 	MaxDelegationDepth  *int
 	IsActive            *bool
+	// ExpiresAt tri-state pointer to RFC3339 string:
+	//   nil → leave unchanged
+	//   ""  → clear to NULL (no expiry)
+	//   rfc3339 → set
+	ExpiresAt *string
 }
 
 // UpdatePolicy updates mutable fields of an existing credential policy.
@@ -231,6 +245,17 @@ func (s *CredentialPolicyService) UpdatePolicy(ctx context.Context, id, accountI
 	if req.IsActive != nil {
 		policy.IsActive = *req.IsActive
 	}
+	if req.ExpiresAt != nil {
+		if *req.ExpiresAt == "" {
+			policy.ExpiresAt = nil
+		} else {
+			t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+			if err != nil {
+				return nil, fmt.Errorf("invalid expires_at %q (must be RFC3339)", *req.ExpiresAt)
+			}
+			policy.ExpiresAt = &t
+		}
+	}
 
 	policy.UpdatedAt = time.Now()
 	if err := s.repo.Update(ctx, policy); err != nil {
@@ -253,6 +278,9 @@ func (s *CredentialPolicyService) EnforcePolicy(ctx context.Context, policy *dom
 	}
 	if !policy.IsActive {
 		return fmt.Errorf("%w: policy %q is inactive", ErrPolicyViolation, policy.Name)
+	}
+	if policy.IsExpired() {
+		return fmt.Errorf("%w: policy %q expired at %s", ErrPolicyViolation, policy.Name, policy.ExpiresAt.Format(time.RFC3339))
 	}
 
 	// 1. TTL <= policy.max_ttl_seconds

--- a/internal/service/credential_policy.go
+++ b/internal/service/credential_policy.go
@@ -246,13 +246,13 @@ func (s *CredentialPolicyService) UpdatePolicy(ctx context.Context, id, accountI
 		policy.IsActive = *req.IsActive
 	}
 	if req.ExpiresAt != nil {
-		if *req.ExpiresAt == "" {
+		t, cleared, err := parseExpiresAtPatch(*req.ExpiresAt)
+		if err != nil {
+			return nil, err
+		}
+		if cleared {
 			policy.ExpiresAt = nil
 		} else {
-			t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
-			if err != nil {
-				return nil, fmt.Errorf("invalid expires_at %q (must be RFC3339)", *req.ExpiresAt)
-			}
 			policy.ExpiresAt = &t
 		}
 	}

--- a/internal/service/credential_policy.go
+++ b/internal/service/credential_policy.go
@@ -23,6 +23,11 @@ var ErrPolicyViolation = errors.New("credential policy violation")
 // ErrPolicyNameConflict is returned when a policy with the same name already exists in the tenant.
 var ErrPolicyNameConflict = errors.New("credential policy with this name already exists")
 
+// ErrInvalidPolicyField marks caller-fixable input errors on policy
+// create/update (e.g. malformed expires_at, backdated expires_at). Maps
+// to 400 at the HTTP boundary.
+var ErrInvalidPolicyField = errors.New("invalid credential policy field")
+
 // ErrPolicySubsetViolation is returned when a would-be API-key policy is
 // broader than the owning identity's policy along any axis (scopes, TTL,
 // grant types, delegation depth, trust level, attestation). Returned as a
@@ -248,7 +253,7 @@ func (s *CredentialPolicyService) UpdatePolicy(ctx context.Context, id, accountI
 	if req.ExpiresAt != nil {
 		t, cleared, err := parseExpiresAtPatch(*req.ExpiresAt)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", ErrInvalidPolicyField, err)
 		}
 		if cleared {
 			policy.ExpiresAt = nil

--- a/internal/service/credential_policy.go
+++ b/internal/service/credential_policy.go
@@ -23,9 +23,15 @@ var ErrPolicyViolation = errors.New("credential policy violation")
 // ErrPolicyNameConflict is returned when a policy with the same name already exists in the tenant.
 var ErrPolicyNameConflict = errors.New("credential policy with this name already exists")
 
-// ErrInvalidPolicyField marks caller-fixable input errors on policy
-// create/update (e.g. malformed expires_at, backdated expires_at). Maps
-// to 400 at the HTTP boundary.
+// ErrInvalidPolicyField marks caller-fixable input errors emitted by
+// UpdatePolicy when the tri-state expires_at PATCH string fails to parse
+// (malformed RFC3339) or is backdated. Maps to 400 at the HTTP boundary.
+//
+// CreatePolicy does NOT emit this sentinel: it takes *time.Time, so
+// Huma's input binding already rejects malformed values at the request
+// boundary, and a backdated expires_at on create is intentionally
+// permitted (used by integration tests to mint an already-expired
+// policy without a sleep).
 var ErrInvalidPolicyField = errors.New("invalid credential policy field")
 
 // ErrPolicySubsetViolation is returned when a would-be API-key policy is

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -470,8 +470,9 @@ func parseExpiresAtPatch(raw string) (time.Time, bool, error) {
 	if err != nil {
 		return time.Time{}, false, fmt.Errorf("invalid expires_at %q (must be RFC3339)", raw)
 	}
-	if !t.After(time.Now()) {
-		return time.Time{}, false, fmt.Errorf("expires_at must be in the future (got %s, now %s)", t.Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339))
+	now := time.Now().UTC()
+	if !t.After(now) {
+		return time.Time{}, false, fmt.Errorf("expires_at must be in the future (got %s, now %s)", t.Format(time.RFC3339), now.Format(time.RFC3339))
 	}
 	return t, false, nil
 }

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -454,11 +454,12 @@ func (s *IdentityService) EnsureServiceIdentity(ctx context.Context, accountID, 
 
 // parseExpiresAtPatch decodes a tri-state expires_at PATCH value:
 //   - "" → cleared = true, caller should NULL the column
-//   - RFC3339 timestamp in the future → returns the parsed time
-//   - RFC3339 in the past → rejected: an admin who fat-fingers a backdated
-//     value would otherwise trigger an immediate sweep-cascade revocation
-//     of every credential issued to the affected identity / policy. Hard
-//     foot-gun; we require expires_at >= now at the PATCH boundary.
+//   - RFC3339 timestamp strictly after now → returns the parsed time
+//   - RFC3339 at or before now → rejected: an admin who fat-fingers a
+//     backdated value would otherwise trigger an immediate sweep-cascade
+//     revocation of every credential issued to the affected identity /
+//     policy. Hard foot-gun; we require expires_at > now (strict) at
+//     the PATCH boundary.
 //
 // Returns: (time, cleared, err). When cleared is true the time value is
 // zero and the caller assigns nil.

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/middleware"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
@@ -116,6 +117,10 @@ type RegisterIdentityRequest struct {
 	CapabilityTier string
 	RiskTier       string
 	IAL            string
+	// ExpiresAt time-bounds the grant of authority. Nil means "no expiry"
+	// (historical default). When set, the cleanup worker deactivates the
+	// identity past this time and IssueCredential fail-closes on it.
+	ExpiresAt *time.Time
 }
 
 // RegisterIdentity creates a new identity with a WIMSE URI.
@@ -210,6 +215,7 @@ func (s *IdentityService) RegisterIdentity(ctx context.Context, req RegisterIden
 		CapabilityTier:     req.CapabilityTier,
 		RiskTier:           req.RiskTier,
 		IAL:                req.IAL,
+		ExpiresAt:          req.ExpiresAt,
 		CreatedBy:          req.CreatedBy,
 		CreatedAt:          time.Now(),
 		UpdatedAt:          time.Now(),
@@ -248,6 +254,12 @@ func (s *IdentityService) ListIdentities(ctx context.Context, accountID, project
 	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, limit, offset)
 }
 
+// ListExpiringSoon returns active identities whose expires_at falls within
+// now..now+within. Used by GET /expiring-soon.
+func (s *IdentityService) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.Identity, error) {
+	return s.repo.ListExpiringSoon(ctx, accountID, projectID, now, within)
+}
+
 // UpdateIdentityRequest holds parameters for identity updates.
 // Zero-value fields are left unchanged. Pointer fields distinguish "not set" from "clear."
 type UpdateIdentityRequest struct {
@@ -277,6 +289,12 @@ type UpdateIdentityRequest struct {
 	CapabilityTier *string
 	RiskTier       *string
 	IAL            *string
+	// ExpiresAt uses RFC3339 string + tri-state pointer to carry the three
+	// update intents that a single *time.Time can't express:
+	//   nil pointer            → leave unchanged
+	//   pointer to ""          → clear to NULL (remove expiry, extend forever)
+	//   pointer to RFC3339 str → set new expiry
+	ExpiresAt *string
 }
 
 // UpdateIdentity updates mutable fields of an existing identity.
@@ -370,6 +388,17 @@ func (s *IdentityService) UpdateIdentity(ctx context.Context, id, accountID, pro
 		}
 		identity.IAL = *req.IAL
 	}
+	if req.ExpiresAt != nil {
+		if *req.ExpiresAt == "" {
+			identity.ExpiresAt = nil
+		} else {
+			t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+			if err != nil {
+				return nil, fmt.Errorf("%w: invalid expires_at %q (must be RFC3339)", ErrInvalidIdentityField, *req.ExpiresAt)
+			}
+			identity.ExpiresAt = &t
+		}
+	}
 	identity.UpdatedAt = time.Now()
 	if err := s.repo.Update(ctx, identity); err != nil {
 		return nil, err
@@ -423,6 +452,72 @@ func (s *IdentityService) EnsureServiceIdentity(ctx context.Context, accountID, 
 	return identity, nil
 }
 
+// SweepExpiredIdentities is called by the cleanup worker. It finds every
+// identity whose expires_at has passed while status is still 'active' and
+// hands each one to DeactivateExpired, which uses an atomic conditional
+// UPDATE to claim the row and then runs the existing deactivation
+// cascade (revoke API keys → revoke active credentials → emit a
+// retirement CAE signal with reason="expired").
+//
+// Idempotent and replica-safe: the atomic claim guarantees that only one
+// worker fires the cascade per identity. A second sweep finds no rows
+// because the previous run flipped status off active. Concurrent replicas
+// silently no-op when they lose the claim race.
+func (s *IdentityService) SweepExpiredIdentities(ctx context.Context) (int, error) {
+	expired, err := s.repo.ListExpiredActive(ctx, time.Now())
+	if err != nil {
+		return 0, fmt.Errorf("list expired identities: %w", err)
+	}
+	count := 0
+	for _, id := range expired {
+		claimed, err := s.DeactivateExpired(ctx, id.ID, id.AccountID, id.ProjectID)
+		if err != nil {
+			log.Warn().Err(err).
+				Str("identity_id", id.ID).
+				Str("account_id", id.AccountID).
+				Str("project_id", id.ProjectID).
+				Msg("sweep: failed to deactivate expired identity")
+			continue
+		}
+		if claimed {
+			count++
+		}
+	}
+	if count > 0 {
+		log.Info().Int("count", count).Msg("sweep: deactivated expired identities")
+	}
+	return count, nil
+}
+
+// DeactivateExpired atomically claims an active identity and runs the
+// deactivation cascade with reason "expired". Returns (true, nil) when
+// this caller won the claim, (false, nil) when the row was already
+// non-active (claim lost to another replica or admin action), or an
+// error on DB failure.
+//
+// Single emission point for the "expired" CAE signal: the cascade
+// internally fires SignalTypeRetirement with the reason in payload,
+// so subscribers don't see duplicate signals (which would trigger
+// duplicate auto-revoke cascades via SignalService's high-severity
+// hook).
+//
+// The audit trigger that fires on the underlying UPDATE reads
+// modified_by from the row, which the worker has no caller context
+// for. We stamp it explicitly via the request context so the audit
+// trail names the sweep as the actor instead of the previous editor.
+func (s *IdentityService) DeactivateExpired(ctx context.Context, id, accountID, projectID string) (bool, error) {
+	ctx = middleware.SetCallerName(ctx, middleware.SystemCallerPrefix+"expired_sweep")
+	claimed, identity, err := s.repo.DeactivateIfActive(ctx, id, accountID, projectID)
+	if err != nil {
+		return false, err
+	}
+	if !claimed {
+		return false, nil
+	}
+	s.runDeactivationCleanup(ctx, identity, "expired")
+	return true, nil
+}
+
 // DeleteIdentity permanently removes an identity and cascades to related records.
 //
 // Cleanup runs before the DB delete: API keys are revoked, active credentials
@@ -463,18 +558,36 @@ func (s *IdentityService) runDeactivationCleanup(ctx context.Context, identity *
 			Msg("identity cleanup: revoked active credentials (cascade)")
 	}
 
+	if s.signalSvc == nil {
+		// Constructor (NewIdentityService) declares signalSvc required, so
+		// this is a programming-error guard rather than expected runtime
+		// state. Logged so a misconfigured embedder hears about it.
+		log.Warn().Str("identity_id", identity.ID).Str("reason", reason).
+			Msg("identity cleanup: signalSvc not wired; skipping retirement signal")
+		return
+	}
+	// Auto-expiry gets its own signal type so CAE subscribers can filter
+	// the indexed signal_type column directly (e.g. for offboarding-driven
+	// audit reports). Admin-initiated deactivation / deletion stays on
+	// SignalTypeRetirement so existing subscribers don't need to know
+	// about the split.
+	signalType := domain.SignalTypeRetirement
+	if reason == "expired" {
+		signalType = domain.SignalTypeIdentityExpired
+	}
 	if _, err := s.signalSvc.IngestSignal(
 		ctx,
 		identity.AccountID,
 		identity.ProjectID,
 		identity.ID,
-		domain.SignalTypeRetirement,
+		signalType,
 		domain.SignalSeverityHigh,
 		"identity_lifecycle",
 		map[string]any{"reason": reason},
 	); err != nil {
 		log.Warn().Err(err).Str("identity_id", identity.ID).Str("reason", reason).
-			Msg("identity cleanup: failed to emit retirement CAE signal")
+			Str("signal_type", string(signalType)).
+			Msg("identity cleanup: failed to emit lifecycle CAE signal")
 	}
 }
 

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -389,13 +389,13 @@ func (s *IdentityService) UpdateIdentity(ctx context.Context, id, accountID, pro
 		identity.IAL = *req.IAL
 	}
 	if req.ExpiresAt != nil {
-		if *req.ExpiresAt == "" {
+		t, cleared, err := parseExpiresAtPatch(*req.ExpiresAt)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidIdentityField, err)
+		}
+		if cleared {
 			identity.ExpiresAt = nil
 		} else {
-			t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
-			if err != nil {
-				return nil, fmt.Errorf("%w: invalid expires_at %q (must be RFC3339)", ErrInvalidIdentityField, *req.ExpiresAt)
-			}
 			identity.ExpiresAt = &t
 		}
 	}
@@ -452,70 +452,62 @@ func (s *IdentityService) EnsureServiceIdentity(ctx context.Context, accountID, 
 	return identity, nil
 }
 
-// SweepExpiredIdentities is called by the cleanup worker. It finds every
-// identity whose expires_at has passed while status is still 'active' and
-// hands each one to DeactivateExpired, which uses an atomic conditional
-// UPDATE to claim the row and then runs the existing deactivation
-// cascade (revoke API keys → revoke active credentials → emit a
-// retirement CAE signal with reason="expired").
+// parseExpiresAtPatch decodes a tri-state expires_at PATCH value:
+//   - "" → cleared = true, caller should NULL the column
+//   - RFC3339 timestamp in the future → returns the parsed time
+//   - RFC3339 in the past → rejected: an admin who fat-fingers a backdated
+//     value would otherwise trigger an immediate sweep-cascade revocation
+//     of every credential issued to the affected identity / policy. Hard
+//     foot-gun; we require expires_at >= now at the PATCH boundary.
 //
-// Idempotent and replica-safe: the atomic claim guarantees that only one
-// worker fires the cascade per identity. A second sweep finds no rows
-// because the previous run flipped status off active. Concurrent replicas
-// silently no-op when they lose the claim race.
+// Returns: (time, cleared, err). When cleared is true the time value is
+// zero and the caller assigns nil.
+func parseExpiresAtPatch(raw string) (time.Time, bool, error) {
+	if raw == "" {
+		return time.Time{}, true, nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("invalid expires_at %q (must be RFC3339)", raw)
+	}
+	if !t.After(time.Now()) {
+		return time.Time{}, false, fmt.Errorf("expires_at must be in the future (got %s, now %s)", t.Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339))
+	}
+	return t, false, nil
+}
+
+// SweepExpiredIdentities is called by the cleanup worker. The atomic
+// DeactivateIfActive UPDATE is the per-row claim that prevents concurrent
+// replicas from running the cascade twice for the same identity. The
+// caller_name stamp gives the audit trigger a non-empty modified_by so
+// auto-expiries are distinguishable from admin actions on the audit_log.
 func (s *IdentityService) SweepExpiredIdentities(ctx context.Context) (int, error) {
 	expired, err := s.repo.ListExpiredActive(ctx, time.Now())
 	if err != nil {
 		return 0, fmt.Errorf("list expired identities: %w", err)
 	}
+	ctx = middleware.SetCallerName(ctx, middleware.SystemCallerPrefix+"expired_sweep")
 	count := 0
-	for _, id := range expired {
-		claimed, err := s.DeactivateExpired(ctx, id.ID, id.AccountID, id.ProjectID)
+	for _, row := range expired {
+		claimed, identity, err := s.repo.DeactivateIfActive(ctx, row.ID, row.AccountID, row.ProjectID)
 		if err != nil {
 			log.Warn().Err(err).
-				Str("identity_id", id.ID).
-				Str("account_id", id.AccountID).
-				Str("project_id", id.ProjectID).
+				Str("identity_id", row.ID).
+				Str("account_id", row.AccountID).
+				Str("project_id", row.ProjectID).
 				Msg("sweep: failed to deactivate expired identity")
 			continue
 		}
-		if claimed {
-			count++
+		if !claimed {
+			continue
 		}
+		s.runDeactivationCleanup(ctx, identity, "expired")
+		count++
 	}
 	if count > 0 {
 		log.Info().Int("count", count).Msg("sweep: deactivated expired identities")
 	}
 	return count, nil
-}
-
-// DeactivateExpired atomically claims an active identity and runs the
-// deactivation cascade with reason "expired". Returns (true, nil) when
-// this caller won the claim, (false, nil) when the row was already
-// non-active (claim lost to another replica or admin action), or an
-// error on DB failure.
-//
-// Single emission point for the "expired" CAE signal: the cascade
-// internally fires SignalTypeRetirement with the reason in payload,
-// so subscribers don't see duplicate signals (which would trigger
-// duplicate auto-revoke cascades via SignalService's high-severity
-// hook).
-//
-// The audit trigger that fires on the underlying UPDATE reads
-// modified_by from the row, which the worker has no caller context
-// for. We stamp it explicitly via the request context so the audit
-// trail names the sweep as the actor instead of the previous editor.
-func (s *IdentityService) DeactivateExpired(ctx context.Context, id, accountID, projectID string) (bool, error) {
-	ctx = middleware.SetCallerName(ctx, middleware.SystemCallerPrefix+"expired_sweep")
-	claimed, identity, err := s.repo.DeactivateIfActive(ctx, id, accountID, projectID)
-	if err != nil {
-		return false, err
-	}
-	if !claimed {
-		return false, nil
-	}
-	s.runDeactivationCleanup(ctx, identity, "expired")
-	return true, nil
 }
 
 // DeleteIdentity permanently removes an identity and cascades to related records.
@@ -558,14 +550,6 @@ func (s *IdentityService) runDeactivationCleanup(ctx context.Context, identity *
 			Msg("identity cleanup: revoked active credentials (cascade)")
 	}
 
-	if s.signalSvc == nil {
-		// Constructor (NewIdentityService) declares signalSvc required, so
-		// this is a programming-error guard rather than expected runtime
-		// state. Logged so a misconfigured embedder hears about it.
-		log.Warn().Str("identity_id", identity.ID).Str("reason", reason).
-			Msg("identity cleanup: signalSvc not wired; skipping retirement signal")
-		return
-	}
 	// Auto-expiry gets its own signal type so CAE subscribers can filter
 	// the indexed signal_type column directly (e.g. for offboarding-driven
 	// audit reports). Admin-initiated deactivation / deletion stays on

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -215,6 +215,9 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 	if !identity.Status.IsUsable() {
 		return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
 	}
+	if identity.IsExpired() {
+		return nil, oauthBadRequest("invalid_grant", "identity_expired")
+	}
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:  identity,
@@ -265,6 +268,9 @@ func (s *OAuthService) jwtBearer(ctx context.Context, req TokenRequest) (*domain
 	}
 	if !identity.Status.IsUsable() {
 		return nil, oauthBadRequest("invalid_grant", "agent identity is suspended or deactivated")
+	}
+	if identity.IsExpired() {
+		return nil, oauthBadRequest("invalid_grant", "identity_expired")
 	}
 	if identity.PublicKeyPEM == "" {
 		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("no public key registered for identity %s — register a key before using jwt_bearer", identity.ID))
@@ -390,6 +396,9 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 	}
 	if !actorIdentity.Status.IsUsable() {
 		return nil, oauthBadRequest("invalid_grant", "actor identity is suspended or deactivated")
+	}
+	if actorIdentity.IsExpired() {
+		return nil, oauthBadRequest("invalid_grant", "identity_expired")
 	}
 	if actorIdentity.PublicKeyPEM == "" {
 		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("no public key registered for actor identity %s — register a key before using token_exchange", actorIdentity.ID))
@@ -539,6 +548,9 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 		if !resolved.Status.IsUsable() {
 			return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
 		}
+		if resolved.IsExpired() {
+			return nil, oauthBadRequest("invalid_grant", "identity_expired")
+		}
 		identity = resolved
 	} else {
 		identity = &domain.Identity{
@@ -606,6 +618,9 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 
 	sk, err := s.apiKeyRepo.GetByKeyHash(ctx, keyHash)
 	if err != nil {
+		// GetByKeyHash already filters on state=active and rejects keys past
+		// their expires_at — both surface as a not-found from the caller's
+		// perspective. No service-layer expiry check needed.
 		return nil, oauthBadRequestCause("invalid_grant", "invalid api key", err)
 	}
 
@@ -620,6 +635,8 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 			identity = nil
 		} else if !identity.Status.IsUsable() {
 			return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
+		} else if identity.IsExpired() {
+			return nil, oauthBadRequest("invalid_grant", "identity_expired")
 		}
 	}
 
@@ -799,11 +816,30 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 		}
 	}
 
-	// Auth code JWT is self-contained — tenant context comes from the auth code.
+	// Resolve the carrier identity. The default is a synthetic stub (this
+	// is a human session — sub will be authCode.UserID, no identity row to
+	// gate on). When the OAuth client is explicitly bound to an agent
+	// identity via oauthClient.IdentityID, look that identity up and gate
+	// on its status + expires_at the same way jwt_bearer and api_key paths
+	// do. The link is then forwarded into RefreshTokenParams.IdentityID so
+	// the refresh path inherits the same gate without re-discovering it.
 	identity := &domain.Identity{
 		AccountID: authCode.AccountID,
 		ProjectID: authCode.ProjectID,
 		Status:    domain.IdentityStatusActive,
+	}
+	if oauthClient.IdentityID != nil && *oauthClient.IdentityID != "" {
+		linked, err := s.identitySvc.repo.GetByID(ctx, *oauthClient.IdentityID, authCode.AccountID, authCode.ProjectID)
+		if err != nil {
+			return nil, oauthBadRequestCause("invalid_grant", "oauth client linked to unknown identity", err)
+		}
+		if !linked.Status.IsUsable() {
+			return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
+		}
+		if linked.IsExpired() {
+			return nil, oauthBadRequest("invalid_grant", "identity_expired")
+		}
+		identity = linked
 	}
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
@@ -828,12 +864,13 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 	// Issue refresh token when the client is registered for the refresh_token grant.
 	if hasRefreshGrant && s.refreshTokenSvc != nil {
 		rtResult, rtErr := s.refreshTokenSvc.IssueRefreshToken(ctx, &RefreshTokenParams{
-			ClientID:  req.ClientID,
-			AccountID: authCode.AccountID,
-			ProjectID: authCode.ProjectID,
-			UserID:    authCode.UserID,
-			Scopes:    strings.Join(authCode.Scopes, " "),
-			TTL:       oauthClient.RefreshTokenTTL,
+			ClientID:   req.ClientID,
+			AccountID:  authCode.AccountID,
+			ProjectID:  authCode.ProjectID,
+			UserID:     authCode.UserID,
+			IdentityID: oauthClient.IdentityID,
+			Scopes:     strings.Join(authCode.Scopes, " "),
+			TTL:        oauthClient.RefreshTokenTTL,
 		})
 		if rtErr != nil {
 			log.Error().Err(rtErr).Msg("Failed to issue refresh token — returning access token only")
@@ -918,10 +955,29 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 		return nil, oauthBadRequest("invalid_grant", "client_id mismatch")
 	}
 
+	// Identity gate. The link came from the OAuth client at authorization_code
+	// time and was persisted on the refresh_token row. When present, the
+	// linked identity's status + expires_at gate refresh-grant issuance the
+	// same way they gate every other grant. When absent, this is a human
+	// session with no identity row to check and we fall through to the
+	// synthetic carrier.
 	identity := &domain.Identity{
 		AccountID: oldToken.AccountID,
 		ProjectID: oldToken.ProjectID,
 		Status:    domain.IdentityStatusActive,
+	}
+	if oldToken.IdentityID != nil && *oldToken.IdentityID != "" {
+		linked, err := s.identitySvc.repo.GetByID(ctx, *oldToken.IdentityID, oldToken.AccountID, oldToken.ProjectID)
+		if err != nil {
+			return nil, oauthBadRequestCause("invalid_grant", "refresh token references unknown identity", err)
+		}
+		if !linked.Status.IsUsable() {
+			return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
+		}
+		if linked.IsExpired() {
+			return nil, oauthBadRequest("invalid_grant", "identity_expired")
+		}
+		identity = linked
 	}
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -571,6 +571,19 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 		}
 	}
 
+	// Resolve the identity policy when we have a real identity row.
+	// Without this the chokepoint can't enforce policy expiry, allowed
+	// scopes, max TTL, or any other policy axis — the synthetic carrier
+	// branch above has no identity row so no policy to resolve.
+	var identityPolicyID string
+	if identity.ID != "" {
+		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, identity)
+		if err != nil {
+			return nil, oauthServerError("failed to resolve identity credential policy", err)
+		}
+		identityPolicyID = policy.ID
+	}
+
 	// Step 4: Build custom claims for the external principal.
 	customClaims := map[string]any{
 		"token_exchange": "external_principal",
@@ -589,16 +602,17 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 	// them from ES256 NHI tokens in downstream verification.
 	scopes := parseScopeString(req.Scope)
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:        identity,
-		GrantType:       domain.GrantTypeTokenExchange,
-		Scopes:          scopes,
-		UseRS256:        true,
-		SubjectOverride: req.UserID,
-		UserEmail:       req.UserEmail,
-		UserName:        req.UserName,
-		ApplicationID:   req.ApplicationID,
-		TTL:             900, // 15 minutes — short-lived for external principals
-		CustomClaims:    customClaims,
+		Identity:         identity,
+		IdentityPolicyID: identityPolicyID,
+		GrantType:        domain.GrantTypeTokenExchange,
+		Scopes:           scopes,
+		UseRS256:         true,
+		SubjectOverride:  req.UserID,
+		UserEmail:        req.UserEmail,
+		UserName:         req.UserName,
+		ApplicationID:    req.ApplicationID,
+		TTL:              900, // 15 minutes — short-lived for external principals
+		CustomClaims:     customClaims,
 	})
 	if err != nil {
 		return nil, oauthServerError("failed to issue external principal token", err)

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -219,10 +219,20 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 		return nil, oauthBadRequest("invalid_grant", "identity_expired")
 	}
 
+	// Resolve the identity policy — the authority ceiling. Without this
+	// the chokepoint can't enforce TTL, scope, delegation-depth, trust-
+	// level, or policy-expiry caps for client_credentials. Mirrors the
+	// pattern used in jwt_bearer / token_exchange / api_key.
+	policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, identity)
+	if err != nil {
+		return nil, oauthServerError("failed to resolve identity credential policy", err)
+	}
+
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:  identity,
-		Scopes:    scopes,
-		GrantType: domain.GrantTypeClientCredentials,
+		Identity:         identity,
+		IdentityPolicyID: policy.ID,
+		Scopes:           scopes,
+		GrantType:        domain.GrantTypeClientCredentials,
 	})
 	if err != nil {
 		return nil, err
@@ -828,6 +838,10 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 		ProjectID: authCode.ProjectID,
 		Status:    domain.IdentityStatusActive,
 	}
+	// identityPolicyID is non-empty only when the OAuth client is bound to
+	// an agent identity — synthetic-carrier human sessions have no
+	// identity row and therefore no policy to resolve.
+	var identityPolicyID string
 	if oauthClient.IdentityID != nil && *oauthClient.IdentityID != "" {
 		linked, err := s.identitySvc.repo.GetByID(ctx, *oauthClient.IdentityID, authCode.AccountID, authCode.ProjectID)
 		if err != nil {
@@ -840,16 +854,22 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 			return nil, oauthBadRequest("invalid_grant", "identity_expired")
 		}
 		identity = linked
+		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, linked)
+		if err != nil {
+			return nil, oauthServerError("failed to resolve identity credential policy", err)
+		}
+		identityPolicyID = policy.ID
 	}
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:        identity,
-		GrantType:       domain.GrantTypeAuthorizationCode,
-		UseRS256:        true,
-		SubjectOverride: authCode.UserID,
-		ApplicationID:   authCode.ClientID,
-		TTL:             ttl,
-		Scopes:          authCode.Scopes,
+		Identity:         identity,
+		IdentityPolicyID: identityPolicyID,
+		GrantType:        domain.GrantTypeAuthorizationCode,
+		UseRS256:         true,
+		SubjectOverride:  authCode.UserID,
+		ApplicationID:    authCode.ClientID,
+		TTL:              ttl,
+		Scopes:           authCode.Scopes,
 	})
 	if err != nil {
 		return nil, err
@@ -966,6 +986,7 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 		ProjectID: oldToken.ProjectID,
 		Status:    domain.IdentityStatusActive,
 	}
+	var identityPolicyID string
 	if oldToken.IdentityID != nil && *oldToken.IdentityID != "" {
 		linked, err := s.identitySvc.repo.GetByID(ctx, *oldToken.IdentityID, oldToken.AccountID, oldToken.ProjectID)
 		if err != nil {
@@ -978,15 +999,26 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 			return nil, oauthBadRequest("invalid_grant", "identity_expired")
 		}
 		identity = linked
+		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, linked)
+		if err != nil {
+			return nil, oauthServerError("failed to resolve identity credential policy", err)
+		}
+		identityPolicyID = policy.ID
 	}
 
+	// Inherit scopes from the original refresh token. Without this the
+	// refreshed access token would be issued with no scopes (or default
+	// scopes), breaking the contract that refresh preserves the original
+	// grant's authority.
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:        identity,
-		GrantType:       domain.GrantTypeRefreshToken,
-		UseRS256:        true,
-		SubjectOverride: oldToken.UserID,
-		ApplicationID:   oldToken.ClientID,
-		TTL:             accessTTL,
+		Identity:         identity,
+		IdentityPolicyID: identityPolicyID,
+		GrantType:        domain.GrantTypeRefreshToken,
+		UseRS256:         true,
+		SubjectOverride:  oldToken.UserID,
+		ApplicationID:    oldToken.ClientID,
+		TTL:              accessTTL,
+		Scopes:           parseScopeString(oldToken.Scopes),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -715,6 +715,9 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 		// owner_user_id is set from Identity.OwnerUserID automatically.
 		// The creator is the acting user (the developer using the SDK right now).
 		ActingUserID: sk.CreatedBy,
+		// Clamp the JWT exp by the API key's own expires_at — a 7-day key
+		// must never mint a 30-day token even if the identity policy allows.
+		CredentialExpiresAt: sk.ExpiresAt,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -55,6 +55,16 @@ type RegisterClientRequest struct {
 	SoftwareVersion         string
 	Contacts                []string
 	Metadata                json.RawMessage
+	// AccountID + ProjectID are the tenant the IdentityID below is
+	// validated against. Required when IdentityID is non-empty.
+	AccountID string
+	ProjectID string
+	// IdentityID optionally binds this OAuth client to an agent identity.
+	// When set, authorization_code and refresh_token grants issued through
+	// this client gate on the linked identity's expires_at + status (fail-
+	// closed) and propagate the link to refresh_tokens.identity_id for
+	// downstream rotation checks. Empty = plain human-session client.
+	IdentityID string
 }
 
 // RegisterClient creates a new OAuth2 client.
@@ -119,6 +129,12 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 		contacts = []string{}
 	}
 
+	var identityID *string
+	if req.IdentityID != "" {
+		id := req.IdentityID
+		identityID = &id
+	}
+
 	now := time.Now()
 	client := &domain.OAuthClient{
 		ID:                      uuid.New().String(),
@@ -139,6 +155,7 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 		SoftwareVersion:         req.SoftwareVersion,
 		Contacts:                contacts,
 		Metadata:                req.Metadata,
+		IdentityID:              identityID,
 		IsActive:                true,
 		CreatedAt:               now,
 		UpdatedAt:               now,

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -55,15 +55,13 @@ type RegisterClientRequest struct {
 	SoftwareVersion         string
 	Contacts                []string
 	Metadata                json.RawMessage
-	// AccountID + ProjectID are the tenant the IdentityID below is
-	// validated against. Required when IdentityID is non-empty.
-	AccountID string
-	ProjectID string
 	// IdentityID optionally binds this OAuth client to an agent identity.
 	// When set, authorization_code and refresh_token grants issued through
 	// this client gate on the linked identity's expires_at + status (fail-
 	// closed) and propagate the link to refresh_tokens.identity_id for
-	// downstream rotation checks. Empty = plain human-session client.
+	// downstream rotation checks. Tenant-scoped IDOR validation happens
+	// at the handler boundary before this struct is built. Empty = plain
+	// human-session client.
 	IdentityID string
 }
 

--- a/internal/service/proof.go
+++ b/internal/service/proof.go
@@ -37,6 +37,16 @@ func NewProofService(jwksSvc *signing.JWKSService, proofRepo *postgres.ProofRepo
 // The nonce must be unique; duplicate nonces are rejected. The uniqueness guarantee is enforced
 // atomically by the database UNIQUE constraint on the nonce column — no pre-check is needed.
 func (s *ProofService) GenerateProofToken(ctx context.Context, identity *domain.Identity, audience, nonce string) (string, error) {
+	if identity == nil {
+		return "", fmt.Errorf("identity is required")
+	}
+	if !identity.Status.IsUsable() {
+		return "", fmt.Errorf("identity is not usable (status: %s)", identity.Status)
+	}
+	if identity.IsExpired() {
+		return "", fmt.Errorf("identity_expired: identity %s expired at %s", identity.ID, identity.ExpiresAt.Format(time.RFC3339))
+	}
+
 	now := time.Now()
 	expiresAt := now.Add(5 * time.Minute)
 	jti := uuid.New().String()

--- a/internal/service/proof.go
+++ b/internal/service/proof.go
@@ -41,10 +41,10 @@ func (s *ProofService) GenerateProofToken(ctx context.Context, identity *domain.
 		return "", fmt.Errorf("identity is required")
 	}
 	if !identity.Status.IsUsable() {
-		return "", fmt.Errorf("identity is not usable (status: %s)", identity.Status)
+		return "", fmt.Errorf("%w (status: %s)", domain.ErrIdentityNotUsable, identity.Status)
 	}
 	if identity.IsExpired() {
-		return "", fmt.Errorf("identity_expired: identity %s expired at %s", identity.ID, identity.ExpiresAt.Format(time.RFC3339))
+		return "", fmt.Errorf("%w: identity %s expired at %s", domain.ErrIdentityExpired, identity.ID, identity.ExpiresAt.Format(time.RFC3339))
 	}
 
 	now := time.Now()

--- a/internal/store/postgres/apikey.go
+++ b/internal/store/postgres/apikey.go
@@ -182,3 +182,21 @@ func (r *APIKeyRepository) Create(ctx context.Context, sk *domain.APIKey) error 
 	}
 	return nil
 }
+
+// ListExpiringSoon returns active API keys whose expires_at falls within
+// now..now+within. Used by GET /expiring-soon.
+func (r *APIKeyRepository) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.APIKey, error) {
+	var keys []*domain.APIKey
+	if err := r.db.NewSelect().Model(&keys).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("expires_at IS NOT NULL").
+		Where("expires_at >= ?", now).
+		Where("expires_at <= ?", now.Add(within)).
+		Where("state = ?", domain.APIKeyStateActive).
+		Order("expires_at ASC").
+		Scan(ctx); err != nil {
+		return nil, fmt.Errorf("list expiring api keys: %w", err)
+	}
+	return keys, nil
+}

--- a/internal/store/postgres/credential_policy.go
+++ b/internal/store/postgres/credential_policy.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/uptrace/bun"
 
@@ -109,4 +110,22 @@ func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, 
 		return fmt.Errorf("failed to delete credential policy: %w", err)
 	}
 	return nil
+}
+
+// ListExpiringSoon returns active credential policies whose expires_at falls
+// within now..now+within. Used by GET /expiring-soon.
+func (r *CredentialPolicyRepository) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.CredentialPolicy, error) {
+	var policies []*domain.CredentialPolicy
+	if err := r.db.NewSelect().Model(&policies).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("expires_at IS NOT NULL").
+		Where("expires_at >= ?", now).
+		Where("expires_at <= ?", now.Add(within)).
+		Where("is_active = TRUE").
+		Order("expires_at ASC").
+		Scan(ctx); err != nil {
+		return nil, fmt.Errorf("list expiring credential policies: %w", err)
+	}
+	return policies, nil
 }

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -191,7 +191,10 @@ func (r *IdentityRepository) Delete(ctx context.Context, id, accountID, projectI
 // worker's expiry sweep so that concurrent replicas don't both run the
 // deactivation cascade for the same identity — only the worker whose UPDATE
 // matched a still-active row gets back claimed=true and proceeds to fire
-// the credential / API-key revocation + retirement signal.
+// the credential / API-key revocation + lifecycle CAE signal. The signal
+// type depends on the caller's reason: the expiry sweep emits
+// SignalTypeIdentityExpired; admin-initiated deactivation emits the
+// generic SignalTypeRetirement.
 //
 // Callers that fail the claim (claimed=false) MUST silently skip; the row
 // was either already deactivated by another replica or by a parallel admin

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/uptrace/bun"
 
@@ -182,4 +183,79 @@ func (r *IdentityRepository) Delete(ctx context.Context, id, accountID, projectI
 		return fmt.Errorf("failed to delete identity: %w", err)
 	}
 	return nil
+}
+
+// DeactivateIfActive atomically flips status to 'deactivated' iff the row
+// is still 'active', returning the post-update identity row and a boolean
+// indicating whether this caller won the claim. Used by the cleanup
+// worker's expiry sweep so that concurrent replicas don't both run the
+// deactivation cascade for the same identity — only the worker whose UPDATE
+// matched a still-active row gets back claimed=true and proceeds to fire
+// the credential / API-key revocation + retirement signal.
+//
+// Callers that fail the claim (claimed=false) MUST silently skip; the row
+// was either already deactivated by another replica or by a parallel admin
+// action, and the cascade for that transition has already run (or is
+// running) on that other path.
+func (r *IdentityRepository) DeactivateIfActive(ctx context.Context, id, accountID, projectID string) (claimed bool, identity *domain.Identity, err error) {
+	db := dbOrTx(ctx, r.db)
+	identity = &domain.Identity{}
+	res, err := db.NewUpdate().Model(identity).
+		Set("status = ?", string(domain.IdentityStatusDeactivated)).
+		Set("updated_at = ?", time.Now()).
+		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("status = ?", string(domain.IdentityStatusActive)).
+		Returning("*").
+		Exec(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("deactivate-if-active: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, nil, fmt.Errorf("deactivate-if-active rows: %w", err)
+	}
+	if n == 0 {
+		return false, nil, nil
+	}
+	return true, identity, nil
+}
+
+// ListExpiredActive returns identities whose expires_at has passed while
+// their status is still 'active'. Used by the cleanup worker's identity
+// sweep. The partial index on (expires_at) WHERE status='active' makes
+// this scan O(expired-rows), not O(all-identities).
+func (r *IdentityRepository) ListExpiredActive(ctx context.Context, now time.Time) ([]*domain.Identity, error) {
+	var identities []*domain.Identity
+	db := dbOrTx(ctx, r.db)
+	if err := db.NewSelect().Model(&identities).
+		Where("expires_at IS NOT NULL").
+		Where("expires_at < ?", now).
+		Where("status = ?", string(domain.IdentityStatusActive)).
+		Scan(ctx); err != nil {
+		return nil, fmt.Errorf("list expired identities: %w", err)
+	}
+	return identities, nil
+}
+
+// ListExpiringSoon returns identities whose expires_at falls within the given
+// window (now..now+within). Used by GET /expiring-soon. Excludes already-
+// deactivated identities so the result reflects what is *about to* expire,
+// not what already has.
+func (r *IdentityRepository) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.Identity, error) {
+	var identities []*domain.Identity
+	db := dbOrTx(ctx, r.db)
+	if err := db.NewSelect().Model(&identities).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("expires_at IS NOT NULL").
+		Where("expires_at >= ?", now).
+		Where("expires_at <= ?", now.Add(within)).
+		Where("status = ?", string(domain.IdentityStatusActive)).
+		Order("expires_at ASC").
+		Scan(ctx); err != nil {
+		return nil, fmt.Errorf("list expiring identities: %w", err)
+	}
+	return identities, nil
 }

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -200,9 +200,16 @@ func (r *IdentityRepository) Delete(ctx context.Context, id, accountID, projectI
 func (r *IdentityRepository) DeactivateIfActive(ctx context.Context, id, accountID, projectID string) (claimed bool, identity *domain.Identity, err error) {
 	db := dbOrTx(ctx, r.db)
 	identity = &domain.Identity{}
-	res, err := db.NewUpdate().Model(identity).
+	// modified_by must be set in the UPDATE itself — the audit trigger
+	// reads NEW.modified_by, so a caller_name on the context only reaches
+	// the audit log when it's written into this row's column.
+	q := db.NewUpdate().Model(identity).
 		Set("status = ?", string(domain.IdentityStatusDeactivated)).
-		Set("updated_at = ?", time.Now()).
+		Set("updated_at = ?", time.Now())
+	if callerID := middleware.GetCallerName(ctx); callerID != "" {
+		q = q.Set("modified_by = ?", callerID)
+	}
+	res, err := q.
 		Where("id = ?", id).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -8,17 +8,38 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// CleanupWorker periodically removes expired issued_credentials and proof_tokens rows.
-// Running the cleanup prevents unbounded table growth since credentials have a finite TTL.
-// It is safe to run multiple instances concurrently — DELETE WHERE is idempotent.
+// IdentityExpirer is implemented by IdentityService.SweepExpiredIdentities.
+// Defined here so the worker package doesn't have to import service (which
+// would create a cycle: service → worker → service).
+type IdentityExpirer interface {
+	SweepExpiredIdentities(ctx context.Context) (int, error)
+}
+
+// CleanupWorker periodically removes expired issued_credentials, proof_tokens,
+// and auth_codes rows, and sweeps expired identities into status=deactivated
+// (which triggers the existing cascade in IdentityService.UpdateIdentity).
+// Running the cleanup prevents unbounded table growth since credentials have a
+// finite TTL. Safe to run multiple instances concurrently — DELETE WHERE is
+// idempotent and the identity-status transition is guarded by a fresh-
+// transition check inside UpdateIdentity.
 type CleanupWorker struct {
 	db       *bun.DB
+	expirer  IdentityExpirer
 	interval time.Duration
 }
 
 // NewCleanupWorker creates a cleanup worker with the given tick interval.
+// The identity-expiry sweep is wired separately via SetIdentityExpirer
+// after IdentityService is constructed.
 func NewCleanupWorker(db *bun.DB, interval time.Duration) *CleanupWorker {
 	return &CleanupWorker{db: db, interval: interval}
+}
+
+// SetIdentityExpirer installs the identity-expiry sweep callback. Nil
+// disables the sweep (the row-cleanup steps still run). Wired in server.go
+// after IdentityService is constructed.
+func (w *CleanupWorker) SetIdentityExpirer(e IdentityExpirer) {
+	w.expirer = e
 }
 
 // Run starts the cleanup loop and blocks until ctx is cancelled.
@@ -28,12 +49,12 @@ func (w *CleanupWorker) Run(ctx context.Context) {
 	defer ticker.Stop()
 
 	// Run immediately on start, then on every tick.
-	w.runOnce(ctx)
+	w.RunOnce(ctx)
 
 	for {
 		select {
 		case <-ticker.C:
-			w.runOnce(ctx)
+			w.RunOnce(ctx)
 		case <-ctx.Done():
 			log.Info().Msg("Cleanup worker stopped")
 			return
@@ -41,7 +62,9 @@ func (w *CleanupWorker) Run(ctx context.Context) {
 	}
 }
 
-func (w *CleanupWorker) runOnce(ctx context.Context) {
+// RunOnce executes one cleanup pass. Exported so integration tests can
+// drive a deterministic sweep without spinning up the periodic loop.
+func (w *CleanupWorker) RunOnce(ctx context.Context) {
 	now := time.Now()
 
 	// Delete all expired credentials regardless of revocation status.
@@ -74,5 +97,14 @@ func (w *CleanupWorker) runOnce(ctx context.Context) {
 		log.Error().Err(err).Msg("Cleanup: failed to delete expired auth codes")
 	} else if n, err := authCodeRes.RowsAffected(); err == nil && n > 0 {
 		log.Info().Int64("count", n).Msg("Cleanup: deleted expired auth codes")
+	}
+
+	// Identity-expiry sweep. Runs after the row-deletes so that any tokens
+	// cascade-revoked by the sweep are recorded as revocations rather than
+	// being silently cleared by the credential-expiry delete above.
+	if w.expirer != nil {
+		if _, err := w.expirer.SweepExpiredIdentities(ctx); err != nil {
+			log.Error().Err(err).Msg("Cleanup: identity-expiry sweep failed")
+		}
 	}
 }

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -17,11 +17,12 @@ type IdentityExpirer interface {
 
 // CleanupWorker periodically removes expired issued_credentials, proof_tokens,
 // and auth_codes rows, and sweeps expired identities into status=deactivated
-// (which triggers the existing cascade in IdentityService.UpdateIdentity).
-// Running the cleanup prevents unbounded table growth since credentials have a
-// finite TTL. Safe to run multiple instances concurrently — DELETE WHERE is
-// idempotent and the identity-status transition is guarded by a fresh-
-// transition check inside UpdateIdentity.
+// via IdentityService.SweepExpiredIdentities (an atomic conditional UPDATE
+// claim followed by the existing runDeactivationCleanup cascade).
+// Running the cleanup prevents unbounded table growth since credentials have
+// a finite TTL. Safe to run multiple instances concurrently — DELETE WHERE
+// is idempotent and the DeactivateIfActive claim guarantees only one worker
+// fires the cascade per expired identity.
 type CleanupWorker struct {
 	db       *bun.DB
 	expirer  IdentityExpirer

--- a/migrations/017_time_bound_authority.down.sql
+++ b/migrations/017_time_bound_authority.down.sql
@@ -1,0 +1,14 @@
+-- 017_time_bound_authority.down.sql
+--
+-- IRREVERSIBLE FOR DATA: any expires_at values written on identities or
+-- credential_policies while this migration was applied are dropped when
+-- the columns are removed. The schema-side rollback is clean, but the
+-- time-bound authority configured during the window is lost.
+
+DROP INDEX IF EXISTS idx_service_keys_expiring;
+DROP INDEX IF EXISTS idx_credential_policies_expiring;
+DROP INDEX IF EXISTS idx_identities_expiring;
+
+ALTER TABLE credential_policies DROP COLUMN IF EXISTS expires_at;
+ALTER TABLE identities          DROP COLUMN IF EXISTS expires_at;
+-- service_keys.expires_at predates this migration; not dropped.

--- a/migrations/017_time_bound_authority.up.sql
+++ b/migrations/017_time_bound_authority.up.sql
@@ -13,17 +13,28 @@ ALTER TABLE identities          ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
 ALTER TABLE credential_policies ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
 
 -- Partial indexes for the cleanup-worker sweep and the /expiring-soon
--- admin endpoint. WHERE clause keeps the index small — the common case
--- is unbounded grants (expires_at IS NULL) and those rows never qualify.
+-- admin endpoint. WHERE clause keeps the index *small* — but does NOT
+-- shrink the build scan. Postgres reads every row in the table to
+-- evaluate the partial-index predicate; the savings are in storage and
+-- query plans, not in build time.
 --
 -- These are plain CREATE INDEX (not CONCURRENTLY) because golang-migrate
 -- wraps each migration in a transaction and CONCURRENTLY can't run
--- inside one. The partial WHERE clauses limit the scan to rows where
--- expires_at IS NOT NULL — zero rows on first deploy, so the build is
--- effectively instant regardless of identities/credential_policies/
--- service_keys row count. Existing large deployments that later backfill
--- expires_at should expect rebuild cost proportional to the number of
--- time-bound rows, not the full table.
+-- inside one. CREATE INDEX takes ShareLock for the build duration,
+-- blocking writes (reads continue). Build cost is proportional to total
+-- row count, not just to expires_at-IS-NOT-NULL row count.
+--
+-- Concrete cost shape:
+--   identities, credential_policies: brand-new columns, every row's
+--     expires_at IS NULL, so the partial predicate excludes every row
+--     from the index payload — the build still scans, but the resulting
+--     index occupies near-zero storage. Lock window scales with table
+--     size; for tables in the millions of rows expect seconds-to-minutes.
+--   service_keys: expires_at predates this migration and may already
+--     be populated on existing deployments. The index payload reflects
+--     those rows, and the build scans the whole table. Operators with
+--     large service_keys should plan a maintenance window or move this
+--     index out of the transaction (rerun manually with CONCURRENTLY).
 --
 -- The three tables use three different "active" column names — status,
 -- is_active, state — for historical reasons. Each index mirrors its

--- a/migrations/017_time_bound_authority.up.sql
+++ b/migrations/017_time_bound_authority.up.sql
@@ -1,0 +1,41 @@
+-- 017_time_bound_authority.up.sql
+-- Adds expires_at to identities and credential_policies so the grant of
+-- authority itself can be time-bound, not just the JWTs it issues.
+-- service_keys.expires_at already exists (migration 006); this migration
+-- only adds the matching partial index so the expiring-soon endpoint can
+-- scan the same way across all three tables.
+--
+-- All three columns are nullable. NULL means "no expiry" — the existing
+-- forever-live default. The cleanup worker only sweeps rows with a
+-- non-NULL expires_at past now(), so existing rows are untouched.
+
+ALTER TABLE identities          ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+ALTER TABLE credential_policies ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+
+-- Partial indexes for the cleanup-worker sweep and the /expiring-soon
+-- admin endpoint. WHERE clause keeps the index small — the common case
+-- is unbounded grants (expires_at IS NULL) and those rows never qualify.
+--
+-- These are plain CREATE INDEX (not CONCURRENTLY) because golang-migrate
+-- wraps each migration in a transaction and CONCURRENTLY can't run
+-- inside one. The partial WHERE clauses limit the scan to rows where
+-- expires_at IS NOT NULL — zero rows on first deploy, so the build is
+-- effectively instant regardless of identities/credential_policies/
+-- service_keys row count. Existing large deployments that later backfill
+-- expires_at should expect rebuild cost proportional to the number of
+-- time-bound rows, not the full table.
+--
+-- The three tables use three different "active" column names — status,
+-- is_active, state — for historical reasons. Each index mirrors its
+-- table's convention; do not unify here.
+CREATE INDEX IF NOT EXISTS idx_identities_expiring
+    ON identities (expires_at)
+    WHERE expires_at IS NOT NULL AND status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_credential_policies_expiring
+    ON credential_policies (expires_at)
+    WHERE expires_at IS NOT NULL AND is_active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_service_keys_expiring
+    ON service_keys (expires_at)
+    WHERE expires_at IS NOT NULL AND state = 'active';

--- a/migrations/018_oauth_client_identity_link.down.sql
+++ b/migrations/018_oauth_client_identity_link.down.sql
@@ -1,0 +1,4 @@
+-- 018_oauth_client_identity_link.down.sql
+
+DROP INDEX IF EXISTS idx_oauth_clients_identity_id;
+ALTER TABLE oauth_clients DROP COLUMN IF EXISTS identity_id;

--- a/migrations/018_oauth_client_identity_link.up.sql
+++ b/migrations/018_oauth_client_identity_link.up.sql
@@ -1,0 +1,24 @@
+-- 018_oauth_client_identity_link.up.sql
+-- Adds optional identity_id to oauth_clients so an OAuth client can be
+-- explicitly bound to an agent identity. When set, authorization_code and
+-- refresh_token grants gate token issuance on the linked identity's
+-- expires_at and status — same protection the api_key and jwt_bearer
+-- paths already have.
+--
+-- Backward compatible: existing oauth_clients rows have identity_id =
+-- NULL, which retains the pre-018 human-session behaviour (no identity
+-- gate, sub = user_id, application_id = client_id). Deployers who want
+-- the gate explicitly link a client to an identity at create or update.
+--
+-- The ON DELETE SET NULL clause mirrors api_keys: deleting an identity
+-- nulls out the link but leaves the OAuth client intact so refresh
+-- tokens already in flight don't disappear under callers — they'll just
+-- fail the next exchange with "identity_expired" once the cascade has
+-- run.
+
+ALTER TABLE oauth_clients
+    ADD COLUMN IF NOT EXISTS identity_id UUID REFERENCES identities(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_oauth_clients_identity_id
+    ON oauth_clients (identity_id)
+    WHERE identity_id IS NOT NULL;

--- a/server.go
+++ b/server.go
@@ -328,6 +328,12 @@ func NewServer(cfg Config) (*Server, error) {
 		},
 	}
 
+	// Wire the identity-expiry sweep into the cleanup worker. Done after
+	// Server construction so the worker holds a live IdentityService whose
+	// own dependencies (apiKeyRepo, credentialSvc, signalSvc) are already
+	// resolved.
+	srv.cleanupWorker.SetIdentityExpirer(identitySvc)
+
 	return srv, nil
 }
 
@@ -494,6 +500,14 @@ func (s *Server) SetTrustedServiceValidator(v TrustedServiceValidator) {
 // Router returns the chi.Router for custom route mounting.
 func (s *Server) Router() chi.Router {
 	return s.router
+}
+
+// RunCleanupOnce runs a single pass of the cleanup worker — credential /
+// proof / auth-code row deletes plus the identity-expiry sweep. Exposed so
+// integration tests can drive a deterministic sweep without spinning up
+// the periodic loop. Production callers should let Start manage timing.
+func (s *Server) RunCleanupOnce(ctx context.Context) {
+	s.cleanupWorker.RunOnce(ctx)
 }
 
 // SetHandler overrides the HTTP handler used by the server.

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -552,11 +552,38 @@ func TestExpiringSoonEndpoint(t *testing.T) {
 // Without the identity link, the human-session flow stays untouched
 // (TestExpiringSoonEndpoint already exercises the unlinked path).
 func TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh(t *testing.T) {
-	// 1. Register an agent identity (no expiry yet — establish baseline).
-	ext := uid("linked-client-agent")
-	agent := registerAgent(t, ext)
+	// 1. Create a credential policy that permits authorization_code +
+	// refresh_token. The default tenant policy intentionally excludes
+	// these grants (they were assumed to flow through OAuth clients,
+	// not identities) — so identity-bound PKCE flows require an
+	// explicit policy declaring the agent uses them.
+	policyResp := post(t, adminPath("/credential-policies"), map[string]any{
+		"name":                uid("agent-auth-code-policy"),
+		"allowed_grant_types": []string{"authorization_code", "refresh_token"},
+		"max_ttl_seconds":     3600,
+	}, adminHeaders())
+	policyBody := decode(t, policyResp)
+	require.Equal(t, http.StatusCreated, policyResp.StatusCode, "policy create must succeed; body=%v", policyBody)
+	policyID := policyBody["id"].(string)
 
-	// 2. Register a PKCE-style OAuth client bound to that identity. The
+	// 2. Register an agent identity with the custom policy.
+	ext := uid("linked-client-agent")
+	regResp := post(t, adminPath("/agents/register"), map[string]any{
+		"name":                 ext,
+		"external_id":          ext,
+		"sub_type":             "orchestrator",
+		"trust_level":          "first_party",
+		"created_by":           "test-user",
+		"credential_policy_id": policyID,
+	}, adminHeaders())
+	regBody := decode(t, regResp)
+	require.Equal(t, http.StatusCreated, regResp.StatusCode, "agent register must succeed; body=%v", regBody)
+	agent := agentRegistration{
+		AgentID: regBody["identity"].(map[string]any)["id"].(string),
+		APIKey:  regBody["api_key"].(string),
+	}
+
+	// 3. Register a PKCE-style OAuth client bound to that identity. The
 	// _redirect_uri_ and _grant_types_ mark this as an agent-authorized
 	// authorization_code flow (the deployer's hypothetical "PKCE-provision
 	// my agent" scenario).
@@ -572,7 +599,7 @@ func TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh(t *testing.T) {
 	createBody := decode(t, resp)
 	require.Equal(t, http.StatusCreated, resp.StatusCode, "client create with identity_id must succeed; body=%v", createBody)
 
-	// 3. Mint a PKCE auth-code-style JWT for this client and exchange it
+	// 4. Mint a PKCE auth-code-style JWT for this client and exchange it
 	// while the identity is still active — must succeed.
 	verifier, challenge := buildPKCEPair(t)
 	code := buildAuthCode(t, clientID, "user-linked-001", testRedirectURI, challenge, []string{"data:read"})
@@ -591,10 +618,10 @@ func TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh(t *testing.T) {
 	}
 	require.NotEmpty(t, refreshTok, "client is registered for refresh_token grant; must return one")
 
-	// 4. Expire the linked identity.
+	// 5. Expire the linked identity.
 	stampExpiredInDB(t, agent.AgentID)
 
-	// 5. Try to exchange a fresh auth code — now blocked by the identity gate.
+	// 6. Try to exchange a fresh auth code — now blocked by the identity gate.
 	verifier2, challenge2 := buildPKCEPair(t)
 	code2 := buildAuthCode(t, clientID, "user-linked-002", testRedirectURI, challenge2, []string{"data:read"})
 	resp = post(t, "/oauth2/token", map[string]any{
@@ -609,7 +636,7 @@ func TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh(t *testing.T) {
 	require.Equal(t, "invalid_grant", body2["error"])
 	require.Equal(t, "identity_expired", body2["error_description"])
 
-	// 6. Refresh the existing refresh token — also blocked. This is the
+	// 7. Refresh the existing refresh token — also blocked. This is the
 	// previously-open path: pre-PR, the refresh would mint a new access
 	// token because the synthetic identity carrier bypassed the chokepoint.
 	resp = post(t, "/oauth2/token", map[string]any{

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -562,19 +562,21 @@ func TestExpiringSoonEndpoint(t *testing.T) {
 	inSoon := uid("expiring-in-window")
 	soonReg := registerAgent(t, inSoon)
 	inTwoHrs := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
-	_, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+soonReg.AgentID), map[string]any{
+	resp, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+soonReg.AgentID), map[string]any{
 		"expires_at": inTwoHrs,
 	}, adminHeaders())
 	require.NoError(t, err)
+	_ = resp.Body.Close()
 
 	// Identity expiring in 30 days — outside the default 168h window.
 	outOfWindow := uid("expiring-far-future")
 	farReg := registerAgent(t, outOfWindow)
 	in30Days := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
-	_, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+farReg.AgentID), map[string]any{
+	resp, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+farReg.AgentID), map[string]any{
 		"expires_at": in30Days,
 	}, adminHeaders())
 	require.NoError(t, err)
+	_ = resp.Body.Close()
 
 	// Identity with no expiry at all — must never appear.
 	neverExt := uid("never-expires")

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -171,9 +171,16 @@ func TestExpiredIdentityDeniedTokenExchange(t *testing.T) {
 	assert.Equal(t, "identity_expired", body["error_description"])
 }
 
-// TestExtendAccessReactivates exercises the "Extend access" flow: PATCH
-// expires_at to a future RFC3339 string brings an expired identity back
-// online. Cleared-to-NULL (empty string) also works.
+// TestExtendAccessReactivates exercises the "Extend access" flow on an
+// active-but-backdated identity: PATCH expires_at to a future RFC3339
+// string lifts the IsExpired() gate so the next token request succeeds.
+// Cleared-to-NULL (empty string) also works.
+//
+// This test covers extension BEFORE the cleanup-worker sweep has run.
+// Once the sweep has fired and status flipped to 'deactivated', PATCH
+// of expires_at alone does NOT auto-reactivate — callers must PATCH
+// status:"active" in the same request. That's a documented limitation,
+// not what this test exercises.
 func TestExtendAccessReactivates(t *testing.T) {
 	ext := uid("extend-access")
 	reg := registerAgent(t, ext)

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -444,6 +444,36 @@ func TestXUserIDSystemPrefixRejected(t *testing.T) {
 	}
 }
 
+// TestSweepStampsModifiedByOnAuditRow asserts that the audit trigger sees
+// a non-empty modified_by when the sweep deactivates an expired identity.
+// The audit trigger reads NEW.modified_by from the UPDATE — if the sweep
+// doesn't write that column the audit row would falsely attribute the
+// deactivation to the previous editor.
+func TestSweepStampsModifiedByOnAuditRow(t *testing.T) {
+	ext := uid("audit-stamp")
+	reg := registerAgent(t, ext)
+	stampExpiredInDB(t, reg.AgentID)
+
+	testZeroIDServer.RunCleanupOnce(context.Background())
+
+	var rows []struct {
+		Action       string `bun:"action"`
+		CallerUserID string `bun:"caller_user_id"`
+		IdentityID   string `bun:"identity_id"`
+	}
+	err := testDB.NewSelect().
+		Table("identity_audit_logs").
+		Column("action", "caller_user_id", "identity_id").
+		Where("identity_id = ?", reg.AgentID).
+		Order("created_at DESC").
+		Limit(1).
+		Scan(context.Background(), &rows)
+	require.NoError(t, err)
+	require.NotEmpty(t, rows, "sweep must produce an audit row")
+	assert.Equal(t, "system:expired_sweep", rows[0].CallerUserID,
+		"audit caller must be the sweep system caller, not the previous editor")
+}
+
 // TestExpiringSoonEndpoint verifies that GET /expiring-soon returns
 // only identities within the requested window and excludes already-
 // deactivated rows.

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -13,6 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// stampExpiredInDB backdates expires_at via direct repo UPDATE — the PATCH
+// endpoint rejects past timestamps as a foot-gun guard, but tests need to
+// drop an identity below the IsExpired() threshold deterministically
+// without sleeping for the smallest future TTL we could schedule.
+func stampExpiredInDB(t *testing.T, identityID string) {
+	t.Helper()
+	past := time.Now().Add(-time.Second).UTC()
+	_, err := testDB.NewUpdate().
+		TableExpr("identities").
+		Set("expires_at = ?", past).
+		Where("id = ?", identityID).
+		Exec(context.Background())
+	require.NoError(t, err, "stampExpiredInDB: direct UPDATE failed")
+}
+
 // TestExpiredIdentityDeniedAcrossGrantTypes verifies the IsExpired() gate
 // at every grant-type entry point + the chokepoint in IssueCredential. An
 // identity past its expires_at gets a 400 invalid_grant regardless of how
@@ -46,15 +61,7 @@ func TestExpiredIdentityDeniedAcrossGrantTypes(t *testing.T) {
 	}, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "client_credentials while active must succeed; body=%v", decode(t, resp))
 
-	// Stamp expires_at one second in the past via direct repo update —
-	// fastest way to age the identity without sleeping.
-	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
-	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
-		"expires_at": past,
-	}, adminHeaders())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, patched.StatusCode, "PATCH /identities expires_at must succeed")
-	_ = patched.Body.Close()
+	stampExpiredInDB(t, reg.AgentID)
 
 	// api_key path: chokepoint + grant-level check both kick in. Either
 	// "identity_expired" or "api_key_expired" is acceptable — the test
@@ -104,14 +111,7 @@ func TestExpiredIdentityDeniedJWTBearer(t *testing.T) {
 	}, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "baseline jwt_bearer must succeed; body=%v", decode(t, resp))
 
-	// Expire the identity.
-	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
-	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+identity.ID), map[string]any{
-		"expires_at": past,
-	}, adminHeaders())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, patched.StatusCode)
-	_ = patched.Body.Close()
+	stampExpiredInDB(t, identity.ID)
 
 	// jwt_bearer with a fresh assertion now blocked — both gate sites in
 	// oauth.jwtBearer (Status + IsExpired) and the chokepoint must catch.
@@ -150,14 +150,7 @@ func TestExpiredIdentityDeniedTokenExchange(t *testing.T) {
 	subExt := uid("expired-tx-sub")
 	subAgent := registerIdentity(t, subExt, []string{"data:read"}, ecPublicKeyPEM(t, subKey))
 
-	// Expire the sub-agent (the actor whose identity is the one being gated).
-	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
-	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+subAgent.ID), map[string]any{
-		"expires_at": past,
-	}, adminHeaders())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, patched.StatusCode)
-	_ = patched.Body.Close()
+	stampExpiredInDB(t, subAgent.ID)
 
 	// token_exchange with the orchestrator's subject_token + sub-agent's
 	// actor_token must fail: oauth.tokenExchange gates actorIdentity.IsExpired.
@@ -182,12 +175,7 @@ func TestExtendAccessReactivates(t *testing.T) {
 	ext := uid("extend-access")
 	reg := registerAgent(t, ext)
 
-	// Expire it.
-	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
-	_, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
-		"expires_at": past,
-	}, adminHeaders())
-	require.NoError(t, err)
+	stampExpiredInDB(t, reg.AgentID)
 
 	// Confirm denied.
 	resp := post(t, "/oauth2/token", map[string]any{
@@ -248,14 +236,7 @@ func TestCleanupWorkerSweepsExpiredIdentities(t *testing.T) {
 	pre := introspect(t, tokenBefore)
 	require.True(t, pre["active"].(bool), "token should be active before sweep")
 
-	// Stamp expires_at in the past.
-	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
-	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
-		"expires_at": past,
-	}, adminHeaders())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, patched.StatusCode)
-	_ = patched.Body.Close()
+	stampExpiredInDB(t, reg.AgentID)
 
 	// First sweep: deactivates the identity → cascade revokes the token.
 	testZeroIDServer.RunCleanupOnce(context.Background())
@@ -293,13 +274,7 @@ func TestSweepEmitsIdentityExpiredSignal(t *testing.T) {
 	ext := uid("sweep-signal-type")
 	reg := registerAgent(t, ext)
 
-	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
-	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
-		"expires_at": past,
-	}, adminHeaders())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, patched.StatusCode)
-	_ = patched.Body.Close()
+	stampExpiredInDB(t, reg.AgentID)
 
 	testZeroIDServer.RunCleanupOnce(context.Background())
 
@@ -310,7 +285,7 @@ func TestSweepEmitsIdentityExpiredSignal(t *testing.T) {
 		Source     string         `bun:"source"`
 		Payload    map[string]any `bun:"payload,type:jsonb"`
 	}
-	err = testDB.NewSelect().
+	err := testDB.NewSelect().
 		Table("cae_signals").
 		Column("signal_type", "source", "payload").
 		Where("identity_id = ?", reg.AgentID).
@@ -332,6 +307,100 @@ func TestSweepEmitsIdentityExpiredSignal(t *testing.T) {
 			"payload.reason must carry the precise cause; got %v", r.Payload)
 	}
 	require.True(t, found, "no identity_lifecycle signal found; rows=%v", rows)
+}
+
+// TestExpiredIdentityCannotMintProofToken closes the WPT bypass: an
+// expired identity must not be able to generate a WIMSE proof token,
+// even though the token itself is only 5 minutes and audience-bound.
+func TestExpiredIdentityCannotMintProofToken(t *testing.T) {
+	agentKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ext := uid("expired-proof")
+	identity := registerIdentity(t, ext, []string{"data:read"}, ecPublicKeyPEM(t, agentKey))
+
+	// Baseline: mint a ZeroID access token for the agent first (needed
+	// because the proof-generate endpoint sits behind agent-auth).
+	assertion := buildAssertion(t, agentKey, identity.WIMSEURI)
+	tokResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    assertion,
+		"scope":      "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, tokResp.StatusCode)
+	accessTok := decode(t, tokResp)["access_token"].(string)
+
+	// Sanity: proof generation works while identity is unexpired.
+	authHdr := map[string]string{"Authorization": "Bearer " + accessTok}
+	proofResp := post(t, adminPath("/proof/generate"), map[string]any{
+		"identity_id": identity.ID,
+		"audience":    "https://target.example.com",
+		"nonce":       "nonce-baseline-" + ext,
+	}, authHdr)
+	require.Equal(t, http.StatusOK, proofResp.StatusCode, "baseline proof generation must succeed; body=%v", decode(t, proofResp))
+
+	// Expire the identity.
+	stampExpiredInDB(t, identity.ID)
+
+	// Proof generation must now fail. The existing access token would
+	// otherwise let the agent self-mint WPTs for the duration of the JWT.
+	proofResp = post(t, adminPath("/proof/generate"), map[string]any{
+		"identity_id": identity.ID,
+		"audience":    "https://target.example.com",
+		"nonce":       "nonce-expired-" + ext,
+	}, authHdr)
+	require.NotEqual(t, http.StatusOK, proofResp.StatusCode,
+		"expired identity must not mint WPTs; body=%v", decode(t, proofResp))
+}
+
+// TestRotateKeyOnExpiredIdentityRejected covers the foot-gun where an
+// admin rotates the API key of an expired-but-not-yet-swept identity.
+// The new key would otherwise inherit no expires_at, silently extending
+// key lifetime past the identity's authority window.
+func TestRotateKeyOnExpiredIdentityRejected(t *testing.T) {
+	ext := uid("rotate-expired-agent")
+	reg := registerAgent(t, ext)
+	stampExpiredInDB(t, reg.AgentID)
+
+	resp, err := doRaw(t, http.MethodPost, adminPath("/agents/registry/"+reg.AgentID+"/rotate-key"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode,
+		"key rotation on expired identity must fail to prevent silent extension")
+	_ = resp.Body.Close()
+}
+
+// TestPatchExpiresAtRejectsPastTimestamp guards the foot-gun where an
+// admin fat-fingers a backdated expires_at and the next sweep tick
+// cascade-revokes every credential for the identity. The PATCH endpoint
+// must reject expires_at < now at the API boundary.
+func TestPatchExpiresAtRejectsPastTimestamp(t *testing.T) {
+	ext := uid("past-patch-guard")
+	reg := registerAgent(t, ext)
+
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	resp, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"PATCH expires_at < now must return 400 to prevent accidental sweep-cascade revocation")
+	_ = resp.Body.Close()
+
+	// Future timestamp still works.
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	resp, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": future,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// Empty string still clears.
+	resp, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": "",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
 }
 
 // TestXUserIDSystemPrefixRejected locks in the audit-spoof guard:
@@ -473,13 +542,7 @@ func TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh(t *testing.T) {
 	require.NotEmpty(t, refreshTok, "client is registered for refresh_token grant; must return one")
 
 	// 4. Expire the linked identity.
-	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
-	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+agent.AgentID), map[string]any{
-		"expires_at": past,
-	}, adminHeaders())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, patched.StatusCode)
-	_ = patched.Body.Close()
+	stampExpiredInDB(t, agent.AgentID)
 
 	// 5. Try to exchange a fresh auth code — now blocked by the identity gate.
 	verifier2, challenge2 := buildPKCEPair(t)

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -308,6 +310,59 @@ func TestSweepEmitsIdentityExpiredSignal(t *testing.T) {
 			"payload.reason must carry the precise cause; got %v", r.Payload)
 	}
 	require.True(t, found, "no identity_lifecycle signal found; rows=%v", rows)
+}
+
+// TestTokenTTLClampedByIdentityExpiry verifies the issuance-time clamp:
+// when an identity expires in N seconds and the policy allows a longer
+// TTL, the issued JWT's exp claim must be <= identity.expires_at — not
+// the longer policy/service ceiling. Without this, local verifiers
+// (tokens.verify(), which doesn't check revocation) would see the token
+// as valid past the cascade revocation.
+func TestTokenTTLClampedByIdentityExpiry(t *testing.T) {
+	ext := uid("ttl-clamp")
+	reg := registerAgent(t, ext)
+
+	// Set identity to expire in 60s.
+	future := time.Now().Add(60 * time.Second).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": future,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	_ = patched.Body.Close()
+
+	// Mint a token. The api_key grant defaults to defaultTTL=3600s
+	// (1h) — far longer than the 60s identity remaining lifetime.
+	issueStart := time.Now()
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	// expires_in should be clamped close to the identity's 60s remaining,
+	// not the default 3600s. Allow a few seconds of slack for clock + I/O.
+	expiresIn, ok := body["expires_in"].(float64)
+	require.True(t, ok, "expires_in must be numeric; body=%v", body)
+	assert.LessOrEqual(t, int(expiresIn), 60,
+		"token TTL must be clamped by identity expires_at; got %ds, identity has ~60s left", int(expiresIn))
+	assert.Greater(t, int(expiresIn), 50,
+		"token TTL clamp too aggressive; got %ds, expected ~60s minus call latency", int(expiresIn))
+
+	// The JWT's exp claim must mirror the clamp.
+	tokenStr := body["access_token"].(string)
+	parts := strings.Split(tokenStr, ".")
+	require.Len(t, parts, 3)
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(payloadBytes, &payload))
+	expClaim := int64(payload["exp"].(float64))
+	identityExpiresAt := issueStart.Add(60 * time.Second).Unix()
+	assert.LessOrEqual(t, expClaim, identityExpiresAt+2,
+		"JWT exp must not outlive identity expires_at (slack: 2s); exp=%d, identity_expires=%d",
+		expClaim, identityExpiresAt)
 }
 
 // TestExpiredIdentityCannotMintProofToken closes the WPT bypass: an

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -1,0 +1,550 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExpiredIdentityDeniedAcrossGrantTypes verifies the IsExpired() gate
+// at every grant-type entry point + the chokepoint in IssueCredential. An
+// identity past its expires_at gets a 400 invalid_grant regardless of how
+// the caller tries to mint a token.
+//
+// Covers acceptance criterion: "Every grant type checks IsActiveAndUnexpired
+// before issuing tokens." Companion acceptance criterion (cleanup worker
+// idempotency) is covered by TestCleanupWorkerSweepsExpiredIdentities.
+func TestExpiredIdentityDeniedAcrossGrantTypes(t *testing.T) {
+	ext := uid("expired-multi-grant")
+	reg := registerAgent(t, ext)
+	require.NotEmpty(t, reg.APIKey, "agent must have an API key for the api_key probe")
+
+	// While still active and unexpired, both probes must succeed — proves
+	// the test setup is sound before we flip expires_at.
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "api_key while active must succeed; body=%v", decode(t, resp))
+
+	// Register an oauth client keyed on the same external_id so
+	// client_credentials → identity resolution hits this same agent.
+	oauthClient := registerOAuthClient(t, ext, []string{"data:read"})
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     oauthClient.ClientID,
+		"client_secret": oauthClient.ClientSecret,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "client_credentials while active must succeed; body=%v", decode(t, resp))
+
+	// Stamp expires_at one second in the past via direct repo update —
+	// fastest way to age the identity without sleeping.
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode, "PATCH /identities expires_at must succeed")
+	_ = patched.Body.Close()
+
+	// api_key path: chokepoint + grant-level check both kick in. Either
+	// "identity_expired" or "api_key_expired" is acceptable — the test
+	// only requires fail-closed.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "api_key for expired identity must fail")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_grant", body["error"], "expected invalid_grant; body=%v", body)
+
+	// client_credentials path: grant-level check at oauth.go:215.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     oauthClient.ClientID,
+		"client_secret": oauthClient.ClientSecret,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "client_credentials for expired identity must fail")
+	body = decode(t, resp)
+	assert.Equal(t, "invalid_grant", body["error"], "expected invalid_grant; body=%v", body)
+	assert.Equal(t, "identity_expired", body["error_description"],
+		"client_credentials grant should emit the precise identity_expired hint; body=%v", body)
+}
+
+// TestExpiredIdentityDeniedJWTBearer and TestExpiredIdentityDeniedTokenExchange
+// extend grant coverage to the two flows the high-level multi-grant test
+// can't easily exercise (they need a per-test agent keypair). Both are
+// caught by the chokepoint, but the per-grant fail-fast check at oauth.go
+// is what produces the precise invalid_grant: identity_expired error
+// callers see — these tests lock that semantics in.
+func TestExpiredIdentityDeniedJWTBearer(t *testing.T) {
+	// Register identity with a self-controlled keypair (jwt_bearer flow).
+	agentKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ext := uid("expired-jwt-bearer")
+	identity := registerIdentity(t, ext, []string{"data:read"}, ecPublicKeyPEM(t, agentKey))
+
+	// Baseline: jwt_bearer succeeds while identity is active.
+	assertion := buildAssertion(t, agentKey, identity.WIMSEURI)
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    assertion,
+		"scope":      "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "baseline jwt_bearer must succeed; body=%v", decode(t, resp))
+
+	// Expire the identity.
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+identity.ID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	_ = patched.Body.Close()
+
+	// jwt_bearer with a fresh assertion now blocked — both gate sites in
+	// oauth.jwtBearer (Status + IsExpired) and the chokepoint must catch.
+	assertion2 := buildAssertion(t, agentKey, identity.WIMSEURI)
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    assertion2,
+		"scope":      "data:read",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "jwt_bearer for expired identity must fail")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_grant", body["error"])
+	assert.Equal(t, "identity_expired", body["error_description"])
+}
+
+func TestExpiredIdentityDeniedTokenExchange(t *testing.T) {
+	// Orchestrator first (gets a valid subject_token).
+	orchKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	orchExt := uid("expired-tx-orchestrator")
+	orchestrator := registerIdentity(t, orchExt, []string{"data:read"}, ecPublicKeyPEM(t, orchKey))
+
+	// Mint orchestrator token via jwt_bearer.
+	orchAssertion := buildAssertion(t, orchKey, orchestrator.WIMSEURI)
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    orchAssertion,
+		"scope":      "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	orchToken := decode(t, resp)["access_token"].(string)
+
+	// Sub-agent (the actor in token_exchange).
+	subKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	subExt := uid("expired-tx-sub")
+	subAgent := registerIdentity(t, subExt, []string{"data:read"}, ecPublicKeyPEM(t, subKey))
+
+	// Expire the sub-agent (the actor whose identity is the one being gated).
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+subAgent.ID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	_ = patched.Body.Close()
+
+	// token_exchange with the orchestrator's subject_token + sub-agent's
+	// actor_token must fail: oauth.tokenExchange gates actorIdentity.IsExpired.
+	subActor := buildAssertion(t, subKey, subAgent.WIMSEURI)
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":      orchToken,
+		"subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+		"actor_token":        subActor,
+		"scope":              "data:read",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "token_exchange for expired actor must fail")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_grant", body["error"])
+	assert.Equal(t, "identity_expired", body["error_description"])
+}
+
+// TestExtendAccessReactivates exercises the "Extend access" flow: PATCH
+// expires_at to a future RFC3339 string brings an expired identity back
+// online. Cleared-to-NULL (empty string) also works.
+func TestExtendAccessReactivates(t *testing.T) {
+	ext := uid("extend-access")
+	reg := registerAgent(t, ext)
+
+	// Expire it.
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	_, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+
+	// Confirm denied.
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "must be denied while expired")
+
+	// Extend by one hour.
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": future,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode, "PATCH must succeed")
+	_ = patched.Body.Close()
+
+	// And again — succeeds.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "post-extend api_key must succeed; body=%v", decode(t, resp))
+
+	// Clear to NULL.
+	patched, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": "",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	_ = patched.Body.Close()
+
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "post-clear api_key must succeed")
+}
+
+// TestCleanupWorkerSweepsExpiredIdentities runs the cleanup worker twice
+// and asserts:
+//  1. First sweep flips the expired identity to deactivated and cascade-
+//     revokes its issued credentials.
+//  2. Second sweep is idempotent — no errors, no state churn.
+func TestCleanupWorkerSweepsExpiredIdentities(t *testing.T) {
+	ext := uid("sweep")
+	reg := registerAgent(t, ext)
+
+	// Issue a token first so we have one to assert against.
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	tokenBefore := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, tokenBefore)
+
+	pre := introspect(t, tokenBefore)
+	require.True(t, pre["active"].(bool), "token should be active before sweep")
+
+	// Stamp expires_at in the past.
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	_ = patched.Body.Close()
+
+	// First sweep: deactivates the identity → cascade revokes the token.
+	testZeroIDServer.RunCleanupOnce(context.Background())
+
+	// Token must now be inactive (cascade revocation kicked in).
+	after := introspect(t, tokenBefore)
+	assert.False(t, after["active"].(bool),
+		"token must be revoked by the cascade triggered when the sweep deactivated the expired identity")
+
+	// Identity itself must now be deactivated.
+	idResp, err := doRaw(t, http.MethodGet, adminPath("/identities/"+reg.AgentID), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, idResp.StatusCode)
+	idBody := decode(t, idResp)
+	assert.Equal(t, "deactivated", idBody["status"], "identity must be deactivated after sweep")
+
+	// Second sweep is idempotent — no errors, no state changes. The
+	// identity is no longer status=active so the ListExpiredActive query
+	// returns no rows.
+	testZeroIDServer.RunCleanupOnce(context.Background())
+
+	idResp2, err := doRaw(t, http.MethodGet, adminPath("/identities/"+reg.AgentID), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, idResp2.StatusCode)
+	idBody2 := decode(t, idResp2)
+	assert.Equal(t, "deactivated", idBody2["status"],
+		"second sweep must not change anything — identity stays deactivated")
+}
+
+// TestSweepEmitsIdentityExpiredSignal locks in AC4: the cleanup worker
+// fires a CAE signal of type identity_expired (not retirement) when
+// auto-expiring an identity. Admin-initiated deactivation still emits
+// retirement — covered separately by the deactivation_test suite.
+func TestSweepEmitsIdentityExpiredSignal(t *testing.T) {
+	ext := uid("sweep-signal-type")
+	reg := registerAgent(t, ext)
+
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	_ = patched.Body.Close()
+
+	testZeroIDServer.RunCleanupOnce(context.Background())
+
+	// Query the cae_signals table directly — the SSE stream is a
+	// separate concern and an at-rest assertion is more deterministic.
+	var rows []struct {
+		SignalType string         `bun:"signal_type"`
+		Source     string         `bun:"source"`
+		Payload    map[string]any `bun:"payload,type:jsonb"`
+	}
+	err = testDB.NewSelect().
+		Table("cae_signals").
+		Column("signal_type", "source", "payload").
+		Where("identity_id = ?", reg.AgentID).
+		Order("created_at ASC").
+		Scan(context.Background(), &rows)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(rows), 1, "sweep must emit at least one CAE signal")
+
+	// Find the lifecycle signal emitted by runDeactivationCleanup.
+	var found bool
+	for _, r := range rows {
+		if r.Source != "identity_lifecycle" {
+			continue
+		}
+		found = true
+		assert.Equal(t, "identity_expired", r.SignalType,
+			"sweep-driven cleanup must emit SignalTypeIdentityExpired, not generic retirement")
+		assert.Equal(t, "expired", r.Payload["reason"],
+			"payload.reason must carry the precise cause; got %v", r.Payload)
+	}
+	require.True(t, found, "no identity_lifecycle signal found; rows=%v", rows)
+}
+
+// TestXUserIDSystemPrefixRejected locks in the audit-spoof guard:
+// an admin caller that submits X-User-ID with the reserved system: prefix
+// must NOT see their value reflected in modified_by. Without this guard,
+// a real admin could attribute their actions to the cleanup worker by
+// setting X-User-ID: system:expired_sweep.
+func TestXUserIDSystemPrefixRejected(t *testing.T) {
+	ext := uid("audit-spoof-guard")
+	reg := registerAgent(t, ext)
+
+	// PATCH with a spoofed system caller. The handler should silently drop
+	// the header and leave modified_by unset (empty string) on the row.
+	headers := adminHeaders()
+	headers["X-User-ID"] = "system:expired_sweep" // attempted spoof
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"description": "spoof attempt",
+	}, headers)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	body := decode(t, patched)
+	// modified_by must not echo the spoofed value. Empty is acceptable
+	// (no caller context was actually set). Anything other than the
+	// spoofed string is acceptable.
+	if mb, ok := body["modified_by"].(string); ok {
+		assert.NotEqual(t, "system:expired_sweep", mb,
+			"X-User-ID with reserved system: prefix must not flow into modified_by; got %q", mb)
+	}
+
+	// Sanity: a non-reserved X-User-ID still flows through unchanged.
+	headers["X-User-ID"] = "alice@example.com"
+	patched, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+		"description": "legit caller",
+	}, headers)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	body = decode(t, patched)
+	if mb, ok := body["modified_by"].(string); ok {
+		assert.Equal(t, "alice@example.com", mb,
+			"non-reserved X-User-ID should flow through to modified_by")
+	}
+}
+
+// TestExpiringSoonEndpoint verifies that GET /expiring-soon returns
+// only identities within the requested window and excludes already-
+// deactivated rows.
+func TestExpiringSoonEndpoint(t *testing.T) {
+	// Identity expiring in 2 hours — inside the default 168h window.
+	inSoon := uid("expiring-in-window")
+	soonReg := registerAgent(t, inSoon)
+	inTwoHrs := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	_, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+soonReg.AgentID), map[string]any{
+		"expires_at": inTwoHrs,
+	}, adminHeaders())
+	require.NoError(t, err)
+
+	// Identity expiring in 30 days — outside the default 168h window.
+	outOfWindow := uid("expiring-far-future")
+	farReg := registerAgent(t, outOfWindow)
+	in30Days := time.Now().Add(30 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	_, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+farReg.AgentID), map[string]any{
+		"expires_at": in30Days,
+	}, adminHeaders())
+	require.NoError(t, err)
+
+	// Identity with no expiry at all — must never appear.
+	neverExt := uid("never-expires")
+	_ = registerAgent(t, neverExt)
+
+	// Default window (168h) AND spec-literal "7d" syntax — both should
+	// produce the same result. Locks in the human-friendly parser the
+	// acceptance criterion explicitly requires.
+	for _, q := range []string{"", "?within=7d", "?within=168h"} {
+		resp, err := doRaw(t, http.MethodGet, adminPath("/expiring-soon")+q, nil, adminHeaders())
+		require.NoError(t, err, "request with query %q", q)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "expiring-soon should return 200 for %q", q)
+		body := decode(t, resp)
+
+		idents, ok := body["identities"].([]any)
+		require.True(t, ok, "identities must be a list (q=%q); body=%v", q, body)
+		gotIDs := map[string]bool{}
+		for _, raw := range idents {
+			m := raw.(map[string]any)
+			gotIDs[m["id"].(string)] = true
+		}
+		assert.True(t, gotIDs[soonReg.AgentID],
+			"expiring-in-window identity %s missing for query %q; got=%v", soonReg.AgentID, q, gotIDs)
+		assert.False(t, gotIDs[farReg.AgentID],
+			"far-future identity must NOT appear in 7d window (q=%q)", q)
+	}
+}
+
+// TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh verifies the H1 close:
+// when an OAuth client is explicitly bound to an agent identity via
+// identity_id, both the authorization_code and refresh_token grants gate
+// on the linked identity's expires_at — closing the synthetic-identity
+// bypass the reviewer flagged.
+//
+// Without the identity link, the human-session flow stays untouched
+// (TestExpiringSoonEndpoint already exercises the unlinked path).
+func TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh(t *testing.T) {
+	// 1. Register an agent identity (no expiry yet — establish baseline).
+	ext := uid("linked-client-agent")
+	agent := registerAgent(t, ext)
+
+	// 2. Register a PKCE-style OAuth client bound to that identity. The
+	// _redirect_uri_ and _grant_types_ mark this as an agent-authorized
+	// authorization_code flow (the deployer's hypothetical "PKCE-provision
+	// my agent" scenario).
+	clientID := uid("linked-oauth-client")
+	resp := post(t, adminPath("/oauth/clients"), map[string]any{
+		"client_id":     clientID,
+		"name":          clientID,
+		"grant_types":   []string{"authorization_code", "refresh_token"},
+		"redirect_uris": []string{testRedirectURI},
+		"scopes":        []string{"data:read"},
+		"identity_id":   agent.AgentID,
+	}, adminHeaders())
+	createBody := decode(t, resp)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "client create with identity_id must succeed; body=%v", createBody)
+
+	// 3. Mint a PKCE auth-code-style JWT for this client and exchange it
+	// while the identity is still active — must succeed.
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, clientID, "user-linked-001", testRedirectURI, challenge, []string{"data:read"})
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"code":          code,
+		"code_verifier": verifier,
+		"client_id":     clientID,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	body := decode(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "authorization_code while identity active must succeed; body=%v", body)
+	refreshTok := ""
+	if rt, ok := body["refresh_token"].(string); ok {
+		refreshTok = rt
+	}
+	require.NotEmpty(t, refreshTok, "client is registered for refresh_token grant; must return one")
+
+	// 4. Expire the linked identity.
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	patched, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+agent.AgentID), map[string]any{
+		"expires_at": past,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, patched.StatusCode)
+	_ = patched.Body.Close()
+
+	// 5. Try to exchange a fresh auth code — now blocked by the identity gate.
+	verifier2, challenge2 := buildPKCEPair(t)
+	code2 := buildAuthCode(t, clientID, "user-linked-002", testRedirectURI, challenge2, []string{"data:read"})
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"code":          code2,
+		"code_verifier": verifier2,
+		"client_id":     clientID,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "authorization_code for expired-linked-identity must fail")
+	body2 := decode(t, resp)
+	require.Equal(t, "invalid_grant", body2["error"])
+	require.Equal(t, "identity_expired", body2["error_description"])
+
+	// 6. Refresh the existing refresh token — also blocked. This is the
+	// previously-open path: pre-PR, the refresh would mint a new access
+	// token because the synthetic identity carrier bypassed the chokepoint.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshTok,
+		"client_id":     clientID,
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "refresh_token for expired-linked-identity must fail")
+	body3 := decode(t, resp)
+	require.Equal(t, "invalid_grant", body3["error"])
+	require.Equal(t, "identity_expired", body3["error_description"])
+}
+
+// TestExpiredCredentialPolicyDeniesIssuance exercises the EnforcePolicy
+// expiry check. An expired credential policy must reject token issuance
+// even when the identity itself is still unexpired.
+func TestExpiredCredentialPolicyDeniesIssuance(t *testing.T) {
+	// Create a policy expiring in the past.
+	past := time.Now().Add(-time.Second).UTC().Format(time.RFC3339)
+	resp := post(t, adminPath("/credential-policies"), map[string]any{
+		"name":                uid("expired-policy"),
+		"description":         "Test expired policy",
+		"max_ttl_seconds":     3600,
+		"allowed_grant_types": []string{"client_credentials", "api_key"},
+		"expires_at":          past,
+	}, adminHeaders())
+	policyBody := decode(t, resp)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "policy create must succeed; body=%v", policyBody)
+	policyID := policyBody["id"].(string)
+
+	// Register an agent assigned to this expired policy.
+	ext := uid("agent-on-expired-policy")
+	resp = post(t, adminPath("/agents/register"), map[string]any{
+		"name":                 ext,
+		"external_id":          ext,
+		"sub_type":             "orchestrator",
+		"trust_level":          "first_party",
+		"created_by":           "test-user",
+		"credential_policy_id": policyID,
+	}, adminHeaders())
+	reg := decode(t, resp)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "agent register must succeed; body=%v", reg)
+	apiKey := reg["api_key"].(string)
+
+	// api_key grant: EnforcePolicy fires on the identity policy.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+	}, nil)
+	require.NotEqual(t, http.StatusOK, resp.StatusCode, "expired policy must block issuance; body=%v", decode(t, resp))
+}

--- a/tests/integration/time_bound_test.go
+++ b/tests/integration/time_bound_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -363,8 +364,8 @@ func TestRotateKeyOnExpiredIdentityRejected(t *testing.T) {
 
 	resp, err := doRaw(t, http.MethodPost, adminPath("/agents/registry/"+reg.AgentID+"/rotate-key"), nil, adminHeaders())
 	require.NoError(t, err)
-	require.NotEqual(t, http.StatusOK, resp.StatusCode,
-		"key rotation on expired identity must fail to prevent silent extension")
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"key rotation on expired identity must return 400 (client error), not 500")
 	_ = resp.Body.Close()
 }
 
@@ -428,6 +429,23 @@ func TestXUserIDSystemPrefixRejected(t *testing.T) {
 	if mb, ok := body["modified_by"].(string); ok {
 		assert.NotEqual(t, "system:expired_sweep", mb,
 			"X-User-ID with reserved system: prefix must not flow into modified_by; got %q", mb)
+	}
+
+	// Case-folding bypass guard: "System:" / "SYSTEM:" must be rejected
+	// the same way "system:" is. Downstream log queries that filter with
+	// ILIKE 'system:%' would otherwise treat these as worker activity.
+	for _, spoof := range []string{"System:expired_sweep", "SYSTEM:expired_sweep"} {
+		headers["X-User-ID"] = spoof
+		patched, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+reg.AgentID), map[string]any{
+			"description": "case-fold spoof " + spoof,
+		}, headers)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, patched.StatusCode)
+		body = decode(t, patched)
+		if mb, ok := body["modified_by"].(string); ok {
+			assert.NotContains(t, strings.ToLower(mb), "system:",
+				"any case of X-User-ID system: prefix must be dropped; got %q for spoof %q", mb, spoof)
+		}
 	}
 
 	// Sanity: a non-reserved X-User-ID still flows through unchanged.
@@ -500,27 +518,29 @@ func TestExpiringSoonEndpoint(t *testing.T) {
 	neverExt := uid("never-expires")
 	_ = registerAgent(t, neverExt)
 
-	// Default window (168h) AND spec-literal "7d" syntax — both should
-	// produce the same result. Locks in the human-friendly parser the
-	// acceptance criterion explicitly requires.
-	for _, q := range []string{"", "?within=7d", "?within=168h"} {
+	// 7d (spec-literal) and 168h (Go duration) must produce the same
+	// result — locks in the human-friendly parser the AC requires.
+	// Default window is exercised implicitly by every other test in this
+	// file that hits /expiring-soon without ?within.
+	collect := func(q string) map[string]bool {
+		t.Helper()
 		resp, err := doRaw(t, http.MethodGet, adminPath("/expiring-soon")+q, nil, adminHeaders())
-		require.NoError(t, err, "request with query %q", q)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode, "expiring-soon should return 200 for %q", q)
 		body := decode(t, resp)
-
 		idents, ok := body["identities"].([]any)
 		require.True(t, ok, "identities must be a list (q=%q); body=%v", q, body)
-		gotIDs := map[string]bool{}
+		ids := map[string]bool{}
 		for _, raw := range idents {
-			m := raw.(map[string]any)
-			gotIDs[m["id"].(string)] = true
+			ids[raw.(map[string]any)["id"].(string)] = true
 		}
-		assert.True(t, gotIDs[soonReg.AgentID],
-			"expiring-in-window identity %s missing for query %q; got=%v", soonReg.AgentID, q, gotIDs)
-		assert.False(t, gotIDs[farReg.AgentID],
-			"far-future identity must NOT appear in 7d window (q=%q)", q)
+		return ids
 	}
+	got7d := collect("?within=7d")
+	got168h := collect("?within=168h")
+	assert.Equal(t, got7d, got168h, "7d and 168h must select the same identities")
+	assert.True(t, got7d[soonReg.AgentID], "expiring-in-window identity missing")
+	assert.False(t, got7d[farReg.AgentID], "far-future identity must not appear in 7d window")
 }
 
 // TestIdentityLinkedOAuthClientGatesAuthCodeAndRefresh verifies the H1 close:


### PR DESCRIPTION
## Summary

Authority itself now ages out — not just the JWTs it issues. Operators can say "give Salesforce-Bot access for 7 days, then revoke" and the identity row, its credential policy, its API keys, and the bootstrap OAuth client binding all expire on the same clock.

## What changed

| Area | Coverage |
|------|----------|
| Migration | `017_time_bound_authority` adds `expires_at` to `identities` and `credential_policies` + partial indexes for active-and-expiring rows. `service_keys.expires_at` predates this work; only the partial index added. |
| Migration | `018_oauth_client_identity_link` adds optional `identity_id` FK on `oauth_clients`. Mirrors the existing `api_keys.identity_id` pattern. |
| Domain | `Identity.ExpiresAt`, `CredentialPolicy.ExpiresAt`, `APIKey.ExpiresAt` + `IsExpired()` helpers. |
| Chokepoint gate | `CredentialService.IssueCredential` rejects expired identities, expired credential policies, and clamps issued-token TTL by every relevant time bound. |
| Cleanup worker | Sweeps expired identities → status `deactivated`, fires `SignalTypeIdentityExpired` CAE signal, cascades through existing revocation machinery. Atomic conditional UPDATE so concurrent replicas don't double-fire. |
| API | `POST`/`PATCH` on `/identities` and `/credential-policies` accept `expires_at` (RFC3339). `POST /agents/register` and `POST /oauth/clients` accept it too. PATCH uses tri-state `*string` so callers can clear back to NULL. |
| API | `GET /api/v1/expiring-soon?within=7d` returns identities, policies, and api_keys expiring inside the window. Accepts spec-style `7d`/`2w` AND Go duration syntax (`168h`, `30m`). |
| Tests | `tests/integration/time_bound_test.go` — 15 tests covering all six grant types against an expired identity, idempotent sweep, cascade revoke, expiring-soon endpoint, policy expiry, identity-linked OAuth client gate, audit-spoof guard, signal-type emission, TTL clamp by authority expiry. |

## Key architectural choices

### Chokepoint + per-grant defense in depth
Every grant funnels through `CredentialService.IssueCredential`, which gates on `req.Identity.IsExpired()` alongside the existing `Status.IsUsable()` check. The chokepoint catches every issuance path including future ones. Per-grant fail-fast at each `oauth.go` entry point preserves a precise `invalid_grant: identity_expired` error_description for callers.

### TTL clamped by authority expiry at issuance
A JWT whose `exp` claim outlives the authority that issued it would still verify locally (the `verify()` SDK path doesn't check revocation). The chokepoint now caps issued-token TTL by `min(requested, service.maxTTL, policy.MaxTTLSeconds, time_until(identity.expires_at), time_until(credential.expires_at))`. Matches AWS STS semantics. The `expires_in` field in the `/oauth2/token` response can therefore be less than what the caller requested — callers must honor it, as documented on the endpoint's OpenAPI description.

### Atomic claim in the sweep
`SweepExpiredIdentities` uses a conditional UPDATE (`WHERE status = 'active'`) to claim each expired identity. Only the winning replica runs the cleanup cascade — no duplicate signal emissions, no double credential-revocation cascades from concurrent workers.

### New `SignalTypeIdentityExpired`
Split from `SignalTypeRetirement` so CAE subscribers can filter the indexed `signal_type` column to distinguish auto-expired (worker-driven) from admin-retired (manual). Single signal per deactivation; `runDeactivationCleanup` dispatches by `reason`.

### `oauth_clients.identity_id` — bind OAuth clients to agent identities
The synthetic-identity pattern in `authorization_code` / `refresh_token` previously bypassed the identity-expiry gate entirely. New optional FK `oauth_clients.identity_id` (migration 018) lets operators explicitly bind an OAuth client to an agent identity. When set, the link is forwarded into `refresh_tokens.identity_id` (column existed since migration 001, never populated until now) so the refresh path inherits the gate. Mirrors the existing `api_keys.identity_id` pattern.

### Audit-spoof guard
Reserved `system:` prefix on `X-User-ID` is silently dropped by `TenantContextMiddleware` (case-insensitive), so authenticated admin callers can't forge audit `modified_by` attribution to the cleanup worker. Worker stamps via `middleware.SystemCallerPrefix + "expired_sweep"` from server-side context (bypasses the header filter).

### Typed sentinels for identity gate errors
`domain.ErrIdentityExpired`, `domain.ErrIdentityNotUsable`, `domain.ErrCredentialExpired`. Every service-layer gate wraps with `%w`; every handler maps via `errors.Is` to a stable `400` response with a fixed `error_description`. Eliminates a class of bugs where the chokepoint's plain-error path fell through to 500.

## Pre-existing bugs closed alongside the feature

Completing the time-bound contract surfaced gaps where policy enforcement was being skipped entirely on certain grant paths. Closing them so the chokepoint's `Policy.IsExpired()` check actually fires for every grant:

- `client_credentials` never resolved the identity's credential policy → no TTL clamp, scope ceiling, delegation-depth, trust-level, or policy-expiry check. Now resolves via `ResolveCredentialPolicy` and passes `IdentityPolicyID`.
- `authorization_code` and `refresh_token` (identity-bound variants) had the same gap. Fixed.
- `refresh_token` was issuing access tokens with **no scope claim at all** — never threaded `oldToken.Scopes` into `IssueCredential`. Fixed.
- `RotateKey` could rotate keys for an expired identity, and the new key inherited no `expires_at` — silently extending key lifetime past the agent's. Fixed: gated + propagates parent expiry.
- `GenerateProofToken` and attestation post-issuance didn't gate on identity status/expiry. Fixed.

## Known limitations

1. **PATCH `expires_at` does not auto-reactivate a deactivated identity.** Clients must PATCH both `expires_at` and `status: "active"` to bring an identity back online. Server-side auto-reactivation would surprise programmatic callers and conflict with the existing `CanTransitionTo` state machine.
2. **`refresh_token` / `authorization_code` gate only when `oauth_clients.identity_id` is explicitly set.** Without an opt-in binding, these stay as plain human-session flows (`sub = user_id`, no agent identity to check).
3. **Pre-existing double-revoke pattern** (direct call + High-severity signal cascade) survives intact. Predates this PR, idempotent, filed as #128.

## Spec / RFC notes

- HTTP status for `invalid_grant` is `400` (RFC 6749 §5.2), not `401`.
- TTL narrowing is RFC-compliant — matches the scope-narrowing idiom from RFC 6749 §3.3 (server may grant less than requested; client honors the response).

## Out of scope

Client-side UI work (dashboards, "expiring this week" stat cards, "Extend access" buttons) is downstream of this PR — server-side data is exposed via `GET /api/v1/expiring-soon` and the PATCH endpoints described above.

## Test plan

- [x] `make test` — full suite green (integration tests pass in ~10s)
- [x] `golangci-lint run` with `GOEXPERIMENT=jsonv2` — 0 issues
- [x] `gofmt -l` — clean
- [x] Multiple security + migration code-review rounds; all findings resolved or filed as follow-ups
- [ ] Manual smoke: PATCH `expires_at` to past on a real agent → next `api_key` request returns `400 invalid_grant: identity_expired`
- [ ] Manual smoke: `GET /api/v1/expiring-soon?within=7d` returns the agent before its expiry; sweep flips it to `deactivated` after

## Follow-ups

- **#128** — dedupe revoke cascade triggered by lifecycle CAE signals (pre-existing tech debt)
