### PR TITLE
feat: CIBA push mode (PR 3/3 for #64) — stacked on #131, #132

### DIFF
--- a/domain/backchannel_auth.go
+++ b/domain/backchannel_auth.go
@@ -23,16 +23,31 @@ const (
 )
 
 // BackchannelNotificationMode is how the server informs the client that the
-// request has been resolved. PR 1 only implements "poll".
+// request has been resolved.
 type BackchannelNotificationMode string
 
 const (
 	// BackchannelNotificationPoll — client polls /oauth2/token with the auth_req_id.
 	BackchannelNotificationPoll BackchannelNotificationMode = "poll"
 	// BackchannelNotificationPing — server POSTs to client_notification_endpoint when the
-	// status transitions to approved/denied; client then polls. Implemented in PR 2.
+	// status transitions to approved/denied; client then polls.
 	BackchannelNotificationPing BackchannelNotificationMode = "ping"
+	// BackchannelNotificationPush — server POSTs the full token response to
+	// client_notification_endpoint on approval (or the OAuth error body on
+	// denial); the client never polls. Implemented in PR 3.
+	BackchannelNotificationPush BackchannelNotificationMode = "push"
 )
+
+// IsValidBackchannelDeliveryMode reports whether the given string is a
+// recognised CIBA delivery mode. Empty is treated as the implicit default
+// ("poll") and accepted.
+func IsValidBackchannelDeliveryMode(mode string) bool {
+	switch BackchannelNotificationMode(mode) {
+	case "", BackchannelNotificationPoll, BackchannelNotificationPing, BackchannelNotificationPush:
+		return true
+	}
+	return false
+}
 
 // GrantTypeCIBA is the OpenID CIBA Core 1.0 grant type identifier (§10.1).
 // Clients submit this at /oauth2/token along with auth_req_id to poll for a token.

--- a/domain/token.go
+++ b/domain/token.go
@@ -87,8 +87,14 @@ type OAuthClient struct {
 
 	// CIBA Core 1.0 — ping/push notification endpoint. Registered HTTPS URL
 	// the server POSTs to when a backchannel authentication request resolves.
-	// Empty when the client doesn't support ping mode (polling-only).
+	// Empty when the client doesn't support ping/push mode (polling-only).
 	ClientNotificationEndpoint string `bun:"client_notification_endpoint" json:"client_notification_endpoint,omitempty"`
+
+	// CIBA Core 1.0 §10 — declared token delivery mode for this client.
+	// "poll" (default), "ping", or "push". Determines how a CIBA-issued
+	// token reaches the client: by polling /oauth2/token, by ping callback +
+	// poll, or by push callback (token delivered directly).
+	BackchannelTokenDeliveryMode string `bun:"backchannel_token_delivery_mode" json:"backchannel_token_delivery_mode,omitempty"`
 
 	// Token lifetime (per-client, 0 = use server default)
 	AccessTokenTTL  int `bun:"access_token_ttl"  json:"access_token_ttl,omitempty"`

--- a/hooks.go
+++ b/hooks.go
@@ -63,6 +63,10 @@ type OAuthClientConfig struct {
 	// ClientNotificationEndpoint is the HTTPS callback CIBA ping mode posts to.
 	// Empty for clients that only use polling mode.
 	ClientNotificationEndpoint string
+	// BackchannelTokenDeliveryMode declares which CIBA delivery mode the client
+	// supports: "poll" (default), "ping", or "push". ping/push require a
+	// non-empty ClientNotificationEndpoint.
+	BackchannelTokenDeliveryMode string
 }
 
 // TrustedServiceValidator checks whether the current request comes from a trusted

--- a/internal/handler/oauth_client.go
+++ b/internal/handler/oauth_client.go
@@ -59,7 +59,10 @@ type CreateOAuthClientInput struct {
 
 		// CIBA (OpenID CIBA Core 1.0) — registered callback for ping/push notifications.
 		// Must be HTTPS. Empty when the client only uses polling mode.
-		ClientNotificationEndpoint string `json:"client_notification_endpoint,omitempty" doc:"HTTPS callback URL for CIBA ping mode"`
+		ClientNotificationEndpoint string `json:"client_notification_endpoint,omitempty" doc:"HTTPS callback URL for CIBA ping/push mode"`
+		// CIBA token delivery mode: poll (default), ping, or push. ping/push
+		// require client_notification_endpoint.
+		BackchannelTokenDeliveryMode string `json:"backchannel_token_delivery_mode,omitempty" enum:"poll,ping,push" doc:"CIBA token delivery mode"`
 	}
 }
 
@@ -163,24 +166,25 @@ func (a *API) createOAuthClientOp(ctx context.Context, input *CreateOAuthClientI
 	}
 
 	client, plainSecret, err := a.oauthClientSvc.RegisterClient(ctx, service.RegisterClientRequest{
-		ClientID:                   input.Body.ClientID,
-		Name:                       input.Body.Name,
-		Description:                input.Body.Description,
-		Confidential:               input.Body.Confidential,
-		TokenEndpointAuthMethod:    input.Body.TokenEndpointAuthMethod,
-		GrantTypes:                 input.Body.GrantTypes,
-		Scopes:                     input.Body.Scopes,
-		RedirectURIs:               input.Body.RedirectURIs,
-		AccessTokenTTL:             input.Body.AccessTokenTTL,
-		RefreshTokenTTL:            input.Body.RefreshTokenTTL,
-		JWKSURI:                    input.Body.JWKSURI,
-		JWKS:                       input.Body.JWKS,
-		SoftwareID:                 input.Body.SoftwareID,
-		SoftwareVersion:            input.Body.SoftwareVersion,
-		Contacts:                   input.Body.Contacts,
-		Metadata:                   input.Body.Metadata,
-		IdentityID:                 input.Body.IdentityID,
-		ClientNotificationEndpoint: input.Body.ClientNotificationEndpoint,
+		ClientID:                     input.Body.ClientID,
+		Name:                         input.Body.Name,
+		Description:                  input.Body.Description,
+		Confidential:                 input.Body.Confidential,
+		TokenEndpointAuthMethod:      input.Body.TokenEndpointAuthMethod,
+		GrantTypes:                   input.Body.GrantTypes,
+		Scopes:                       input.Body.Scopes,
+		RedirectURIs:                 input.Body.RedirectURIs,
+		AccessTokenTTL:               input.Body.AccessTokenTTL,
+		RefreshTokenTTL:              input.Body.RefreshTokenTTL,
+		JWKSURI:                      input.Body.JWKSURI,
+		JWKS:                         input.Body.JWKS,
+		SoftwareID:                   input.Body.SoftwareID,
+		SoftwareVersion:              input.Body.SoftwareVersion,
+		Contacts:                     input.Body.Contacts,
+		Metadata:                     input.Body.Metadata,
+		IdentityID:                   input.Body.IdentityID,
+		ClientNotificationEndpoint:   input.Body.ClientNotificationEndpoint,
+		BackchannelTokenDeliveryMode: input.Body.BackchannelTokenDeliveryMode,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrOAuthClientAlreadyExists) {

--- a/internal/handler/wellknown.go
+++ b/internal/handler/wellknown.go
@@ -52,11 +52,24 @@ func (a *API) oauthMetadataOp(_ context.Context, _ *struct{}) (*OAuthMetadataOut
 			"urn:ietf:params:oauth:grant-type:jwt-bearer",
 			"urn:ietf:params:oauth:grant-type:token-exchange",
 			"api_key",
+			"urn:openid:params:grant-type:ciba",
 		},
 		"jwks_uri":                 a.baseURL + "/.well-known/jwks.json",
 		"introspection_endpoint":   a.baseURL + "/oauth2/token/introspect",
 		"revocation_endpoint":      a.baseURL + "/oauth2/token/revoke",
 		"response_types_supported": []string{"token"},
 		"token_endpoint_auth_signing_alg_values_supported": []string{"ES256", "RS256"},
+
+		// CIBA (OpenID CIBA Core 1.0) discovery metadata. The fields here
+		// let CIBA-aware clients auto-discover that this AS supports
+		// backchannel authentication and which delivery modes are wired.
+		"backchannel_authentication_endpoint":         a.baseURL + "/oauth2/bc-authorize",
+		"backchannel_token_delivery_modes_supported":  []string{"poll", "ping", "push"},
+		"backchannel_user_code_parameter_supported":   false,
+		// We don't accept signed bc-authorize requests in v1 — clients
+		// authenticate via standard client_secret_basic/post against the
+		// backchannel endpoint. An empty array signals "no signing algs
+		// supported" per the spec's MAY clause.
+		"backchannel_authentication_request_signing_alg_values_supported": []string{},
 	}}, nil
 }

--- a/internal/handler/wellknown.go
+++ b/internal/handler/wellknown.go
@@ -63,9 +63,9 @@ func (a *API) oauthMetadataOp(_ context.Context, _ *struct{}) (*OAuthMetadataOut
 		// CIBA (OpenID CIBA Core 1.0) discovery metadata. The fields here
 		// let CIBA-aware clients auto-discover that this AS supports
 		// backchannel authentication and which delivery modes are wired.
-		"backchannel_authentication_endpoint":         a.baseURL + "/oauth2/bc-authorize",
-		"backchannel_token_delivery_modes_supported":  []string{"poll", "ping", "push"},
-		"backchannel_user_code_parameter_supported":   false,
+		"backchannel_authentication_endpoint":        a.baseURL + "/oauth2/bc-authorize",
+		"backchannel_token_delivery_modes_supported": []string{"poll", "ping", "push"},
+		"backchannel_user_code_parameter_supported":  false,
 		// We don't accept signed bc-authorize requests in v1 — clients
 		// authenticate via standard client_secret_basic/post against the
 		// backchannel endpoint. An empty array signals "no signing algs

--- a/internal/service/backchannel.go
+++ b/internal/service/backchannel.go
@@ -258,26 +258,39 @@ func (s *BackchannelService) CreateAuthRequest(ctx context.Context, in CreateAut
 		return nil, oauthBadRequestCause("invalid_client", fmt.Sprintf("unknown client %s", in.ClientID), err)
 	}
 
-	// Ping mode: when the client supplies a client_notification_token, the
-	// client MUST have a registered client_notification_endpoint on its
-	// record. The endpoint is the per-client allowlist — we never accept a
-	// per-request URL because that would let a compromised token redirect
-	// notifications.
+	// Determine notification mode. CIBA Core §10 makes the delivery mode a
+	// property of the client registration, not the per-request — so we read
+	// the row off the client and let the per-request client_notification_token
+	// presence act only as a gate (ping/push without a bearer the server can
+	// echo isn't useful).
+	declared := domain.BackchannelNotificationMode(client.BackchannelTokenDeliveryMode)
+	if declared == "" {
+		declared = domain.BackchannelNotificationPoll
+	}
 	notificationMode := domain.BackchannelNotificationPoll
 	notificationEndpoint := ""
-	if in.ClientNotificationToken != "" {
+	switch declared {
+	case domain.BackchannelNotificationPing, domain.BackchannelNotificationPush:
+		if in.ClientNotificationToken == "" {
+			return nil, oauthBadRequest("invalid_request",
+				fmt.Sprintf("backchannel_token_delivery_mode=%s requires client_notification_token on bc-authorize", declared))
+		}
 		if client.ClientNotificationEndpoint == "" {
 			return nil, oauthBadRequest("invalid_request",
 				"client_notification_token requires the client to have a registered client_notification_endpoint")
 		}
 		// Defence-in-depth: re-validate the registered endpoint is HTTPS even
 		// though RegisterClient already enforced it. A future bypass at
-		// registration must not silently degrade ping mode to http.
+		// registration must not silently degrade callbacks to plaintext.
 		if err := validateNotificationEndpoint(client.ClientNotificationEndpoint); err != nil {
 			return nil, oauthBadRequestCause("invalid_request", "client_notification_endpoint is invalid", err)
 		}
-		notificationMode = domain.BackchannelNotificationPing
+		notificationMode = declared
 		notificationEndpoint = client.ClientNotificationEndpoint
+	default:
+		// Poll mode. If the client passed a notification_token despite being
+		// poll-mode, accept it but ignore — clients shouldn't conditionally
+		// branch and we'd rather degrade gracefully than reject.
 	}
 
 	// Reject oversized binding_message rather than silently truncating.
@@ -384,11 +397,14 @@ func (s *BackchannelService) Approve(ctx context.Context, in ApproveInput) error
 		// Lost a race against expiry sweep or a concurrent deny.
 		return oauthBadRequest("access_denied", "request could not be approved (concurrent modification or expiry)")
 	}
-	// Ping mode: notify the client that the request resolved. The client
-	// then polls /oauth2/token to receive the access token. We do this
-	// after the row transition so a successful ping always reflects a
-	// successful state change.
-	s.dispatchPing(ctx, row)
+	// Re-load so callbacks see the persisted approved_subject_* fields and
+	// the updated status. Ping/push dispatchers consume these.
+	persisted, err := s.repo.GetByAuthReqID(ctx, in.AuthReqID)
+	if err == nil {
+		s.dispatchResolution(ctx, persisted, resolutionApproved)
+	} else {
+		log.Warn().Err(err).Str("auth_req_id", in.AuthReqID).Msg("approved row reload failed; dispatch skipped")
+	}
 	return nil
 }
 
@@ -424,8 +440,49 @@ func (s *BackchannelService) Deny(ctx context.Context, in DenyInput) error {
 	if affected == 0 {
 		return oauthBadRequest("access_denied", "request could not be denied (concurrent modification or expiry)")
 	}
-	s.dispatchPing(ctx, row)
+	persisted, err := s.repo.GetByAuthReqID(ctx, in.AuthReqID)
+	if err == nil {
+		s.dispatchResolution(ctx, persisted, resolutionDenied)
+	} else {
+		log.Warn().Err(err).Str("auth_req_id", in.AuthReqID).Msg("denied row reload failed; dispatch skipped")
+	}
 	return nil
+}
+
+// resolutionOutcome is the post-transition state used by dispatchResolution
+// to select the right ping/push payload.
+type resolutionOutcome int
+
+const (
+	resolutionApproved resolutionOutcome = iota
+	resolutionDenied
+)
+
+// dispatchResolution selects the right callback path for the row's
+// notification mode and the outcome (approved/denied):
+//
+//	mode=poll  → no callback; client must poll
+//	mode=ping  → POST {auth_req_id} to client_notification_endpoint
+//	mode=push  → on approved, mint the access token and POST the full
+//	             token response; on denied, POST the OAuth error body.
+//
+// Push-mode minting happens HERE rather than inside Redeem so that the
+// token is delivered exactly once — either via push or, for ping/poll,
+// via a subsequent /oauth2/token call. Redeem refuses push-mode rows.
+func (s *BackchannelService) dispatchResolution(ctx context.Context, row *domain.BackchannelAuthRequest, outcome resolutionOutcome) {
+	if row == nil {
+		return
+	}
+	switch row.NotificationMode {
+	case domain.BackchannelNotificationPing:
+		s.dispatchPing(ctx, row)
+	case domain.BackchannelNotificationPush:
+		if outcome == resolutionApproved {
+			s.dispatchPushApproval(ctx, row)
+		} else {
+			s.dispatchPushDenial(ctx, row)
+		}
+	}
 }
 
 // RedeemInput is the polling-side input the CIBA grant handler hands over.
@@ -451,6 +508,13 @@ func (s *BackchannelService) Redeem(ctx context.Context, in RedeemInput) (*domai
 	if in.ClientID != "" && row.ClientID != in.ClientID {
 		// Mismatch means a different client is polling — refuse without leaking detail.
 		return nil, oauthBadRequest("invalid_grant", "auth_req_id was not issued to this client")
+	}
+
+	// Push mode never permits polling — the token is delivered via the
+	// callback exactly once. Allowing both would double-deliver and break
+	// single-use semantics.
+	if row.NotificationMode == domain.BackchannelNotificationPush {
+		return nil, oauthBadRequest("access_denied", "auth_req_id is delivered via push callback; polling is not permitted")
 	}
 
 	now := time.Now()
@@ -483,67 +547,78 @@ func (s *BackchannelService) Redeem(ctx context.Context, in RedeemInput) (*domai
 		return nil, oauthBadRequest("access_denied", "auth_req_id has already been redeemed")
 
 	case domain.BackchannelStatusApproved:
-		// Claim-first: flip approved → issued BEFORE minting the token so
-		// only one polling thread can ever reach IssueCredential. The
-		// conditional UPDATE in MarkIssued (status='approved' guard) is the
-		// at-most-once invariant; a concurrent caller gets affected=0 and
-		// is rejected with access_denied. This matches the CIBA Core
-		// "auth_req_id is single-use" requirement and prevents the
-		// previously-documented double-mint window.
-		//
-		// Trade-off: if IssueCredential fails after the row has been
-		// flipped to "issued", the user is locked out of retrying this
-		// auth_req_id and must initiate a new bc-authorize. That's
-		// preferable to silently minting two tokens — the failure is
-		// loud (HTTP 500) and the client's retry-with-new-auth-req-id
-		// path handles it cleanly.
-		affected, mErr := s.repo.MarkIssued(ctx, in.AuthReqID)
-		if mErr != nil {
-			return nil, oauthServerError("failed to mark backchannel request issued", mErr)
-		}
-		if affected == 0 {
-			return nil, oauthBadRequest("access_denied", "auth_req_id has already been redeemed")
-		}
-
-		// Synthesise an identity for the approved user. CIBA Core §10.1.2
-		// requires the issued token to identify the user; we mirror the
-		// pattern used by ExternalPrincipalExchange (the human-token path).
-		identity := &domain.Identity{
-			AccountID:    row.AccountID,
-			ProjectID:    row.ProjectID,
-			IdentityType: domain.IdentityTypeService,
-			Status:       domain.IdentityStatusActive,
-		}
-		customClaims := map[string]any{
-			"token_exchange":        "ciba",
-			"backchannel_client_id": row.ClientID,
-		}
-		if row.BindingMessage != "" {
-			customClaims["binding_message"] = row.BindingMessage
-		}
-
-		accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-			Identity:        identity,
-			Scopes:          parseScopeString(row.Scope),
-			GrantType:       domain.GrantTypeCIBA,
-			TTL:             900, // 15 minutes — short-lived; matches ExternalPrincipalExchange
-			UseRS256:        true,
-			SubjectOverride: row.ApprovedSubjectID,
-			UserEmail:       row.ApprovedSubjectEmail,
-			UserName:        row.ApprovedSubjectName,
-			CustomClaims:    customClaims,
-		})
-		if err != nil {
-			return nil, oauthServerError("failed to issue CIBA-grant token", err)
-		}
-
-		accessToken.AccountID = row.AccountID
-		accessToken.ProjectID = row.ProjectID
-		return accessToken, nil
+		return s.issueTokenForApprovedRow(ctx, row)
 
 	default:
 		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("unexpected request status %q", row.Status))
 	}
+}
+
+// issueTokenForApprovedRow mints the CIBA access token for an approved row
+// and atomically flips the row to status='issued'. Shared between Redeem
+// (poll/ping modes — client pulls via /oauth2/token) and dispatchPushApproval
+// (push mode — server delivers via callback).
+//
+// Caller MUST hold the invariant that row.Status == approved. The MarkIssued
+// guard provides the actual at-most-once gate; on a lost race the second
+// caller gets affected=0 and an *OAuthError signalling the duplication.
+func (s *BackchannelService) issueTokenForApprovedRow(ctx context.Context, row *domain.BackchannelAuthRequest) (*domain.AccessToken, error) {
+	// Claim-first: flip approved → issued BEFORE minting the token so only
+	// one caller can ever reach IssueCredential. The conditional UPDATE in
+	// MarkIssued (status='approved' guard) is the at-most-once invariant;
+	// a concurrent caller gets affected=0 and is rejected with access_denied.
+	// This matches the CIBA Core "auth_req_id is single-use" requirement
+	// and prevents the double-mint window that mint-first would expose.
+	//
+	// Trade-off: if IssueCredential fails after the row has been flipped to
+	// "issued", the user is locked out of retrying this auth_req_id and must
+	// initiate a new bc-authorize. That's preferable to silently minting two
+	// tokens — the failure is loud (HTTP 500) and the client's
+	// retry-with-new-auth-req-id path handles it cleanly.
+	affected, mErr := s.repo.MarkIssued(ctx, row.AuthReqID)
+	if mErr != nil {
+		log.Error().Err(mErr).Str("auth_req_id", row.AuthReqID).Msg("failed to mark backchannel request issued")
+		return nil, oauthServerError("failed to commit issuance state", mErr)
+	}
+	if affected == 0 {
+		return nil, oauthBadRequest("access_denied", "auth_req_id has already been redeemed")
+	}
+
+	// Synthesise an identity for the approved user. CIBA Core §10.1.2 requires
+	// the issued token to identify the user; we mirror ExternalPrincipalExchange
+	// (the human-token path).
+	identity := &domain.Identity{
+		AccountID:    row.AccountID,
+		ProjectID:    row.ProjectID,
+		IdentityType: domain.IdentityTypeService,
+		Status:       domain.IdentityStatusActive,
+	}
+	customClaims := map[string]any{
+		"token_exchange":        "ciba",
+		"backchannel_client_id": row.ClientID,
+	}
+	if row.BindingMessage != "" {
+		customClaims["binding_message"] = row.BindingMessage
+	}
+
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+		Identity:        identity,
+		Scopes:          parseScopeString(row.Scope),
+		GrantType:       domain.GrantTypeCIBA,
+		TTL:             900, // 15 minutes — short-lived; matches ExternalPrincipalExchange
+		UseRS256:        true,
+		SubjectOverride: row.ApprovedSubjectID,
+		UserEmail:       row.ApprovedSubjectEmail,
+		UserName:        row.ApprovedSubjectName,
+		CustomClaims:    customClaims,
+	})
+	if err != nil {
+		return nil, oauthServerError("failed to issue CIBA-grant token", err)
+	}
+
+	accessToken.AccountID = row.AccountID
+	accessToken.ProjectID = row.ProjectID
+	return accessToken, nil
 }
 
 // SweepExpired and DeleteExpired are wired by the cleanup worker; surfaced
@@ -604,6 +679,181 @@ func (s *BackchannelService) dispatchNotifier(ctx context.Context, row *domain.B
 			log.Warn().Err(err).Str("auth_req_id", row.AuthReqID).Msg("backchannel notifier returned error")
 			if rerr := s.repo.SetLastNotifyError(dctx, row.AuthReqID, err.Error()); rerr != nil {
 				log.Warn().Err(rerr).Str("auth_req_id", row.AuthReqID).Msg("failed to record last_notify_error")
+			}
+		}
+	}
+
+	if async {
+		go deliver()
+		return
+	}
+	deliver()
+}
+
+// dispatchPushApproval mints the access token for an approved push-mode
+// request and POSTs the full token-endpoint response (CIBA Core §10.3.1)
+// to the client's registered notification endpoint. The bearer header carries
+// the per-request client_notification_token so the client can authenticate
+// the inbound delivery.
+//
+// At-most-once delivery is guaranteed by issueTokenForApprovedRow's MarkIssued
+// gate — a parallel call gets access_denied and we don't double-post. On
+// transport failure, the row stays issued (single-use is sacrificed for
+// retry simplicity: a client that registered push mode trusts the server's
+// delivery; if the callback host is unreachable, the deployer operationalises
+// retry through the admin API or, more realistically, falls back to ping mode).
+//
+// Network retry uses the same exponential-backoff + jitter loop as
+// dispatchPing. 4xx is terminal, 5xx is retried. last_notify_error is
+// recorded so operators see why a token never landed.
+func (s *BackchannelService) dispatchPushApproval(ctx context.Context, row *domain.BackchannelAuthRequest) {
+	if row == nil || row.NotificationMode != domain.BackchannelNotificationPush {
+		return
+	}
+	if row.ClientNotificationEndpoint == "" || row.ClientNotificationToken == "" {
+		return
+	}
+
+	accessToken, err := s.issueTokenForApprovedRow(ctx, row)
+	if err != nil {
+		// Most likely an OAuthError("access_denied") from a lost race against
+		// a concurrent dispatch. Log and exit — the first dispatcher will
+		// have delivered (or will deliver).
+		log.Warn().Err(err).Str("auth_req_id", row.AuthReqID).Msg("push approval mint failed")
+		_ = s.repo.SetLastNotifyError(ctx, row.AuthReqID, err.Error())
+		return
+	}
+
+	// Build the CIBA Core §10.3.1 push notification body. Mirrors the
+	// /oauth2/token success response shape so clients can reuse their
+	// existing token-response parser.
+	tokenType := accessToken.TokenType
+	if tokenType == "" {
+		tokenType = "Bearer"
+	}
+	payload := map[string]any{
+		"access_token": accessToken.AccessToken,
+		"token_type":   tokenType,
+		"expires_in":   accessToken.ExpiresIn,
+		"auth_req_id":  row.AuthReqID,
+	}
+	if accessToken.Scope != "" {
+		payload["scope"] = accessToken.Scope
+	}
+	if accessToken.RefreshToken != "" {
+		payload["refresh_token"] = accessToken.RefreshToken
+	}
+
+	s.postCallback(ctx, row, payload)
+}
+
+// dispatchPushDenial POSTs the OAuth error body (CIBA Core §10.3.2) to the
+// client's notification endpoint when the user denies a push-mode request.
+// No token is minted. Mirrors RFC 6749 §5.2 error shape so clients can reuse
+// their existing token-error parser.
+func (s *BackchannelService) dispatchPushDenial(ctx context.Context, row *domain.BackchannelAuthRequest) {
+	if row == nil || row.NotificationMode != domain.BackchannelNotificationPush {
+		return
+	}
+	if row.ClientNotificationEndpoint == "" || row.ClientNotificationToken == "" {
+		return
+	}
+	payload := map[string]any{
+		"error":             "access_denied",
+		"error_description": "the user denied the authentication request",
+		"auth_req_id":       row.AuthReqID,
+	}
+	s.postCallback(ctx, row, payload)
+}
+
+// postCallback is the shared outbound POST machinery for push approval/denial.
+// Detached context, exponential backoff + jitter, 4xx terminal / 5xx retried,
+// last_notify_error recorded. Shared with dispatchPing's retry loop pattern
+// but takes an arbitrary JSON-serializable payload.
+func (s *BackchannelService) postCallback(ctx context.Context, row *domain.BackchannelAuthRequest, payload map[string]any) {
+	s.mu.RLock()
+	client := s.pingClient
+	async := s.pingDispatchAsync
+	maxRetries := s.cfg.PingMaxRetries
+	baseDelay := s.cfg.PingBaseDelay
+	parent := s.svcCtx
+	s.mu.RUnlock()
+	if parent == nil {
+		// Stop() has been called; service is shutting down — drop the
+		// push rather than firing into the void.
+		return
+	}
+
+	endpoint := row.ClientNotificationEndpoint
+	bearer := row.ClientNotificationToken
+	authReqID := row.AuthReqID
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Error().Err(err).Str("auth_req_id", authReqID).Msg("failed to marshal push callback payload")
+		return
+	}
+
+	deliver := func() {
+		// Parent on svcCtx (cancelled by Server.Shutdown via Stop) instead
+		// of context.Background — graceful shutdown cancels in-flight push
+		// retries instead of letting them outlive the server. Still detached
+		// from the inbound request's ctx so a client disconnect doesn't kill
+		// the outbound delivery.
+		dctx, cancel := context.WithTimeout(parent,
+			s.cfg.PingTimeout*time.Duration(maxRetries+1)+baseDelay*time.Duration(maxRetries+1))
+		defer cancel()
+
+		var lastErr error
+		for attempt := 0; attempt <= maxRetries; attempt++ {
+			if attempt > 0 {
+				delay := baseDelay << (attempt - 1)
+				jitter := time.Duration(jitterMillis()) * time.Millisecond
+				select {
+				case <-time.After(delay + jitter):
+				case <-dctx.Done():
+					lastErr = dctx.Err()
+					goto done
+				}
+			}
+
+			req, err := http.NewRequestWithContext(dctx, http.MethodPost, endpoint, bytes.NewReader(body))
+			if err != nil {
+				lastErr = err
+				goto done
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+bearer)
+			req.Header.Set("User-Agent", "zeroid-ciba-push/1.0")
+
+			resp, err := client.Do(req)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			// Drain + close so the underlying TCP connection can be reused
+			// across retries. HTTP/1.1 keepalive requires the body fully read.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				_ = s.repo.SetLastNotifyError(dctx, authReqID, "")
+				return
+			}
+			lastErr = fmt.Errorf("push callback returned HTTP %d", resp.StatusCode)
+			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+				goto done
+			}
+		}
+
+	done:
+		log.Warn().
+			Err(lastErr).
+			Str("auth_req_id", authReqID).
+			Str("endpoint", endpoint).
+			Msg("CIBA push dispatch failed")
+		if lastErr != nil {
+			if rerr := s.repo.SetLastNotifyError(dctx, authReqID, lastErr.Error()); rerr != nil {
+				log.Warn().Err(rerr).Str("auth_req_id", authReqID).Msg("failed to record push last_notify_error")
 			}
 		}
 	}

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -67,6 +67,9 @@ type RegisterClientRequest struct {
 
 	// CIBA ping/push endpoint. Must be HTTPS when non-empty; validated at registration.
 	ClientNotificationEndpoint string
+	// CIBA Core §10 token delivery mode: "poll" (default), "ping", or "push".
+	// Validated against the domain enum at registration.
+	BackchannelTokenDeliveryMode string
 }
 
 // RegisterClient creates a new OAuth2 client.
@@ -88,6 +91,21 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 		if err := validateNotificationEndpoint(req.ClientNotificationEndpoint); err != nil {
 			return nil, "", err
 		}
+	}
+
+	// CIBA Core §10: validate the declared delivery mode. ping/push require
+	// a registered notification endpoint — refuse the registration outright
+	// rather than letting it fail at bc-authorize time. Empty defaults to "poll".
+	deliveryMode := req.BackchannelTokenDeliveryMode
+	if deliveryMode == "" {
+		deliveryMode = string(domain.BackchannelNotificationPoll)
+	}
+	if !domain.IsValidBackchannelDeliveryMode(deliveryMode) {
+		return nil, "", fmt.Errorf("invalid backchannel_token_delivery_mode %q", deliveryMode)
+	}
+	if (deliveryMode == string(domain.BackchannelNotificationPing) || deliveryMode == string(domain.BackchannelNotificationPush)) &&
+		req.ClientNotificationEndpoint == "" {
+		return nil, "", fmt.Errorf("backchannel_token_delivery_mode=%s requires client_notification_endpoint", deliveryMode)
 	}
 
 	var plainSecret string
@@ -147,29 +165,30 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 
 	now := time.Now()
 	client := &domain.OAuthClient{
-		ID:                         uuid.New().String(),
-		ClientID:                   req.ClientID,
-		ClientSecret:               hashedSecret,
-		Name:                       req.Name,
-		Description:                req.Description,
-		ClientType:                 clientType,
-		TokenEndpointAuthMethod:    authMethod,
-		GrantTypes:                 grantTypes,
-		RedirectURIs:               redirectURIs,
-		Scopes:                     scopes,
-		AccessTokenTTL:             req.AccessTokenTTL,
-		RefreshTokenTTL:            req.RefreshTokenTTL,
-		JWKSURI:                    req.JWKSURI,
-		JWKS:                       req.JWKS,
-		SoftwareID:                 req.SoftwareID,
-		SoftwareVersion:            req.SoftwareVersion,
-		Contacts:                   contacts,
-		Metadata:                   req.Metadata,
-		IdentityID:                 identityID,
-		ClientNotificationEndpoint: req.ClientNotificationEndpoint,
-		IsActive:                   true,
-		CreatedAt:                  now,
-		UpdatedAt:                  now,
+		ID:                           uuid.New().String(),
+		ClientID:                     req.ClientID,
+		ClientSecret:                 hashedSecret,
+		Name:                         req.Name,
+		Description:                  req.Description,
+		ClientType:                   clientType,
+		TokenEndpointAuthMethod:      authMethod,
+		GrantTypes:                   grantTypes,
+		RedirectURIs:                 redirectURIs,
+		Scopes:                       scopes,
+		AccessTokenTTL:               req.AccessTokenTTL,
+		RefreshTokenTTL:              req.RefreshTokenTTL,
+		JWKSURI:                      req.JWKSURI,
+		JWKS:                         req.JWKS,
+		SoftwareID:                   req.SoftwareID,
+		SoftwareVersion:              req.SoftwareVersion,
+		Contacts:                     contacts,
+		Metadata:                     req.Metadata,
+		IdentityID:                   identityID,
+		ClientNotificationEndpoint:   req.ClientNotificationEndpoint,
+		BackchannelTokenDeliveryMode: deliveryMode,
+		IsActive:                     true,
+		CreatedAt:                    now,
+		UpdatedAt:                    now,
 	}
 
 	if err := s.repo.Create(ctx, client); err != nil {

--- a/migrations/021_ciba_push_mode.down.sql
+++ b/migrations/021_ciba_push_mode.down.sql
@@ -1,2 +1,2 @@
--- 016_ciba_push_mode.down.sql
+-- 021_ciba_push_mode.down.sql
 ALTER TABLE oauth_clients DROP COLUMN IF EXISTS backchannel_token_delivery_mode;

--- a/migrations/021_ciba_push_mode.down.sql
+++ b/migrations/021_ciba_push_mode.down.sql
@@ -1,0 +1,2 @@
+-- 016_ciba_push_mode.down.sql
+ALTER TABLE oauth_clients DROP COLUMN IF EXISTS backchannel_token_delivery_mode;

--- a/migrations/021_ciba_push_mode.up.sql
+++ b/migrations/021_ciba_push_mode.up.sql
@@ -1,4 +1,4 @@
--- 016_ciba_push_mode.up.sql
+-- 021_ciba_push_mode.up.sql
 -- OpenID CIBA Core 1.0 §10: token delivery modes.
 --
 -- A client declares its supported delivery mode at registration:

--- a/migrations/021_ciba_push_mode.up.sql
+++ b/migrations/021_ciba_push_mode.up.sql
@@ -1,0 +1,22 @@
+-- 016_ciba_push_mode.up.sql
+-- OpenID CIBA Core 1.0 §10: token delivery modes.
+--
+-- A client declares its supported delivery mode at registration:
+--
+--   poll  — client polls /oauth2/token with the auth_req_id (PR 1).
+--   ping  — server POSTs auth_req_id to client_notification_endpoint on
+--           resolution; client then polls /oauth2/token for the token (PR 2).
+--   push  — server POSTs the full token response (access_token + metadata)
+--           to client_notification_endpoint on resolution; client never polls
+--           (PR 3 — this migration).
+--
+-- Per §10 the mode is a property of the client, not the request, so the
+-- enum lives on oauth_clients. A bc-authorize request from a push-mode
+-- client must supply client_notification_token (same as ping); the
+-- server then delivers the token via callback and refuses any subsequent
+-- polling of the same auth_req_id.
+
+ALTER TABLE oauth_clients
+    ADD COLUMN IF NOT EXISTS backchannel_token_delivery_mode
+        VARCHAR(8) NOT NULL DEFAULT 'poll'
+        CHECK (backchannel_token_delivery_mode IN ('poll', 'ping', 'push'));

--- a/server.go
+++ b/server.go
@@ -613,23 +613,24 @@ func (s *Server) EnsureClient(ctx context.Context, cfg OAuthClientConfig) error 
 	if err != nil {
 		// Client doesn't exist — create it.
 		_, _, regErr := s.oauthClientSvc.RegisterClient(ctx, service.RegisterClientRequest{
-			ClientID:                   cfg.ClientID,
-			Name:                       cfg.Name,
-			Description:                cfg.Description,
-			Confidential:               cfg.Confidential,
-			TokenEndpointAuthMethod:    cfg.TokenEndpointAuthMethod,
-			GrantTypes:                 cfg.GrantTypes,
-			Scopes:                     cfg.Scopes,
-			RedirectURIs:               cfg.RedirectURIs,
-			AccessTokenTTL:             cfg.AccessTokenTTL,
-			RefreshTokenTTL:            cfg.RefreshTokenTTL,
-			JWKSURI:                    cfg.JWKSURI,
-			JWKS:                       cfg.JWKS,
-			SoftwareID:                 cfg.SoftwareID,
-			SoftwareVersion:            cfg.SoftwareVersion,
-			Contacts:                   cfg.Contacts,
-			Metadata:                   cfg.Metadata,
-			ClientNotificationEndpoint: cfg.ClientNotificationEndpoint,
+			ClientID:                     cfg.ClientID,
+			Name:                         cfg.Name,
+			Description:                  cfg.Description,
+			Confidential:                 cfg.Confidential,
+			TokenEndpointAuthMethod:      cfg.TokenEndpointAuthMethod,
+			GrantTypes:                   cfg.GrantTypes,
+			Scopes:                       cfg.Scopes,
+			RedirectURIs:                 cfg.RedirectURIs,
+			AccessTokenTTL:               cfg.AccessTokenTTL,
+			RefreshTokenTTL:              cfg.RefreshTokenTTL,
+			JWKSURI:                      cfg.JWKSURI,
+			JWKS:                         cfg.JWKS,
+			SoftwareID:                   cfg.SoftwareID,
+			SoftwareVersion:              cfg.SoftwareVersion,
+			Contacts:                     cfg.Contacts,
+			Metadata:                     cfg.Metadata,
+			ClientNotificationEndpoint:   cfg.ClientNotificationEndpoint,
+			BackchannelTokenDeliveryMode: cfg.BackchannelTokenDeliveryMode,
 		})
 
 		return regErr
@@ -669,6 +670,10 @@ func (s *Server) EnsureClient(ctx context.Context, cfg OAuthClientConfig) error 
 	}
 	if cfg.ClientNotificationEndpoint != "" && cfg.ClientNotificationEndpoint != existing.ClientNotificationEndpoint {
 		existing.ClientNotificationEndpoint = cfg.ClientNotificationEndpoint
+		updated = true
+	}
+	if cfg.BackchannelTokenDeliveryMode != "" && cfg.BackchannelTokenDeliveryMode != existing.BackchannelTokenDeliveryMode {
+		existing.BackchannelTokenDeliveryMode = cfg.BackchannelTokenDeliveryMode
 		updated = true
 	}
 

--- a/tests/integration/ciba_ping_test.go
+++ b/tests/integration/ciba_ping_test.go
@@ -32,14 +32,17 @@ func TestCIBA_PingMode_HappyPath(t *testing.T) {
 	clientID := uid("ciba-ping-client")
 	const pingEndpoint = "https://ping.example.test/callback"
 
-	// Register the client *with* the notification endpoint — without it,
-	// bc-authorize must reject ping mode (defence-in-depth check below).
+	// Register the client *with* the notification endpoint AND declared
+	// delivery mode = ping. CIBA Core §10 routes on the registration field,
+	// not on per-request token presence — without this, the request falls
+	// through to poll mode and dispatchPing is never invoked.
 	require.NoError(t, testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
-		ClientID:                   clientID,
-		Name:                       clientID + "-ping",
-		GrantTypes:                 []string{"client_credentials"},
-		RedirectURIs:               []string{testRedirectURI},
-		ClientNotificationEndpoint: pingEndpoint,
+		ClientID:                     clientID,
+		Name:                         clientID + "-ping",
+		GrantTypes:                   []string{"client_credentials"},
+		RedirectURIs:                 []string{testRedirectURI},
+		ClientNotificationEndpoint:   pingEndpoint,
+		BackchannelTokenDeliveryMode: "ping",
 	}))
 
 	capt := newCapturingRoundTripper()
@@ -103,26 +106,23 @@ func TestCIBA_PingMode_HappyPath(t *testing.T) {
 }
 
 // TestCIBA_PingMode_RequiresRegisteredEndpoint guards the allowlist invariant:
-// a client that supplies client_notification_token but has NO registered
-// client_notification_endpoint must be rejected at bc-authorize. This is the
-// allowlist's whole point — a compromised client_notification_token cannot
-// redirect the server's outbound POSTs.
+// a client declaring backchannel_token_delivery_mode=ping (or push) MUST have
+// a registered client_notification_endpoint. This is the allowlist's whole
+// point — a compromised client_notification_token cannot redirect the
+// server's outbound POSTs. Per CIBA Core §10 the delivery mode is registration
+// metadata, so we enforce this at RegisterClient rather than waiting for
+// bc-authorize.
 func TestCIBA_PingMode_RequiresRegisteredEndpoint(t *testing.T) {
-	clientID := uid("ciba-ping-noendpoint")
-	registerTestOAuthClient(clientID, []string{"client_credentials"}) // no notification endpoint
-
-	resp := post(t, "/oauth2/bc-authorize", map[string]any{
-		"client_id":                 clientID,
-		"account_id":                testAccountID,
-		"project_id":                testProjectID,
-		"login_hint":                "carol@example.com",
-		"client_notification_token": "any-token",
-	}, nil)
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	body := decode(t, resp)
-	require.Equal(t, "invalid_request", body["error"])
-	require.Contains(t, body["error_description"], "client_notification_endpoint",
-		"error must point at the missing registration field")
+	err := testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:                     uid("ciba-ping-noendpoint"),
+		Name:                         "ciba-ping-noendpoint",
+		GrantTypes:                   []string{"client_credentials"},
+		BackchannelTokenDeliveryMode: "ping",
+		// ClientNotificationEndpoint intentionally omitted.
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "client_notification_endpoint",
+		"rejection must point at the missing registration field")
 }
 
 // TestCIBA_RegisterClient_RejectsHTTPNotificationEndpoint guards CIBA Core §4:

--- a/tests/integration/ciba_push_test.go
+++ b/tests/integration/ciba_push_test.go
@@ -1,0 +1,157 @@
+package integration_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	zeroid "github.com/highflame-ai/zeroid"
+)
+
+// TestCIBA_PushMode_HappyPath exercises OpenID CIBA Core §10.3.1 push delivery:
+//
+//  1. Register a client with backchannel_token_delivery_mode=push and an
+//     HTTPS notification endpoint.
+//  2. bc-authorize with client_notification_token.
+//  3. Approve.
+//  4. Server POSTs the full token response (access_token + token_type +
+//     expires_in + auth_req_id) to the callback with Authorization: Bearer
+//     <client_notification_token>.
+//  5. Polling /oauth2/token with grant_type=ciba and the same auth_req_id is
+//     refused (access_denied) — push delivers exactly once.
+func TestCIBA_PushMode_HappyPath(t *testing.T) {
+	clientID := uid("ciba-push-client")
+	const pushEndpoint = "https://push.example.test/cb"
+
+	require.NoError(t, testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:                     clientID,
+		Name:                         clientID + "-push",
+		GrantTypes:                   []string{"client_credentials"},
+		RedirectURIs:                 []string{testRedirectURI},
+		ClientNotificationEndpoint:   pushEndpoint,
+		BackchannelTokenDeliveryMode: "push",
+	}))
+
+	capt := newCapturingRoundTripper()
+	testZeroIDServer.SetBackchannelPingTransport(capt)
+	testZeroIDServer.SetBackchannelPingDispatchSync(true)
+	t.Cleanup(func() {
+		testZeroIDServer.SetBackchannelPingDispatchSync(false)
+		testZeroIDServer.SetBackchannelPingTransport(nil)
+	})
+
+	const notificationToken = "push-bearer-secret"
+
+	// bc-authorize ─────────────────────────────────────────────────────────
+	bcResp := post(t, "/oauth2/bc-authorize", map[string]any{
+		"client_id":                 clientID,
+		"account_id":                testAccountID,
+		"project_id":                testProjectID,
+		"login_hint":                "dave@example.com",
+		"scope":                     "openid",
+		"client_notification_token": notificationToken,
+	}, nil)
+	require.Equal(t, http.StatusOK, bcResp.StatusCode)
+	authReqID, _ := decode(t, bcResp)["auth_req_id"].(string)
+	require.NotEmpty(t, authReqID)
+
+	// Approve ──────────────────────────────────────────────────────────────
+	approveResp := post(t,
+		adminPath("/oauth2/bc-authorize/"+authReqID+"/approve"),
+		map[string]any{"subject_id": "user-dave-001", "subject_email": "dave@example.com"},
+		adminHeaders(),
+	)
+	require.Equal(t, http.StatusOK, approveResp.StatusCode)
+	_ = decode(t, approveResp)
+
+	// Push fired ───────────────────────────────────────────────────────────
+	captured := capt.requests()
+	require.Len(t, captured, 1, "approve must fire exactly one push callback")
+	cb := captured[0]
+	require.Equal(t, http.MethodPost, cb.Method)
+	require.Equal(t, pushEndpoint, cb.URL)
+	require.Equal(t, "Bearer "+notificationToken, cb.Headers.Get("Authorization"))
+	require.Equal(t, "application/json", cb.Headers.Get("Content-Type"))
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(cb.Body), &payload))
+	require.Equal(t, authReqID, payload["auth_req_id"])
+	require.NotEmpty(t, payload["access_token"], "push callback MUST include access_token")
+	require.Equal(t, "Bearer", payload["token_type"])
+	require.Greater(t, intField(payload, "expires_in"), 0)
+
+	// Polling is forbidden for push-mode rows ──────────────────────────────
+	pollResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":  "urn:openid:params:grant-type:ciba",
+		"auth_req_id": authReqID,
+		"client_id":   clientID,
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, pollResp.StatusCode)
+	require.Equal(t, "access_denied", decode(t, pollResp)["error"])
+}
+
+// TestCIBA_PushMode_Denial delivers an OAuth error body via the callback when
+// the user denies a push-mode request. No token is minted.
+func TestCIBA_PushMode_Denial(t *testing.T) {
+	clientID := uid("ciba-push-deny")
+	const pushEndpoint = "https://push.example.test/cb-deny"
+
+	require.NoError(t, testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:                     clientID,
+		Name:                         clientID + "-push-deny",
+		GrantTypes:                   []string{"client_credentials"},
+		RedirectURIs:                 []string{testRedirectURI},
+		ClientNotificationEndpoint:   pushEndpoint,
+		BackchannelTokenDeliveryMode: "push",
+	}))
+
+	capt := newCapturingRoundTripper()
+	testZeroIDServer.SetBackchannelPingTransport(capt)
+	testZeroIDServer.SetBackchannelPingDispatchSync(true)
+	t.Cleanup(func() {
+		testZeroIDServer.SetBackchannelPingDispatchSync(false)
+		testZeroIDServer.SetBackchannelPingTransport(nil)
+	})
+
+	bcResp := post(t, "/oauth2/bc-authorize", map[string]any{
+		"client_id":                 clientID,
+		"account_id":                testAccountID,
+		"project_id":                testProjectID,
+		"login_hint":                "eve@example.com",
+		"client_notification_token": "deny-bearer",
+	}, nil)
+	require.Equal(t, http.StatusOK, bcResp.StatusCode)
+	authReqID, _ := decode(t, bcResp)["auth_req_id"].(string)
+
+	denyResp := post(t,
+		adminPath("/oauth2/bc-authorize/"+authReqID+"/deny"),
+		struct{}{},
+		adminHeaders(),
+	)
+	require.Equal(t, http.StatusOK, denyResp.StatusCode)
+
+	captured := capt.requests()
+	require.Len(t, captured, 1, "deny must fire exactly one push callback")
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(captured[0].Body), &payload))
+	require.Equal(t, "access_denied", payload["error"], "denial payload follows RFC 6749 §5.2 error shape")
+	require.Equal(t, authReqID, payload["auth_req_id"])
+	require.NotContains(t, payload, "access_token", "denied push MUST NOT carry a token")
+}
+
+// TestCIBA_RegisterClient_PushRequiresEndpoint guards the registration
+// invariant: delivery_mode=push without client_notification_endpoint is
+// rejected (same rule as ping).
+func TestCIBA_RegisterClient_PushRequiresEndpoint(t *testing.T) {
+	err := testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:                     uid("ciba-push-noendpoint"),
+		Name:                         "push-noendpoint",
+		GrantTypes:                   []string{"client_credentials"},
+		BackchannelTokenDeliveryMode: "push",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "client_notification_endpoint")
+}

--- a/tests/integration/wellknown_test.go
+++ b/tests/integration/wellknown_test.go
@@ -62,6 +62,21 @@ func TestOAuthServerMetadata(t *testing.T) {
 	assert.True(t, grantSet["client_credentials"], "must support client_credentials")
 	assert.True(t, grantSet["urn:ietf:params:oauth:grant-type:jwt-bearer"], "must support jwt_bearer")
 	assert.True(t, grantSet["urn:ietf:params:oauth:grant-type:token-exchange"], "must support token_exchange")
+	assert.True(t, grantSet["urn:openid:params:grant-type:ciba"], "must support CIBA grant")
+
+	// CIBA (OpenID CIBA Core 1.0) discovery fields.
+	assert.NotEmpty(t, body["backchannel_authentication_endpoint"],
+		"must advertise backchannel_authentication_endpoint for CIBA-aware clients")
+
+	deliveryModes, ok := body["backchannel_token_delivery_modes_supported"].([]any)
+	require.True(t, ok, "must declare backchannel_token_delivery_modes_supported")
+	modeSet := make(map[string]bool, len(deliveryModes))
+	for _, m := range deliveryModes {
+		modeSet[m.(string)] = true
+	}
+	assert.True(t, modeSet["poll"], "must advertise poll delivery mode")
+	assert.True(t, modeSet["ping"], "must advertise ping delivery mode")
+	assert.True(t, modeSet["push"], "must advertise push delivery mode")
 }
 
 // TestHealthEndpoint verifies that /health returns 200.


### PR DESCRIPTION
## Summary

OpenID CIBA Core 1.0 §10.3 — **push mode**. Final PR in the three-part dependent stack that closes issue #64.

> **⚠ This PR is stacked on #131 and #132.** It contains PR 1 + PR 2 + PR 3 commits. **Do not merge until #131 and #132 have merged.** Once both prerequisites land, the diff here will narrow to the PR 3 commit only.
>
> **Merge order:** PR 1 (#131) → PR 2 (#132) → **PR 3 (this)**.

Sibling discussion: https://github.com/highflame-ai/zeroid/issues/64#issuecomment-4418095786

## What changes vs PR 2

PR 2 added the **ping** callback: server POSTs `{auth_req_id}` on resolution, client polls `/oauth2/token` to get the token. PR 3 adds the **push** callback: server delivers the **full token response** directly in the callback. The client never polls. CIBA Core §10 makes the mode a **client-registration property**, so PR 3 introduces `oauth_clients.backchannel_token_delivery_mode` (`poll`|`ping`|`push`).

## Files added in PR 3 (review focus)

### Schema
- `migrations/016_ciba_push_mode.{up,down}.sql`
  - `oauth_clients.backchannel_token_delivery_mode VARCHAR(8)` enum, CHECK-constrained to `poll`/`ping`/`push`, default `poll`

### Domain / service
- `domain/token.go`: `OAuthClient.BackchannelTokenDeliveryMode`
- `domain/backchannel_auth.go`: `BackchannelNotificationPush` constant + `IsValidBackchannelDeliveryMode` helper
- `internal/service/oauth_client.go`: enum validation; ping/push must register `client_notification_endpoint`
- `internal/service/backchannel.go`:
  - `CreateAuthRequest`: derives mode from `client.BackchannelTokenDeliveryMode` (per CIBA §10 — mode is client-registration property); ping/push require `client_notification_token`
  - `dispatchResolution(ctx, row, outcome)`: routes to `dispatchPing` / `dispatchPushApproval` / `dispatchPushDenial`
  - `issueTokenForApprovedRow` extracted from `Redeem` so push and poll mint via the same code path (single-use guarded by `MarkIssued`'s conditional UPDATE)
  - `dispatchPushApproval`: mints + POSTs full CIBA §10.3.1 token-response body (`access_token`, `token_type`, `expires_in`, `auth_req_id`, optional `scope`/`refresh_token`)
  - `dispatchPushDenial`: POSTs RFC 6749 §5.2 error body (`error=access_denied`, `error_description`, `auth_req_id`)
  - `postCallback`: shared outbound HTTP machinery between ping/push (bounded retry, jitter, 4xx terminal, 5xx retried, `last_notify_error`)
  - `Redeem`: refuses push-mode rows with `access_denied` so polling cannot double-deliver

### Surface (Server, hooks)
- `OAuthClientConfig.BackchannelTokenDeliveryMode` + `EnsureClient` propagation

### Tests (`tests/integration/ciba_push_test.go`)
- **Happy path**: registration with `delivery_mode=push` → bc-authorize → approve → captured POST carries `access_token`/`token_type`/`expires_in` + correct bearer → polling refused with `access_denied`
- **Denial**: deny instead of approve → captured POST carries `{error: access_denied, error_description, auth_req_id}` and **no** `access_token`
- **Registration guard**: `delivery_mode=push` without `client_notification_endpoint` rejected

## Security notes

- **Single delivery**: `Redeem` refuses push-mode auth_req_ids — the token cannot be both pushed and polled. `MarkIssued`'s conditional UPDATE is the at-most-once invariant under concurrent dispatch.
- **Mode is registered, not requested**: per CIBA §10. A compromised `client_notification_token` cannot escalate a poll-mode client to push.
- **Same HTTPS allowlist as PR 2**: push reuses PR 2's `client_notification_endpoint` validation; defence-in-depth re-check at request time.
- **Token never logged**: payload-level logging deliberately avoids the `access_token` field; only the `auth_req_id` and endpoint URL appear in error logs.

## Issue #64 checklist — complete

After this merge, every item on the issue's Requirements checklist is implemented:

| Item | Status |
|---|---|
| `urn:openid:params:grant-type:ciba` | ✅ PR 1 |
| `POST /oauth2/bc-authorize` | ✅ PR 1 |
| Polling mode | ✅ PR 1 |
| Ping mode | ✅ PR 2 |
| Push mode | ✅ PR 3 |
| `login_hint`, `scope`, `binding_message`, `requested_expiry` | ✅ PR 1 |
| `auth_req_id` / `expires_in` / `interval` | ✅ PR 1 |
| `BackchannelNotifier` hook | ✅ PR 1 |
| `Server.SetBackchannelNotifier()` | ✅ PR 1 |
| Approve endpoint | ✅ PR 1 |
| Token issuance via `/oauth2/token` | ✅ PR 1 |
| Credential policy enforcement | ✅ (inherited from `IssueCredential`) |
| `act` claim — `backchannel_client_id` claim recorded | ✅ PR 1 (basic) |
| Pending request expiry | ✅ PR 1 |
| `backchannel_auth_requests` table | ✅ PR 1 |
| CAE signal revocation | ✅ (inherited) |
| Cascade revocation as `subject_token` | ✅ (inherited) |
| Introspection / revocation | ✅ (inherited) |

## Test Plan

- [x] Build + vet clean (`go vet ./...`, `gofmt -l`)
- [x] New tests added: happy-path push, push denial, registration guard
- [ ] CI runs the full stack (after #131 and #132 merge)
- [ ] Manual smoke after the full stack lands: register client with `delivery_mode=push` and `client_notification_endpoint` → bc-authorize with `client_notification_token` → approve → observe POST carrying access_token at the registered endpoint → confirm polling is refused