### PR TITLE
feat: CIBA ping mode (PR 2/3 for #64) — stacked on #131

### DIFF
--- a/domain/backchannel_auth.go
+++ b/domain/backchannel_auth.go
@@ -59,6 +59,7 @@ type BackchannelAuthRequest struct {
 	BindingMessage             string                      `bun:"binding_message,type:text"                    json:"binding_message,omitempty"`
 	NotificationMode           BackchannelNotificationMode `bun:"notification_mode,type:varchar(16)"           json:"notification_mode"`
 	ClientNotificationEndpoint string                      `bun:"client_notification_endpoint,type:text"       json:"client_notification_endpoint,omitempty"`
+	ClientNotificationToken    string                      `bun:"client_notification_token,type:varchar(1024)" json:"-"`
 	Status                     BackchannelStatus           `bun:"status,type:varchar(16)"                      json:"status"`
 	ApprovedSubjectID          string                      `bun:"approved_subject_id,type:varchar(255)"        json:"approved_subject_id,omitempty"`
 	ApprovedSubjectEmail       string                      `bun:"approved_subject_email,type:varchar(255)"     json:"approved_subject_email,omitempty"`

--- a/domain/token.go
+++ b/domain/token.go
@@ -85,6 +85,11 @@ type OAuthClient struct {
 	RedirectURIs []string `bun:"redirect_uris,array" json:"redirect_uris"`
 	Scopes       []string `bun:"scopes,array"       json:"scopes"`
 
+	// CIBA Core 1.0 — ping/push notification endpoint. Registered HTTPS URL
+	// the server POSTs to when a backchannel authentication request resolves.
+	// Empty when the client doesn't support ping mode (polling-only).
+	ClientNotificationEndpoint string `bun:"client_notification_endpoint" json:"client_notification_endpoint,omitempty"`
+
 	// Token lifetime (per-client, 0 = use server default)
 	AccessTokenTTL  int `bun:"access_token_ttl"  json:"access_token_ttl,omitempty"`
 	RefreshTokenTTL int `bun:"refresh_token_ttl" json:"refresh_token_ttl,omitempty"`

--- a/hooks.go
+++ b/hooks.go
@@ -60,6 +60,9 @@ type OAuthClientConfig struct {
 	SoftwareVersion         string
 	Contacts                []string
 	Metadata                json.RawMessage
+	// ClientNotificationEndpoint is the HTTPS callback CIBA ping mode posts to.
+	// Empty for clients that only use polling mode.
+	ClientNotificationEndpoint string
 }
 
 // TrustedServiceValidator checks whether the current request comes from a trusted

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -285,13 +285,14 @@ func (a *API) revokeOp(ctx context.Context, input *OAuthRevokeInput) (*OAuthRevo
 // (clients in ZeroID are global to all tenants).
 type BcAuthorizeInput struct {
 	Body struct {
-		ClientID        string `json:"client_id" required:"true" doc:"OAuth client initiating the backchannel request"`
-		AccountID       string `json:"account_id" required:"true" doc:"Tenant account ID"`
-		ProjectID       string `json:"project_id" required:"true" doc:"Tenant project ID"`
-		LoginHint       string `json:"login_hint" required:"true" doc:"User identifier (email, phone, user_id)"`
-		Scope           string `json:"scope,omitempty" doc:"Requested scopes (space-delimited)"`
-		BindingMessage  string `json:"binding_message,omitempty" doc:"Human-readable context shown to the user during approval"`
-		RequestedExpiry int    `json:"requested_expiry,omitempty" doc:"Auth-request TTL in seconds; bounded by server default"`
+		ClientID                string `json:"client_id" required:"true" doc:"OAuth client initiating the backchannel request"`
+		AccountID               string `json:"account_id" required:"true" doc:"Tenant account ID"`
+		ProjectID               string `json:"project_id" required:"true" doc:"Tenant project ID"`
+		LoginHint               string `json:"login_hint" required:"true" doc:"User identifier (email, phone, user_id)"`
+		Scope                   string `json:"scope,omitempty" doc:"Requested scopes (space-delimited)"`
+		BindingMessage          string `json:"binding_message,omitempty" doc:"Human-readable context shown to the user during approval"`
+		RequestedExpiry         int    `json:"requested_expiry,omitempty" doc:"Auth-request TTL in seconds; bounded by server default"`
+		ClientNotificationToken string `json:"client_notification_token,omitempty" doc:"Bearer the server echoes in the ping callback (required for ping mode)"`
 	}
 }
 
@@ -312,13 +313,14 @@ func (a *API) bcAuthorizeOp(ctx context.Context, input *BcAuthorizeInput) (*BcAu
 		}, nil
 	}
 	out, err := a.backchannelSvc.CreateAuthRequest(ctx, service.CreateAuthRequestInput{
-		ClientID:        input.Body.ClientID,
-		AccountID:       input.Body.AccountID,
-		ProjectID:       input.Body.ProjectID,
-		LoginHint:       input.Body.LoginHint,
-		Scope:           input.Body.Scope,
-		BindingMessage:  input.Body.BindingMessage,
-		RequestedExpiry: input.Body.RequestedExpiry,
+		ClientID:                input.Body.ClientID,
+		AccountID:               input.Body.AccountID,
+		ProjectID:               input.Body.ProjectID,
+		LoginHint:               input.Body.LoginHint,
+		Scope:                   input.Body.Scope,
+		BindingMessage:          input.Body.BindingMessage,
+		RequestedExpiry:         input.Body.RequestedExpiry,
+		ClientNotificationToken: input.Body.ClientNotificationToken,
 	})
 	if err != nil {
 		log.Error().Err(err).Str("client_id", input.Body.ClientID).Msg("bc-authorize failed")

--- a/internal/handler/oauth_client.go
+++ b/internal/handler/oauth_client.go
@@ -56,6 +56,10 @@ type CreateOAuthClientInput struct {
 		// issuance on the linked identity's status + expires_at. The
 		// identity must exist in the caller's tenant (validated below).
 		IdentityID string `json:"identity_id,omitempty" doc:"Optional identity UUID to bind this client to — gates authorization_code and refresh_token grants on the linked identity's status and expires_at"`
+
+		// CIBA (OpenID CIBA Core 1.0) — registered callback for ping/push notifications.
+		// Must be HTTPS. Empty when the client only uses polling mode.
+		ClientNotificationEndpoint string `json:"client_notification_endpoint,omitempty" doc:"HTTPS callback URL for CIBA ping mode"`
 	}
 }
 
@@ -159,23 +163,24 @@ func (a *API) createOAuthClientOp(ctx context.Context, input *CreateOAuthClientI
 	}
 
 	client, plainSecret, err := a.oauthClientSvc.RegisterClient(ctx, service.RegisterClientRequest{
-		ClientID:                input.Body.ClientID,
-		Name:                    input.Body.Name,
-		Description:             input.Body.Description,
-		Confidential:            input.Body.Confidential,
-		TokenEndpointAuthMethod: input.Body.TokenEndpointAuthMethod,
-		GrantTypes:              input.Body.GrantTypes,
-		Scopes:                  input.Body.Scopes,
-		RedirectURIs:            input.Body.RedirectURIs,
-		AccessTokenTTL:          input.Body.AccessTokenTTL,
-		RefreshTokenTTL:         input.Body.RefreshTokenTTL,
-		JWKSURI:                 input.Body.JWKSURI,
-		JWKS:                    input.Body.JWKS,
-		SoftwareID:              input.Body.SoftwareID,
-		SoftwareVersion:         input.Body.SoftwareVersion,
-		Contacts:                input.Body.Contacts,
-		Metadata:                input.Body.Metadata,
-		IdentityID:              input.Body.IdentityID,
+		ClientID:                   input.Body.ClientID,
+		Name:                       input.Body.Name,
+		Description:                input.Body.Description,
+		Confidential:               input.Body.Confidential,
+		TokenEndpointAuthMethod:    input.Body.TokenEndpointAuthMethod,
+		GrantTypes:                 input.Body.GrantTypes,
+		Scopes:                     input.Body.Scopes,
+		RedirectURIs:               input.Body.RedirectURIs,
+		AccessTokenTTL:             input.Body.AccessTokenTTL,
+		RefreshTokenTTL:            input.Body.RefreshTokenTTL,
+		JWKSURI:                    input.Body.JWKSURI,
+		JWKS:                       input.Body.JWKS,
+		SoftwareID:                 input.Body.SoftwareID,
+		SoftwareVersion:            input.Body.SoftwareVersion,
+		Contacts:                   input.Body.Contacts,
+		Metadata:                   input.Body.Metadata,
+		IdentityID:                 input.Body.IdentityID,
+		ClientNotificationEndpoint: input.Body.ClientNotificationEndpoint,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrOAuthClientAlreadyExists) {

--- a/internal/service/backchannel.go
+++ b/internal/service/backchannel.go
@@ -1,11 +1,15 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"sync"
 	"time"
 
@@ -47,6 +51,13 @@ type BackchannelService struct {
 	// still get a working notifier path.
 	svcCtx    context.Context
 	svcCancel context.CancelFunc
+
+	// Ping mode (PR 2) — bounded outbound HTTP client. The RoundTripper is
+	// swappable so tests can capture POSTs without standing up an httptest
+	// listener; production should leave it nil (uses http.DefaultTransport
+	// with a 10-second timeout enforced by pingClient.Timeout).
+	pingClient        *http.Client
+	pingDispatchAsync bool // overridable for tests
 }
 
 // BackchannelNotifierFunc is the internal alias for the public
@@ -83,6 +94,10 @@ type BackchannelServiceConfig struct {
 	MinPollInterval        time.Duration
 	DefaultPollInterval    int
 	MaxBindingMessageBytes int
+	// Ping-mode tunables (PR 2).
+	PingTimeout    time.Duration // per-attempt HTTP timeout
+	PingMaxRetries int           // additional attempts on transient failure; 0 → no retries
+	PingBaseDelay  time.Duration // first-retry backoff; doubled per attempt with jitter
 }
 
 // DefaultBackchannelConfig returns sensible defaults for production deployments.
@@ -93,6 +108,9 @@ func DefaultBackchannelConfig() BackchannelServiceConfig {
 		MinPollInterval:        2 * time.Second,
 		DefaultPollInterval:    5,
 		MaxBindingMessageBytes: 280,
+		PingTimeout:            10 * time.Second,
+		PingMaxRetries:         3,
+		PingBaseDelay:          500 * time.Millisecond,
 	}
 }
 
@@ -118,6 +136,12 @@ func NewBackchannelService(
 	if cfg.MaxBindingMessageBytes == 0 {
 		cfg.MaxBindingMessageBytes = 280
 	}
+	if cfg.PingTimeout == 0 {
+		cfg.PingTimeout = 10 * time.Second
+	}
+	if cfg.PingBaseDelay == 0 {
+		cfg.PingBaseDelay = 500 * time.Millisecond
+	}
 	svcCtx, svcCancel := context.WithCancel(context.Background())
 	return &BackchannelService{
 		repo:                repo,
@@ -127,6 +151,8 @@ func NewBackchannelService(
 		notifyDispatchAsync: true,
 		svcCtx:              svcCtx,
 		svcCancel:           svcCancel,
+		pingClient:          &http.Client{Timeout: cfg.PingTimeout},
+		pingDispatchAsync:   true,
 	}
 }
 
@@ -164,6 +190,23 @@ func (s *BackchannelService) SetNotifyDispatchSync(sync bool) {
 	s.notifyDispatchAsync = !sync
 }
 
+// SetPingTransport overrides the outbound HTTP transport used for CIBA ping
+// dispatch. Tests inject a capturing RoundTripper here so they don't have to
+// stand up a real httptest listener. Pass nil to restore the default
+// http.Transport.
+func (s *BackchannelService) SetPingTransport(rt http.RoundTripper) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pingClient = &http.Client{Timeout: s.cfg.PingTimeout, Transport: rt}
+}
+
+// SetPingDispatchSync forces synchronous ping dispatch — test-only.
+func (s *BackchannelService) SetPingDispatchSync(sync bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pingDispatchAsync = !sync
+}
+
 // CreateAuthRequest input for POST /oauth2/bc-authorize.
 type CreateAuthRequestInput struct {
 	ClientID        string
@@ -173,6 +216,11 @@ type CreateAuthRequestInput struct {
 	Scope           string
 	BindingMessage  string
 	RequestedExpiry int // seconds; 0 → DefaultExpiry
+	// ClientNotificationToken triggers ping-mode dispatch when non-empty.
+	// CIBA Core §7.1: the server includes this verbatim as the bearer
+	// credential in the ping callback's Authorization header. The client
+	// uses it to authenticate the inbound notification.
+	ClientNotificationToken string
 }
 
 // CreateAuthRequestOutput is returned to the client on success.
@@ -209,7 +257,28 @@ func (s *BackchannelService) CreateAuthRequest(ctx context.Context, in CreateAut
 	if err != nil {
 		return nil, oauthBadRequestCause("invalid_client", fmt.Sprintf("unknown client %s", in.ClientID), err)
 	}
-	_ = client // reserved for ping-mode allowlist read in PR 2
+
+	// Ping mode: when the client supplies a client_notification_token, the
+	// client MUST have a registered client_notification_endpoint on its
+	// record. The endpoint is the per-client allowlist — we never accept a
+	// per-request URL because that would let a compromised token redirect
+	// notifications.
+	notificationMode := domain.BackchannelNotificationPoll
+	notificationEndpoint := ""
+	if in.ClientNotificationToken != "" {
+		if client.ClientNotificationEndpoint == "" {
+			return nil, oauthBadRequest("invalid_request",
+				"client_notification_token requires the client to have a registered client_notification_endpoint")
+		}
+		// Defence-in-depth: re-validate the registered endpoint is HTTPS even
+		// though RegisterClient already enforced it. A future bypass at
+		// registration must not silently degrade ping mode to http.
+		if err := validateNotificationEndpoint(client.ClientNotificationEndpoint); err != nil {
+			return nil, oauthBadRequestCause("invalid_request", "client_notification_endpoint is invalid", err)
+		}
+		notificationMode = domain.BackchannelNotificationPing
+		notificationEndpoint = client.ClientNotificationEndpoint
+	}
 
 	// Reject oversized binding_message rather than silently truncating.
 	// Silent truncation produced confusing UX (the prompt the user saw didn't
@@ -240,18 +309,20 @@ func (s *BackchannelService) CreateAuthRequest(ctx context.Context, in CreateAut
 
 	now := time.Now()
 	row := &domain.BackchannelAuthRequest{
-		AuthReqID:        authReqID,
-		AccountID:        in.AccountID,
-		ProjectID:        in.ProjectID,
-		ClientID:         in.ClientID,
-		LoginHint:        in.LoginHint,
-		Scope:            in.Scope,
-		BindingMessage:   bindingMsg,
-		NotificationMode: domain.BackchannelNotificationPoll,
-		Status:           domain.BackchannelStatusPending,
-		IntervalSeconds:  s.cfg.DefaultPollInterval,
-		ExpiresAt:        now.Add(expiry),
-		CreatedAt:        now,
+		AuthReqID:                  authReqID,
+		AccountID:                  in.AccountID,
+		ProjectID:                  in.ProjectID,
+		ClientID:                   in.ClientID,
+		LoginHint:                  in.LoginHint,
+		Scope:                      in.Scope,
+		BindingMessage:             bindingMsg,
+		NotificationMode:           notificationMode,
+		ClientNotificationEndpoint: notificationEndpoint,
+		ClientNotificationToken:    in.ClientNotificationToken,
+		Status:                     domain.BackchannelStatusPending,
+		IntervalSeconds:            s.cfg.DefaultPollInterval,
+		ExpiresAt:                  now.Add(expiry),
+		CreatedAt:                  now,
 	}
 	if err := s.repo.Create(ctx, row); err != nil {
 		return nil, oauthServerError("failed to persist backchannel auth request", err)
@@ -313,6 +384,11 @@ func (s *BackchannelService) Approve(ctx context.Context, in ApproveInput) error
 		// Lost a race against expiry sweep or a concurrent deny.
 		return oauthBadRequest("access_denied", "request could not be approved (concurrent modification or expiry)")
 	}
+	// Ping mode: notify the client that the request resolved. The client
+	// then polls /oauth2/token to receive the access token. We do this
+	// after the row transition so a successful ping always reflects a
+	// successful state change.
+	s.dispatchPing(ctx, row)
 	return nil
 }
 
@@ -348,6 +424,7 @@ func (s *BackchannelService) Deny(ctx context.Context, in DenyInput) error {
 	if affected == 0 {
 		return oauthBadRequest("access_denied", "request could not be denied (concurrent modification or expiry)")
 	}
+	s.dispatchPing(ctx, row)
 	return nil
 }
 
@@ -546,4 +623,136 @@ func mintAuthReqID() (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+// dispatchPing POSTs the CIBA ping callback (Core §10.2) to the client's
+// registered client_notification_endpoint. The payload is the minimal
+// {"auth_req_id": "..."} JSON; the access token is NOT included (that's push
+// mode, which is PR 3). The Authorization header carries the client_notification_token
+// the client supplied at bc-authorize so the client can authenticate the
+// inbound notification.
+//
+// No-ops when:
+//   - notification_mode is "poll"
+//   - client_notification_endpoint is empty (defence-in-depth; CreateAuthRequest
+//     already enforces this)
+//   - client_notification_token is empty (same reason)
+//
+// On retryable failure (network error, 5xx) the dispatcher retries with
+// exponential backoff up to PingMaxRetries; the final error is recorded on
+// the row's last_notify_error column for operator debugging. Non-2xx 4xx
+// responses are treated as terminal (client misconfiguration; retrying
+// won't fix it).
+func (s *BackchannelService) dispatchPing(ctx context.Context, row *domain.BackchannelAuthRequest) {
+	if row == nil || row.NotificationMode != domain.BackchannelNotificationPing {
+		return
+	}
+	if row.ClientNotificationEndpoint == "" || row.ClientNotificationToken == "" {
+		return
+	}
+
+	s.mu.RLock()
+	client := s.pingClient
+	async := s.pingDispatchAsync
+	maxRetries := s.cfg.PingMaxRetries
+	baseDelay := s.cfg.PingBaseDelay
+	parent := s.svcCtx
+	s.mu.RUnlock()
+	if parent == nil {
+		// Stop() has been called; service is shutting down — drop the
+		// ping rather than firing into the void.
+		return
+	}
+
+	endpoint := row.ClientNotificationEndpoint
+	bearer := row.ClientNotificationToken
+	authReqID := row.AuthReqID
+
+	deliver := func() {
+		// Detach from the inbound request's ctx (so a client disconnect doesn't
+		// kill the delivery — the user has already approved) but parent on
+		// svcCtx so Server.Shutdown → Stop() cancels in-flight retries on
+		// graceful shutdown instead of letting them outlive the server.
+		dctx, cancel := context.WithTimeout(parent, s.cfg.PingTimeout*time.Duration(maxRetries+1)+baseDelay*time.Duration(maxRetries+1))
+		defer cancel()
+
+		payload, _ := json.Marshal(map[string]string{"auth_req_id": authReqID})
+
+		var lastErr error
+		for attempt := 0; attempt <= maxRetries; attempt++ {
+			if attempt > 0 {
+				// Exponential backoff with mild jitter. Jitter prevents
+				// retry storms when many requests resolve simultaneously.
+				delay := baseDelay << (attempt - 1)
+				jitter := time.Duration(jitterMillis()) * time.Millisecond
+				select {
+				case <-time.After(delay + jitter):
+				case <-dctx.Done():
+					lastErr = dctx.Err()
+					goto done
+				}
+			}
+
+			req, err := http.NewRequestWithContext(dctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+			if err != nil {
+				lastErr = err
+				goto done // non-retryable: bad URL etc.
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+bearer)
+			req.Header.Set("User-Agent", "zeroid-ciba-ping/1.0")
+
+			resp, err := client.Do(req)
+			if err != nil {
+				lastErr = err
+				continue // network error — retry
+			}
+			// Drain + close so the underlying TCP connection can be reused
+			// across retries / future requests. HTTP/1.1 keepalive requires
+			// the body to be fully read before the connection returns to the pool.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				// Clear any previous last_notify_error so operators see
+				// "succeeded after retry" rather than a stale failure.
+				_ = s.repo.SetLastNotifyError(dctx, authReqID, "")
+				return
+			}
+			lastErr = fmt.Errorf("ping callback returned HTTP %d", resp.StatusCode)
+			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+				// 4xx is terminal — client rejected the callback, retrying
+				// won't change the outcome. Examples: bad bearer, wrong path.
+				goto done
+			}
+		}
+
+	done:
+		log.Warn().
+			Err(lastErr).
+			Str("auth_req_id", authReqID).
+			Str("endpoint", endpoint).
+			Msg("CIBA ping dispatch failed")
+		if lastErr != nil {
+			if rerr := s.repo.SetLastNotifyError(dctx, authReqID, lastErr.Error()); rerr != nil {
+				log.Warn().Err(rerr).Str("auth_req_id", authReqID).Msg("failed to record ping last_notify_error")
+			}
+		}
+	}
+
+	if async {
+		go deliver()
+		return
+	}
+	deliver()
+}
+
+// jitterMillis returns a random 0–250 ms jitter value for retry backoff.
+// Sourced from crypto/rand so we don't depend on math/rand seeding.
+func jitterMillis() int {
+	var b [1]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0
+	}
+	// b[0] ∈ [0,255]; scale to roughly [0, 250].
+	return int(b[0]) * 250 / 255
 }

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -63,6 +64,9 @@ type RegisterClientRequest struct {
 	// at the handler boundary before this struct is built. Empty = plain
 	// human-session client.
 	IdentityID string
+
+	// CIBA ping/push endpoint. Must be HTTPS when non-empty; validated at registration.
+	ClientNotificationEndpoint string
 }
 
 // RegisterClient creates a new OAuth2 client.
@@ -76,6 +80,14 @@ type RegisterClientRequest struct {
 func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterClientRequest) (*domain.OAuthClient, string, error) {
 	if req.ClientID == "" || req.Name == "" {
 		return nil, "", fmt.Errorf("clientID and name are required")
+	}
+	// CIBA Core §4: client_notification_endpoint MUST be an HTTPS URL when
+	// supplied. Reject http:// / non-URL values at registration so a faulty
+	// client cannot lead the server to POST credentials over plaintext.
+	if req.ClientNotificationEndpoint != "" {
+		if err := validateNotificationEndpoint(req.ClientNotificationEndpoint); err != nil {
+			return nil, "", err
+		}
 	}
 
 	var plainSecret string
@@ -135,28 +147,29 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 
 	now := time.Now()
 	client := &domain.OAuthClient{
-		ID:                      uuid.New().String(),
-		ClientID:                req.ClientID,
-		ClientSecret:            hashedSecret,
-		Name:                    req.Name,
-		Description:             req.Description,
-		ClientType:              clientType,
-		TokenEndpointAuthMethod: authMethod,
-		GrantTypes:              grantTypes,
-		RedirectURIs:            redirectURIs,
-		Scopes:                  scopes,
-		AccessTokenTTL:          req.AccessTokenTTL,
-		RefreshTokenTTL:         req.RefreshTokenTTL,
-		JWKSURI:                 req.JWKSURI,
-		JWKS:                    req.JWKS,
-		SoftwareID:              req.SoftwareID,
-		SoftwareVersion:         req.SoftwareVersion,
-		Contacts:                contacts,
-		Metadata:                req.Metadata,
-		IdentityID:              identityID,
-		IsActive:                true,
-		CreatedAt:               now,
-		UpdatedAt:               now,
+		ID:                         uuid.New().String(),
+		ClientID:                   req.ClientID,
+		ClientSecret:               hashedSecret,
+		Name:                       req.Name,
+		Description:                req.Description,
+		ClientType:                 clientType,
+		TokenEndpointAuthMethod:    authMethod,
+		GrantTypes:                 grantTypes,
+		RedirectURIs:               redirectURIs,
+		Scopes:                     scopes,
+		AccessTokenTTL:             req.AccessTokenTTL,
+		RefreshTokenTTL:            req.RefreshTokenTTL,
+		JWKSURI:                    req.JWKSURI,
+		JWKS:                       req.JWKS,
+		SoftwareID:                 req.SoftwareID,
+		SoftwareVersion:            req.SoftwareVersion,
+		Contacts:                   contacts,
+		Metadata:                   req.Metadata,
+		IdentityID:                 identityID,
+		ClientNotificationEndpoint: req.ClientNotificationEndpoint,
+		IsActive:                   true,
+		CreatedAt:                  now,
+		UpdatedAt:                  now,
 	}
 
 	if err := s.repo.Create(ctx, client); err != nil {
@@ -269,4 +282,22 @@ func generateSecureToken(byteLen int) (string, error) {
 		return "", fmt.Errorf("failed to generate secure token: %w", err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+// validateNotificationEndpoint enforces the CIBA Core §4 rule that
+// client_notification_endpoint MUST be an absolute HTTPS URL. http:// is
+// rejected so the server can never POST the per-request bearer
+// (client_notification_token) over plaintext.
+func validateNotificationEndpoint(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid client_notification_endpoint: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("client_notification_endpoint must be https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("client_notification_endpoint must include a host")
+	}
+	return nil
 }

--- a/migrations/020_ciba_ping_columns.down.sql
+++ b/migrations/020_ciba_ping_columns.down.sql
@@ -1,0 +1,3 @@
+-- 020_ciba_ping_columns.down.sql
+ALTER TABLE backchannel_auth_requests DROP COLUMN IF EXISTS client_notification_token;
+ALTER TABLE oauth_clients DROP COLUMN IF EXISTS client_notification_endpoint;

--- a/migrations/020_ciba_ping_columns.up.sql
+++ b/migrations/020_ciba_ping_columns.up.sql
@@ -1,0 +1,22 @@
+-- 020_ciba_ping_columns.up.sql
+-- CIBA Core 1.0 ping mode adds two pieces of state:
+--
+--   1. oauth_clients.client_notification_endpoint — the registered HTTPS URL
+--      the server POSTs to when a bc-authorize request resolves. Registered
+--      at client-registration time so the URL acts as a per-client
+--      allowlist; bc-authorize requests in ping mode reuse whatever is on
+--      the client record (the client cannot supply an arbitrary endpoint
+--      per-request — that would defeat the allowlist).
+--
+--   2. backchannel_auth_requests.client_notification_token — a per-request
+--      bearer the *client* supplies on bc-authorize. The server echoes it
+--      back unchanged in the ping callback's Authorization header so the
+--      client can authenticate the inbound notification (CIBA Core §10.2).
+--      Length-capped at 1024 bytes — the spec doesn't bound it, but
+--      anything beyond that is almost certainly an injection attempt.
+
+ALTER TABLE oauth_clients
+    ADD COLUMN IF NOT EXISTS client_notification_endpoint TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE backchannel_auth_requests
+    ADD COLUMN IF NOT EXISTS client_notification_token VARCHAR(1024);

--- a/server.go
+++ b/server.go
@@ -541,6 +541,25 @@ func (s *Server) SetAttestationPermissive(enabled bool) {
 	s.attestationSvc.SetPermissive(enabled)
 }
 
+// SetBackchannelPingTransport overrides the outbound HTTP RoundTripper used
+// for CIBA ping callbacks. Tests inject a capturing RoundTripper here so
+// they can assert on the outbound request without standing up a real
+// httptest listener. Pass nil to restore the default transport.
+func (s *Server) SetBackchannelPingTransport(rt http.RoundTripper) {
+	if s.backchannelSvc == nil {
+		return
+	}
+	s.backchannelSvc.SetPingTransport(rt)
+}
+
+// SetBackchannelPingDispatchSync forces synchronous ping dispatch — test-only.
+func (s *Server) SetBackchannelPingDispatchSync(sync bool) {
+	if s.backchannelSvc == nil {
+		return
+	}
+	s.backchannelSvc.SetPingDispatchSync(sync)
+}
+
 // SetTrustedServiceValidator sets the validator used during external principal
 // token exchange (RFC 8693) to verify the caller is a trusted internal service.
 // The validator reads from context (populated by deployer-provided global middleware
@@ -594,22 +613,23 @@ func (s *Server) EnsureClient(ctx context.Context, cfg OAuthClientConfig) error 
 	if err != nil {
 		// Client doesn't exist — create it.
 		_, _, regErr := s.oauthClientSvc.RegisterClient(ctx, service.RegisterClientRequest{
-			ClientID:                cfg.ClientID,
-			Name:                    cfg.Name,
-			Description:             cfg.Description,
-			Confidential:            cfg.Confidential,
-			TokenEndpointAuthMethod: cfg.TokenEndpointAuthMethod,
-			GrantTypes:              cfg.GrantTypes,
-			Scopes:                  cfg.Scopes,
-			RedirectURIs:            cfg.RedirectURIs,
-			AccessTokenTTL:          cfg.AccessTokenTTL,
-			RefreshTokenTTL:         cfg.RefreshTokenTTL,
-			JWKSURI:                 cfg.JWKSURI,
-			JWKS:                    cfg.JWKS,
-			SoftwareID:              cfg.SoftwareID,
-			SoftwareVersion:         cfg.SoftwareVersion,
-			Contacts:                cfg.Contacts,
-			Metadata:                cfg.Metadata,
+			ClientID:                   cfg.ClientID,
+			Name:                       cfg.Name,
+			Description:                cfg.Description,
+			Confidential:               cfg.Confidential,
+			TokenEndpointAuthMethod:    cfg.TokenEndpointAuthMethod,
+			GrantTypes:                 cfg.GrantTypes,
+			Scopes:                     cfg.Scopes,
+			RedirectURIs:               cfg.RedirectURIs,
+			AccessTokenTTL:             cfg.AccessTokenTTL,
+			RefreshTokenTTL:            cfg.RefreshTokenTTL,
+			JWKSURI:                    cfg.JWKSURI,
+			JWKS:                       cfg.JWKS,
+			SoftwareID:                 cfg.SoftwareID,
+			SoftwareVersion:            cfg.SoftwareVersion,
+			Contacts:                   cfg.Contacts,
+			Metadata:                   cfg.Metadata,
+			ClientNotificationEndpoint: cfg.ClientNotificationEndpoint,
 		})
 
 		return regErr
@@ -645,6 +665,10 @@ func (s *Server) EnsureClient(ctx context.Context, cfg OAuthClientConfig) error 
 	}
 	if cfg.RefreshTokenTTL > 0 && cfg.RefreshTokenTTL != existing.RefreshTokenTTL {
 		existing.RefreshTokenTTL = cfg.RefreshTokenTTL
+		updated = true
+	}
+	if cfg.ClientNotificationEndpoint != "" && cfg.ClientNotificationEndpoint != existing.ClientNotificationEndpoint {
+		existing.ClientNotificationEndpoint = cfg.ClientNotificationEndpoint
 		updated = true
 	}
 

--- a/tests/integration/ciba_ping_test.go
+++ b/tests/integration/ciba_ping_test.go
@@ -1,0 +1,198 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	zeroid "github.com/highflame-ai/zeroid"
+)
+
+// TestCIBA_PingMode_HappyPath exercises the OpenID CIBA Core §10.2 ping
+// callback end-to-end:
+//
+//  1. Register a client with a registered client_notification_endpoint (HTTPS).
+//  2. Client posts bc-authorize *with* client_notification_token.
+//  3. Admin approves.
+//  4. Server fires an outbound POST to client_notification_endpoint carrying
+//     Authorization: Bearer <client_notification_token> and a body of
+//     {"auth_req_id": "..."}.
+//  5. Client polls /oauth2/token and receives the access token.
+//
+// The outbound POST is captured via a RoundTripper override installed on
+// Server.SetBackchannelPingTransport — no real httptest listener is needed.
+// Ping dispatch is forced synchronous so the test can assert deterministically.
+func TestCIBA_PingMode_HappyPath(t *testing.T) {
+	clientID := uid("ciba-ping-client")
+	const pingEndpoint = "https://ping.example.test/callback"
+
+	// Register the client *with* the notification endpoint — without it,
+	// bc-authorize must reject ping mode (defence-in-depth check below).
+	require.NoError(t, testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:                   clientID,
+		Name:                       clientID + "-ping",
+		GrantTypes:                 []string{"client_credentials"},
+		RedirectURIs:               []string{testRedirectURI},
+		ClientNotificationEndpoint: pingEndpoint,
+	}))
+
+	capt := newCapturingRoundTripper()
+	testZeroIDServer.SetBackchannelPingTransport(capt)
+	testZeroIDServer.SetBackchannelPingDispatchSync(true)
+	t.Cleanup(func() {
+		testZeroIDServer.SetBackchannelPingDispatchSync(false)
+		testZeroIDServer.SetBackchannelPingTransport(nil)
+	})
+
+	const notificationToken = "ping-bearer-from-client-xyz"
+
+	// ── bc-authorize with ping ──────────────────────────────────────────────
+	bcResp := post(t, "/oauth2/bc-authorize", map[string]any{
+		"client_id":                 clientID,
+		"account_id":                testAccountID,
+		"project_id":                testProjectID,
+		"login_hint":                "bob@example.com",
+		"scope":                     "openid",
+		"client_notification_token": notificationToken,
+	}, nil)
+	require.Equal(t, http.StatusOK, bcResp.StatusCode)
+	bcBody := decode(t, bcResp)
+	authReqID, _ := bcBody["auth_req_id"].(string)
+	require.NotEmpty(t, authReqID)
+
+	// No ping yet — the row is still pending.
+	require.Empty(t, capt.requests(), "ping must not fire before approval")
+
+	// ── Approve ─────────────────────────────────────────────────────────────
+	approveResp := post(t,
+		adminPath("/oauth2/bc-authorize/"+authReqID+"/approve"),
+		map[string]any{"subject_id": "user-bob-001", "subject_email": "bob@example.com"},
+		adminHeaders(),
+	)
+	require.Equal(t, http.StatusOK, approveResp.StatusCode)
+	_ = decode(t, approveResp)
+
+	// ── Ping fired ──────────────────────────────────────────────────────────
+	captured := capt.requests()
+	require.Len(t, captured, 1, "approve must fire exactly one ping")
+	pingReq := captured[0]
+	require.Equal(t, http.MethodPost, pingReq.Method)
+	require.Equal(t, pingEndpoint, pingReq.URL)
+	require.Equal(t, "Bearer "+notificationToken, pingReq.Headers.Get("Authorization"))
+	require.Equal(t, "application/json", pingReq.Headers.Get("Content-Type"))
+
+	var pingPayload map[string]string
+	require.NoError(t, json.Unmarshal([]byte(pingReq.Body), &pingPayload))
+	require.Equal(t, authReqID, pingPayload["auth_req_id"], "ping body must echo auth_req_id")
+	require.NotContains(t, pingPayload, "access_token", "ping callback must NOT include the token (that's push mode, PR 3)")
+
+	// ── Poll → token ────────────────────────────────────────────────────────
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":  "urn:openid:params:grant-type:ciba",
+		"auth_req_id": authReqID,
+		"client_id":   clientID,
+	}, nil)
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+	require.NotEmpty(t, decode(t, tokenResp)["access_token"])
+}
+
+// TestCIBA_PingMode_RequiresRegisteredEndpoint guards the allowlist invariant:
+// a client that supplies client_notification_token but has NO registered
+// client_notification_endpoint must be rejected at bc-authorize. This is the
+// allowlist's whole point — a compromised client_notification_token cannot
+// redirect the server's outbound POSTs.
+func TestCIBA_PingMode_RequiresRegisteredEndpoint(t *testing.T) {
+	clientID := uid("ciba-ping-noendpoint")
+	registerTestOAuthClient(clientID, []string{"client_credentials"}) // no notification endpoint
+
+	resp := post(t, "/oauth2/bc-authorize", map[string]any{
+		"client_id":                 clientID,
+		"account_id":                testAccountID,
+		"project_id":                testProjectID,
+		"login_hint":                "carol@example.com",
+		"client_notification_token": "any-token",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	require.Equal(t, "invalid_request", body["error"])
+	require.Contains(t, body["error_description"], "client_notification_endpoint",
+		"error must point at the missing registration field")
+}
+
+// TestCIBA_RegisterClient_RejectsHTTPNotificationEndpoint guards CIBA Core §4:
+// HTTPS-only. A plain http:// endpoint must be rejected at client registration
+// so the server can never POST credentials over plaintext.
+func TestCIBA_RegisterClient_RejectsHTTPNotificationEndpoint(t *testing.T) {
+	err := testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:                   uid("ciba-http-bad"),
+		Name:                       "ciba-http-bad",
+		GrantTypes:                 []string{"client_credentials"},
+		ClientNotificationEndpoint: "http://insecure.example.test/cb",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "https", "rejection message must explain the scheme requirement")
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+// capturedRequest is a minimal record of an outbound HTTP request — just the
+// pieces the test needs to assert on. Avoids holding live *http.Request
+// pointers (whose Body is single-read).
+type capturedRequest struct {
+	Method  string
+	URL     string
+	Headers http.Header
+	Body    string
+}
+
+// capturingRoundTripper records every request it sees and returns 204 No
+// Content so the dispatcher's success path runs.
+type capturingRoundTripper struct {
+	mu       sync.Mutex
+	captured []capturedRequest
+	// failOnce, when set, makes the first call return an error so tests can
+	// exercise the retry path. PR 2 leaves this unused; reserved for a
+	// follow-up retry test if reviewers want one.
+	failOnce error
+}
+
+func newCapturingRoundTripper() *capturingRoundTripper { return &capturingRoundTripper{} }
+
+func (c *capturingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bodyBytes, _ := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	c.captured = append(c.captured, capturedRequest{
+		Method:  req.Method,
+		URL:     req.URL.String(),
+		Headers: req.Header.Clone(),
+		Body:    string(bodyBytes),
+	})
+	if c.failOnce != nil {
+		err := c.failOnce
+		c.failOnce = nil
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: http.StatusNoContent,
+		Status:     "204 No Content",
+		Body:       io.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func (c *capturingRoundTripper) requests() []capturedRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]capturedRequest, len(c.captured))
+	copy(out, c.captured)
+	return out
+}


### PR DESCRIPTION
## Summary

OpenID CIBA Core 1.0 §10.2 — **ping mode**. Second of three sequential dependent PRs that close issue #64.

> **⚠ This PR is stacked on #131 (PR 1).** It contains the PR 1 commit (`f00b692`) AND the PR 2 commit (`495f8c6`). **Do not merge this PR until #131 has merged.** Once #131 merges, the diff here will narrow to the PR 2 commit only — review will be straightforward at that point.
>
> **Merge order:** PR 1 (#131) → **PR 2 (this)** → PR 3.

Sibling discussion: https://github.com/highflame-ai/zeroid/issues/64#issuecomment-4418095786

## What changes vs PR 1

PR 1 shipped polling-mode CIBA end-to-end. PR 2 adds the **server-initiated callback** that lets clients skip the poll-loop:

1. Client registers with `client_notification_endpoint` (HTTPS) — the **per-client allowlist** for outbound POSTs.
2. Client posts `bc-authorize` with `client_notification_token` (the bearer the server will echo).
3. When the request transitions `pending → approved` (or `pending → denied`), the server POSTs `{auth_req_id}` to the registered endpoint with `Authorization: Bearer <client_notification_token>`.
4. Client then polls `/oauth2/token` and receives the access token (the token is NOT included in the ping — that's push mode, PR 3).

## Files added in PR 2 (review focus)

### Schema
- `migrations/015_ciba_ping_columns.{up,down}.sql`
  - `oauth_clients.client_notification_endpoint TEXT` — registered HTTPS allowlist
  - `backchannel_auth_requests.client_notification_token VARCHAR(1024)` — per-request bearer

### Domain / service
- `domain/token.go`: `OAuthClient.ClientNotificationEndpoint`
- `domain/backchannel_auth.go`: `BackchannelAuthRequest.ClientNotificationToken` (\`json:\"-\"\` — never serialised)
- `internal/service/oauth_client.go`: `validateNotificationEndpoint(...)` — HTTPS-only at registration
- `internal/service/backchannel.go`:
  - bc-authorize: switches to `ping` mode when `client_notification_token` is supplied AND the client has a registered HTTPS endpoint
  - `dispatchPing(ctx, row)` fires on Approve/Deny — bounded retry with exponential backoff + jitter, 4xx terminal, 5xx retried, records `last_notify_error`
  - `SetPingTransport(rt)`, `SetPingDispatchSync(bool)` — test-only

### Surface (Server)
- `Server.SetBackchannelPingTransport(http.RoundTripper)` — inject a capturing transport in tests
- `Server.SetBackchannelPingDispatchSync(bool)` — force synchronous dispatch in tests
- `OAuthClientConfig.ClientNotificationEndpoint` — pluggable via `EnsureClient`

### Tests (`tests/integration/ciba_ping_test.go`)
- **Happy path**: capturing RoundTripper asserts on URL, bearer, JSON body. Token does NOT contain `access_token` (push-mode guard).
- **Allowlist invariant**: `client_notification_token` without a registered `client_notification_endpoint` → 400 `invalid_request`.
- **HTTPS-only**: `http://` registration endpoint rejected at `EnsureClient`/`RegisterClient`.

## Security notes

- **Allowlist via registration**: per-request endpoints would defeat the allowlist; a leaked `client_notification_token` cannot redirect the outbound POST.
- **HTTPS at both layers**: validated at registration AND re-validated at request-time so a future bypass in one path doesn't silently degrade callbacks to plaintext.
- **Non-blocking dispatch**: `dispatchPing` runs in a goroutine with `context.WithTimeout` detached from the inbound request — caller cancellation can't kill an in-flight notification.
- **4xx terminal / 5xx retried**: client misconfiguration (bad bearer, wrong path) isn't retried; transient infrastructure faults are.
- **Token never persisted in JSON output**: `client_notification_token` carries \`json:\"-\"\` so list/get endpoints never echo it back.

## Issue #64 checklist delta vs PR 1

| Item | PR 1 | PR 2 |
|---|---|---|
| Ping mode | ⏳ | ✅ |
| Per-client URL allowlist | ⏳ | ✅ |
| Server retries on transient failure | ⏳ | ✅ |
| `client_notification_token` | ⏳ | ✅ |

## Test Plan

- [x] Build + vet clean (`go vet ./...`, `gofmt -l`)
- [x] New tests added — happy path, allowlist invariant, HTTPS-only registration
- [ ] CI runs the new tests (after #131 merges)
- [ ] Manual smoke after PR 1 + PR 2 land: register client with notification endpoint → bc-authorize with token → approve → observe ping → poll for access_token