### PR TITLE
docs: add SECURITY.md with private vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+  
+  We take security seriously. Please report vulnerabilities **privately** so we can
+  fix them before disclosure.
+
+  ## Reporting a vulnerability
+
+  **Use GitHub's private vulnerability reporting:**
+  https://github.com/highflame-ai/zeroid/security/advisories/new
+
+  This routes the report to repository administrators only. Do not file a public
+  issue for any vulnerability that has an exploit path — the issues tracker is
+  public and indexed by search engines.
+
+  If you cannot use the GitHub form, email **support@highflame.com** with:
+
+  - A description of the issue
+  - Steps to reproduce
+  - Affected versions
+  - Your name + contact for credit (optional)
+  - A suggested fix or mitigation if you have one
+
+  ## Scope
+  
+  In scope:
+  - Auth bypass, IDOR, tenant-isolation violations
+  - Token forgery, signature confusion, algorithm confusion
+  - Privilege escalation, scope-ceiling bypasses
+  - SSRF, SQLi, command injection
+  - Secret exposure (logs, errors, telemetry)
+  - DoS that's amplifiable beyond a single client
+
+  Out of scope (please file public issues for these):
+  - Documentation typos
+  - Feature requests
+  - Performance issues that aren't security-amplifiable
+  - Self-DoS (e.g. "if I generate a 10GB JWT, the server slows down")
+
+  ## Supported versions
+
+  Security fixes ship to:
+  - `main` (always)
+  - The most recent tagged release (when versioned releases exist)
+  
+  ## Response SLA
+
+  - Initial acknowledgement: **within 2 business days**
+  - Triage decision (in scope / out of scope / severity): **within 5 business days**
+  - Fix targeted: **within 30 days** for critical/high; **90 days** for medium; best-effort for low
+  - Public disclosure (CVE): **after a fix is available** and customers have had reasonable time to update
+
+  ## Process
+
+  1. Reporter files a private report
+  2. Highflame triages, drafts a GitHub Security Advisory
+  3. Fix is developed in a temporary private fork (linked off the advisory)
+  4. Once the fix lands on `main` and a release tag exists, the advisory is published as a CVE
+  5. Reporter is credited (with permission)
+
+  ## Credits
+  
+  We thank everyone who has reported issues responsibly. Confirmed reporters who
+  opt in are listed in the published advisory and our release notes.


### PR DESCRIPTION
Routes vulnerability reports through GitHub's private vulnerability reporting (now enabled at the repo level) so security bugs don't get disclosed publicly before patches are available.

This is the missing piece of the public-repo security setup:

| Layer | Status |
|---|---|
| Private Vulnerability Reporting | ✅ enabled (`gh api /repos/.../private-vulnerability-reporting` returns `enabled:true`) |
| Dependabot security updates | ✅ enabled |
| Secret scanning | ✅ enabled |
| Push protection | ✅ enabled |
| SECURITY.md | ⬅️ this PR |

After merge, GitHub auto-renders SECURITY.md under the Security tab + links it from the new-issue page, so anyone considering filing a public security issue sees the private-reporting path first.

## What it says

- Use [private vulnerability reporting](https://github.com/highflame-ai/zeroid/security/advisories/new) for any exploit-path issue
- Fall back to support@highflame.com if the form isn't workable
- Scope: auth bypass, IDOR, token forgery, SSRF, SQLi, secret exposure, amplifiable DoS
- Out of scope: typos, feature requests, self-DoS
- SLA: ack in 2 business days; fix in 30/90 days by severity
- Process: report → triage → temp-fork fix → CVE on publish → credit

## Self-merge OK

No code changes, single doc add. Squash + merge when convenient.