### PR TITLE
security: SSRF guard on CIBA notification endpoints

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,9 +28,28 @@ type Config struct {
 	Telemetry   TelemetryConfig   `koanf:"telemetry"`
 	Logging     LoggingConfig     `koanf:"logging"`
 	Attestation AttestationConfig `koanf:"attestation"`
+	Backchannel BackchannelConfig `koanf:"backchannel"`
 
 	// WIMSEDomain is the domain prefix for SPIFFE/WIMSE URIs (e.g. "zeroid.dev").
 	WIMSEDomain string `koanf:"wimse_domain"`
+}
+
+// BackchannelConfig governs CIBA (OpenID CIBA Core 1.0) behavior. All fields
+// are optional; defaults are applied in service.DefaultBackchannelConfig().
+type BackchannelConfig struct {
+	// AllowPrivateNotificationEndpoints relaxes the SSRF guard on CIBA
+	// outbound notification destinations. Default false (production-safe).
+	//
+	// When false, registered client_notification_endpoint hosts are resolved
+	// and rejected if they (or any of their resolved IPs) fall in private,
+	// loopback, link-local, multicast, CGN, or unspecified ranges. Re-checked
+	// at request time as DNS-rebinding defense.
+	//
+	// When true, the guard is disabled — only HTTPS scheme + non-empty host
+	// are enforced. Use ONLY in single-tenant test/dev deployments that
+	// register endpoints like https://localhost:9000/. Production deployments
+	// MUST keep this false (see GHSA-599q-j34m-33vc).
+	AllowPrivateNotificationEndpoints bool `koanf:"allow_private_notification_endpoints"`
 }
 
 // AttestationConfig governs the attestation verification subsystem. The

--- a/internal/service/backchannel.go
+++ b/internal/service/backchannel.go
@@ -287,7 +287,7 @@ func (s *BackchannelService) CreateAuthRequest(ctx context.Context, in CreateAut
 		//   2. Re-resolve the host against the SSRF blocklist. The registered
 		//      hostname might have been DNS-rebound to point at a private IP
 		//      since registration — this catches that (GHSA-599q-j34m-33vc).
-		if err := validateNotificationEndpoint(client.ClientNotificationEndpoint, s.cfg.AllowPrivateNotificationEndpoints); err != nil {
+		if err := validateNotificationEndpoint(ctx, client.ClientNotificationEndpoint, s.cfg.AllowPrivateNotificationEndpoints); err != nil {
 			return nil, oauthBadRequestCause("invalid_request", "client_notification_endpoint is invalid", err)
 		}
 		notificationMode = domain.BackchannelNotificationPing

--- a/internal/service/backchannel.go
+++ b/internal/service/backchannel.go
@@ -98,6 +98,16 @@ type BackchannelServiceConfig struct {
 	PingTimeout    time.Duration // per-attempt HTTP timeout
 	PingMaxRetries int           // additional attempts on transient failure; 0 → no retries
 	PingBaseDelay  time.Duration // first-retry backoff; doubled per attempt with jitter
+
+	// AllowPrivateNotificationEndpoints relaxes the SSRF guard on
+	// outbound CIBA notification destinations when true. Defaults to false
+	// (production-safe). Production deployments must keep this false — see
+	// GHSA-599q-j34m-33vc. Flip to true ONLY in single-tenant test/dev
+	// environments that need to register loopback-style endpoints like
+	// https://localhost:9000/. Mirrors OAuthClientService's same-named
+	// setter; both should be set from the same source in the deployer's
+	// server construction code.
+	AllowPrivateNotificationEndpoints bool
 }
 
 // DefaultBackchannelConfig returns sensible defaults for production deployments.
@@ -270,10 +280,14 @@ func (s *BackchannelService) CreateAuthRequest(ctx context.Context, in CreateAut
 			return nil, oauthBadRequest("invalid_request",
 				"client_notification_token requires the client to have a registered client_notification_endpoint")
 		}
-		// Defence-in-depth: re-validate the registered endpoint is HTTPS even
-		// though RegisterClient already enforced it. A future bypass at
-		// registration must not silently degrade ping mode to http.
-		if err := validateNotificationEndpoint(client.ClientNotificationEndpoint); err != nil {
+		// Defence-in-depth: re-validate the registered endpoint at request time.
+		// Two reasons:
+		//   1. Re-confirm HTTPS so a future registration-side bypass cannot
+		//      silently degrade ping mode to plaintext.
+		//   2. Re-resolve the host against the SSRF blocklist. The registered
+		//      hostname might have been DNS-rebound to point at a private IP
+		//      since registration — this catches that (GHSA-599q-j34m-33vc).
+		if err := validateNotificationEndpoint(client.ClientNotificationEndpoint, s.cfg.AllowPrivateNotificationEndpoints); err != nil {
 			return nil, oauthBadRequestCause("invalid_request", "client_notification_endpoint is invalid", err)
 		}
 		notificationMode = domain.BackchannelNotificationPing

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"time"
 
@@ -30,11 +31,26 @@ var ErrInvalidClientSecret = errors.New("invalid client secret")
 // OAuthClientService manages OAuth2 client registration.
 type OAuthClientService struct {
 	repo *postgres.OAuthClientRepository
+	// allowPrivateNotificationEndpoints relaxes the SSRF guard on
+	// client_notification_endpoint registration when true. Defaults to
+	// false (production-safe). Flipped via SetAllowPrivateNotificationEndpoints
+	// in test / single-tenant dev deployments that need to register
+	// loopback-style endpoints like https://localhost:9000/.
+	allowPrivateNotificationEndpoints bool
 }
 
 // NewOAuthClientService creates a new OAuthClientService.
 func NewOAuthClientService(repo *postgres.OAuthClientRepository) *OAuthClientService {
 	return &OAuthClientService{repo: repo}
+}
+
+// SetAllowPrivateNotificationEndpoints toggles the SSRF guard on
+// client_notification_endpoint registration. Production must keep this false
+// (the default). Tests + single-tenant dev deployments needing loopback
+// endpoints flip to true. Mirrors BackchannelServiceConfig's same-named
+// field; both should be set from the same source in server.go.
+func (s *OAuthClientService) SetAllowPrivateNotificationEndpoints(allow bool) {
+	s.allowPrivateNotificationEndpoints = allow
 }
 
 // RegisterClientRequest holds all fields for creating an OAuth2 client.
@@ -83,9 +99,11 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 	}
 	// CIBA Core §4: client_notification_endpoint MUST be an HTTPS URL when
 	// supplied. Reject http:// / non-URL values at registration so a faulty
-	// client cannot lead the server to POST credentials over plaintext.
+	// client cannot lead the server to POST credentials over plaintext. The
+	// SSRF guard (resolved-IP check against private ranges) also fires here
+	// unless allowPrivateNotificationEndpoints is set for test/dev.
 	if req.ClientNotificationEndpoint != "" {
-		if err := validateNotificationEndpoint(req.ClientNotificationEndpoint); err != nil {
+		if err := validateNotificationEndpoint(req.ClientNotificationEndpoint, s.allowPrivateNotificationEndpoints); err != nil {
 			return nil, "", err
 		}
 	}
@@ -284,11 +302,29 @@ func generateSecureToken(byteLen int) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// ErrPrivateNotificationEndpoint is the sentinel returned when an outbound
+// destination resolves to a private / loopback / link-local / multicast /
+// CGN / unspecified IP range. Service-layer validation errors are wrapped via
+// %w so callers (registration handler, request-time dispatch checks) can use
+// errors.Is to recognise the SSRF-guard rejection consistently.
+//
+// Mitigation for GHSA-599q-j34m-33vc — unguarded outbound HTTPS from CIBA
+// notification dispatch could be used as an SSRF primitive to scan internal
+// networks or hit cloud-metadata services from inside the zeroid process.
+var ErrPrivateNotificationEndpoint = errors.New("client_notification_endpoint resolves to a private or reserved IP range")
+
 // validateNotificationEndpoint enforces the CIBA Core §4 rule that
 // client_notification_endpoint MUST be an absolute HTTPS URL. http:// is
 // rejected so the server can never POST the per-request bearer
 // (client_notification_token) over plaintext.
-func validateNotificationEndpoint(raw string) error {
+//
+// When allowPrivate is false (production default), the host is resolved and
+// every returned IP is checked against a private/reserved-range blocklist.
+// If ANY resolved IP is blocked, the registration is rejected — DNS-rebinding
+// defense (a hostname pointing at both public and private IPs is treated as
+// hostile). Pass allowPrivate=true ONLY in test/dev contexts where you
+// register endpoints like https://localhost:8080/.
+func validateNotificationEndpoint(raw string, allowPrivate bool) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid client_notification_endpoint: %w", err)
@@ -299,5 +335,74 @@ func validateNotificationEndpoint(raw string) error {
 	if u.Host == "" {
 		return fmt.Errorf("client_notification_endpoint must include a host")
 	}
+	if !allowPrivate {
+		if err := assertNotPrivate(u.Hostname()); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// assertNotPrivate resolves host and rejects if ANY returned IP is in a
+// private / loopback / link-local / multicast / CGN / unspecified range.
+// All resolved IPs are checked so that DNS-rebinding (rotating A records
+// between resolution attempts) cannot bypass the guard by returning a public
+// IP at registration and a private IP at request-time.
+//
+// Pure-IP hostnames are also handled — net.LookupIP returns a single-element
+// slice with the literal IP, so the blocklist check applies to direct
+// IP-as-host registrations like https://10.0.0.5/.
+func assertNotPrivate(host string) error {
+	ips, err := lookupIPs(host)
+	if err != nil {
+		return fmt.Errorf("client_notification_endpoint host %q does not resolve: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("client_notification_endpoint host %q returned no IPs", host)
+	}
+	for _, ip := range ips {
+		if isBlockedIP(ip) {
+			return fmt.Errorf("%w: %s → %s", ErrPrivateNotificationEndpoint, host, ip.String())
+		}
+	}
+	return nil
+}
+
+// lookupIPs is a package-level var so tests can inject a stubbed resolver
+// without touching real DNS. Production uses net.LookupIP which goes through
+// the OS resolver (honours /etc/hosts, /etc/resolv.conf, etc.).
+var lookupIPs = func(host string) ([]net.IP, error) {
+	return net.LookupIP(host)
+}
+
+// isBlockedIP returns true for any IP that should not be reachable as a
+// CIBA notification target. Covers:
+//
+//   - RFC 1918 IPv4 private (10/8, 172.16/12, 192.168/16) — net.IP.IsPrivate
+//   - RFC 4193 IPv6 ULA (fc00::/7) — net.IP.IsPrivate, also catches Azure
+//     IMDS at fd00:ec2::254 which sits inside fc00::/7
+//   - Loopback (127/8, ::1) — net.IP.IsLoopback
+//   - Link-local unicast (169.254/16, fe80::/10) — net.IP.IsLinkLocalUnicast.
+//     Catches AWS/GCP IMDS at 169.254.169.254 and OpenStack at 169.254.169.254.
+//   - Link-local multicast (224.0.0/24, ff02::/16) — net.IP.IsLinkLocalMulticast
+//   - Multicast (224/4, ff00::/8) — net.IP.IsMulticast
+//   - Unspecified (0.0.0.0, ::) — net.IP.IsUnspecified
+//   - RFC 6598 Carrier-Grade NAT (100.64/10) — not exposed by stdlib;
+//     checked manually below
+func isBlockedIP(ip net.IP) bool {
+	if ip.IsPrivate() ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() {
+		return true
+	}
+	// RFC 6598 CGN: 100.64.0.0/10
+	if v4 := ip.To4(); v4 != nil {
+		if v4[0] == 100 && v4[1]&0xC0 == 0x40 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -103,7 +103,7 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 	// SSRF guard (resolved-IP check against private ranges) also fires here
 	// unless allowPrivateNotificationEndpoints is set for test/dev.
 	if req.ClientNotificationEndpoint != "" {
-		if err := validateNotificationEndpoint(req.ClientNotificationEndpoint, s.allowPrivateNotificationEndpoints); err != nil {
+		if err := validateNotificationEndpoint(ctx, req.ClientNotificationEndpoint, s.allowPrivateNotificationEndpoints); err != nil {
 			return nil, "", err
 		}
 	}
@@ -304,27 +304,38 @@ func generateSecureToken(byteLen int) (string, error) {
 
 // ErrPrivateNotificationEndpoint is the sentinel returned when an outbound
 // destination resolves to a private / loopback / link-local / multicast /
-// CGN / unspecified IP range. Service-layer validation errors are wrapped via
+// CGN / unspecified address. Service-layer validation errors wrap this via
 // %w so callers (registration handler, request-time dispatch checks) can use
-// errors.Is to recognise the SSRF-guard rejection consistently.
+// errors.Is to recognise the SSRF-guard rejection consistently. The error
+// deliberately does NOT echo the resolved IP back to the caller — leaking
+// our internal DNS view of the client's hostname is not a useful diagnostic
+// for the client and could expose split-horizon DNS topology.
 //
 // Mitigation for GHSA-599q-j34m-33vc — unguarded outbound HTTPS from CIBA
 // notification dispatch could be used as an SSRF primitive to scan internal
 // networks or hit cloud-metadata services from inside the zeroid process.
-var ErrPrivateNotificationEndpoint = errors.New("client_notification_endpoint resolves to a private or reserved IP range")
+var ErrPrivateNotificationEndpoint = errors.New("client_notification_endpoint resolves to a private or reserved address")
+
+// dnsLookupTimeout caps each resolve call so a slow / hanging DNS server
+// cannot stall a registration or dispatch indefinitely. 2 seconds is well
+// above typical resolver latency and leaves headroom inside the surrounding
+// HTTP request budget.
+const dnsLookupTimeout = 2 * time.Second
 
 // validateNotificationEndpoint enforces the CIBA Core §4 rule that
 // client_notification_endpoint MUST be an absolute HTTPS URL. http:// is
 // rejected so the server can never POST the per-request bearer
 // (client_notification_token) over plaintext.
 //
-// When allowPrivate is false (production default), the host is resolved and
-// every returned IP is checked against a private/reserved-range blocklist.
-// If ANY resolved IP is blocked, the registration is rejected — DNS-rebinding
-// defense (a hostname pointing at both public and private IPs is treated as
-// hostile). Pass allowPrivate=true ONLY in test/dev contexts where you
-// register endpoints like https://localhost:8080/.
-func validateNotificationEndpoint(raw string, allowPrivate bool) error {
+// When allowPrivate is false (production default), the host is resolved with
+// a 2-second timeout and every returned IP is checked against a
+// private/reserved-range blocklist. If ANY resolved IP is blocked, the
+// registration is rejected — DNS-rebinding defence (a hostname pointing at
+// both public and private IPs is treated as hostile). Pass allowPrivate=true
+// ONLY in test/dev contexts where you register endpoints like
+// https://localhost:8080/; in that mode DNS resolution is skipped entirely
+// so synthetic RFC 6761 .test/.example/.invalid fixtures don't hard-fail.
+func validateNotificationEndpoint(ctx context.Context, raw string, allowPrivate bool) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid client_notification_endpoint: %w", err)
@@ -335,25 +346,31 @@ func validateNotificationEndpoint(raw string, allowPrivate bool) error {
 	if u.Host == "" {
 		return fmt.Errorf("client_notification_endpoint must include a host")
 	}
-	if !allowPrivate {
-		if err := assertNotPrivate(u.Hostname()); err != nil {
-			return err
-		}
-	}
-	return nil
+	return resolveAndCheckHost(ctx, u.Hostname(), allowPrivate)
 }
 
-// assertNotPrivate resolves host and rejects if ANY returned IP is in a
-// private / loopback / link-local / multicast / CGN / unspecified range.
-// All resolved IPs are checked so that DNS-rebinding (rotating A records
-// between resolution attempts) cannot bypass the guard by returning a public
-// IP at registration and a private IP at request-time.
+// resolveAndCheckHost performs a timeout-bounded DNS lookup for host and
+// rejects if ANY returned IP is in the private/reserved blocklist (DNS-
+// rebinding defence: a hostname that mixes public and private A records is
+// treated as hostile). When allowPrivate is true, DNS resolution is skipped
+// entirely — synthetic RFC 6761 .test/.example/.invalid fixtures in
+// integration tests would otherwise hard-fail under NXDOMAIN.
 //
-// Pure-IP hostnames are also handled — net.LookupIP returns a single-element
+// The resolved IP is logged at debug level for operator triage but NOT
+// echoed back to the caller — leaking our internal DNS view of the client's
+// hostname is not a useful diagnostic for the client and could expose
+// split-horizon DNS topology.
+//
+// Pure-IP hostnames are also handled — the resolver returns a single-entry
 // slice with the literal IP, so the blocklist check applies to direct
 // IP-as-host registrations like https://10.0.0.5/.
-func assertNotPrivate(host string) error {
-	ips, err := lookupIPs(host)
+func resolveAndCheckHost(ctx context.Context, host string, allowPrivate bool) error {
+	if allowPrivate {
+		return nil
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, dnsLookupTimeout)
+	defer cancel()
+	ips, err := lookupIPs(lookupCtx, host)
 	if err != nil {
 		return fmt.Errorf("client_notification_endpoint host %q does not resolve: %w", host, err)
 	}
@@ -362,17 +379,30 @@ func assertNotPrivate(host string) error {
 	}
 	for _, ip := range ips {
 		if isBlockedIP(ip) {
-			return fmt.Errorf("%w: %s → %s", ErrPrivateNotificationEndpoint, host, ip.String())
+			log.Debug().
+				Str("host", host).
+				Str("blocked_ip", ip.String()).
+				Msg("SSRF guard rejected notification endpoint")
+			return ErrPrivateNotificationEndpoint
 		}
 	}
 	return nil
 }
 
 // lookupIPs is a package-level var so tests can inject a stubbed resolver
-// without touching real DNS. Production uses net.LookupIP which goes through
-// the OS resolver (honours /etc/hosts, /etc/resolv.conf, etc.).
-var lookupIPs = func(host string) ([]net.IP, error) {
-	return net.LookupIP(host)
+// without touching real DNS. Production uses net.DefaultResolver.LookupIPAddr
+// which honours the supplied context (so the dnsLookupTimeout actually
+// bounds the call — net.LookupIP does not respect context).
+var lookupIPs = func(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, len(addrs))
+	for i, a := range addrs {
+		ips[i] = a.IP
+	}
+	return ips, nil
 }
 
 // isBlockedIP returns true for any IP that should not be reachable as a
@@ -383,9 +413,10 @@ var lookupIPs = func(host string) ([]net.IP, error) {
 //     IMDS at fd00:ec2::254 which sits inside fc00::/7
 //   - Loopback (127/8, ::1) — net.IP.IsLoopback
 //   - Link-local unicast (169.254/16, fe80::/10) — net.IP.IsLinkLocalUnicast.
-//     Catches AWS/GCP IMDS at 169.254.169.254 and OpenStack at 169.254.169.254.
-//   - Link-local multicast (224.0.0/24, ff02::/16) — net.IP.IsLinkLocalMulticast
-//   - Multicast (224/4, ff00::/8) — net.IP.IsMulticast
+//     Catches AWS/GCP IMDS at 169.254.169.254.
+//   - Multicast (224/4, ff00::/8) — net.IP.IsMulticast. This is a strict
+//     superset of IsLinkLocalMulticast (224.0.0/24, ff02::/16), so the
+//     link-local-multicast check is implied and not repeated.
 //   - Unspecified (0.0.0.0, ::) — net.IP.IsUnspecified
 //   - RFC 6598 Carrier-Grade NAT (100.64/10) — not exposed by stdlib;
 //     checked manually below
@@ -393,7 +424,6 @@ func isBlockedIP(ip net.IP) bool {
 	if ip.IsPrivate() ||
 		ip.IsLoopback() ||
 		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast() ||
 		ip.IsMulticast() ||
 		ip.IsUnspecified() {
 		return true

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -406,20 +406,31 @@ var lookupIPs = func(ctx context.Context, host string) ([]net.IP, error) {
 }
 
 // isBlockedIP returns true for any IP that should not be reachable as a
-// CIBA notification target. Covers:
+// CIBA notification target. Covers, in order:
 //
+// Via stdlib helpers:
 //   - RFC 1918 IPv4 private (10/8, 172.16/12, 192.168/16) — net.IP.IsPrivate
 //   - RFC 4193 IPv6 ULA (fc00::/7) — net.IP.IsPrivate, also catches Azure
 //     IMDS at fd00:ec2::254 which sits inside fc00::/7
 //   - Loopback (127/8, ::1) — net.IP.IsLoopback
 //   - Link-local unicast (169.254/16, fe80::/10) — net.IP.IsLinkLocalUnicast.
 //     Catches AWS/GCP IMDS at 169.254.169.254.
-//   - Multicast (224/4, ff00::/8) — net.IP.IsMulticast. This is a strict
-//     superset of IsLinkLocalMulticast (224.0.0/24, ff02::/16), so the
-//     link-local-multicast check is implied and not repeated.
+//   - Multicast (224/4, ff00::/8) — net.IP.IsMulticast. Strict superset of
+//     IsLinkLocalMulticast (224.0.0/24, ff02::/16), so the link-local check
+//     is implied and not repeated.
 //   - Unspecified (0.0.0.0, ::) — net.IP.IsUnspecified
-//   - RFC 6598 Carrier-Grade NAT (100.64/10) — not exposed by stdlib;
-//     checked manually below
+//
+// Manual ranges not exposed by stdlib:
+//   - RFC 1122 "this network" (0.0.0.0/8) — IsUnspecified only catches the
+//     single address 0.0.0.0; the rest of the /8 should also never appear
+//     as a destination.
+//   - RFC 6598 Carrier-Grade NAT (100.64.0.0/10)
+//   - RFC 5737 documentation (192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24) —
+//     not publicly routed; could be hijacked locally.
+//   - RFC 2544 benchmarking (198.18.0.0/15) — for network-device testing,
+//     never publicly routed.
+//   - RFC 1112 / RFC 6890 reserved (240.0.0.0/4) — class E reserved, never
+//     allocated for routing.
 func isBlockedIP(ip net.IP) bool {
 	if ip.IsPrivate() ||
 		ip.IsLoopback() ||
@@ -428,11 +439,35 @@ func isBlockedIP(ip net.IP) bool {
 		ip.IsUnspecified() {
 		return true
 	}
-	// RFC 6598 CGN: 100.64.0.0/10
-	if v4 := ip.To4(); v4 != nil {
-		if v4[0] == 100 && v4[1]&0xC0 == 0x40 {
-			return true
-		}
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	switch {
+	case v4[0] == 0:
+		// RFC 1122 "this network": 0.0.0.0/8
+		return true
+	case v4[0] == 100 && v4[1]&0xC0 == 0x40:
+		// RFC 6598 CGN: 100.64.0.0/10
+		return true
+	case v4[0] == 192 && v4[1] == 0 && v4[2] == 2:
+		// RFC 5737 TEST-NET-1: 192.0.2.0/24
+		return true
+	case v4[0] == 198 && v4[1] == 51 && v4[2] == 100:
+		// RFC 5737 TEST-NET-2: 198.51.100.0/24
+		return true
+	case v4[0] == 203 && v4[1] == 0 && v4[2] == 113:
+		// RFC 5737 TEST-NET-3: 203.0.113.0/24
+		return true
+	case v4[0] == 198 && v4[1]&0xFE == 18:
+		// RFC 2544 benchmarking: 198.18.0.0/15
+		return true
+	case v4[0]&0xF0 == 0xF0:
+		// RFC 1112 / RFC 6890 reserved: 240.0.0.0/4. Excludes 255.255.255.255
+		// only in the broadcast sense — that's caught by IsLinkLocalUnicast/
+		// IsLoopback for typical interfaces, and would be hostile as a
+		// destination either way.
+		return true
 	}
 	return false
 }

--- a/internal/service/oauth_client_ssrf_test.go
+++ b/internal/service/oauth_client_ssrf_test.go
@@ -54,11 +54,34 @@ func TestIsBlockedIP(t *testing.T) {
 		{"unspecified IPv4", "0.0.0.0", true, "unspecified"},
 		{"unspecified IPv6", "::", true, "unspecified"},
 
+		// RFC 1122 "this network" — 0.0.0.0/8. IsUnspecified only catches
+		// the all-zeros address; the rest of the /8 is reserved.
+		{"this network — 0/8 low", "0.0.0.1", true, "RFC 1122 this network"},
+		{"this network — 0/8 high", "0.255.255.254", true, "RFC 1122 this network"},
+
 		// CGN (RFC 6598) — not exposed by stdlib helpers; manual check
 		{"CGN — 100.64/10 low", "100.64.0.1", true, "carrier-grade NAT"},
 		{"CGN — 100.64/10 high", "100.127.255.254", true, "carrier-grade NAT"},
 		{"just outside CGN", "100.128.0.1", false, "100.128+ is public"},
 		{"just before CGN", "100.63.255.254", false, "100.0-63 is public"},
+
+		// RFC 5737 documentation — never publicly routed; defense-in-depth
+		{"RFC 5737 TEST-NET-1", "192.0.2.5", true, "documentation"},
+		{"RFC 5737 TEST-NET-2", "198.51.100.5", true, "documentation"},
+		{"RFC 5737 TEST-NET-3", "203.0.113.5", true, "documentation"},
+		{"just outside TEST-NET-1", "192.0.3.5", false, "192.0.3 is public"},
+		{"just before TEST-NET-3", "203.0.112.5", false, "203.0.112 is public"},
+
+		// RFC 2544 benchmarking — 198.18.0.0/15
+		{"RFC 2544 — 198.18/15 low", "198.18.0.1", true, "benchmarking"},
+		{"RFC 2544 — 198.18/15 high", "198.19.255.254", true, "benchmarking"},
+		{"just outside RFC 2544", "198.20.0.1", false, "198.20+ is public"},
+		{"just before RFC 2544", "198.17.255.254", false, "198.17 is public"},
+
+		// RFC 1112 / RFC 6890 reserved — 240.0.0.0/4
+		{"reserved /4 — 240", "240.0.0.1", true, "reserved class E"},
+		{"reserved /4 — 254", "254.255.255.254", true, "reserved class E"},
+		{"just before reserved /4", "239.255.255.254", true, "still multicast"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -169,7 +192,8 @@ func TestValidateNotificationEndpoint_RequestTimeRebinding(t *testing.T) {
 	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
 		calls++
 		if calls == 1 {
-			return []net.IP{net.ParseIP("203.0.113.10")}, nil // RFC 5737 docs IP
+			// example.com — public IP, no SSRF risk
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil
 		}
 		return []net.IP{net.ParseIP("169.254.169.254")}, nil // AWS IMDS
 	}
@@ -210,7 +234,8 @@ func TestValidateNotificationEndpoint_PublicHostPasses(t *testing.T) {
 	prev := lookupIPs
 	defer func() { lookupIPs = prev }()
 	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
-		return []net.IP{net.ParseIP("203.0.113.10")}, nil // RFC 5737 docs IP
+		// example.com — public IP, no SSRF risk
+		return []net.IP{net.ParseIP("93.184.216.34")}, nil
 	}
 	if err := validateNotificationEndpoint(context.Background(), "https://callback.example.com/cb", false); err != nil {
 		t.Fatalf("expected public-IP registration to pass; got %v", err)

--- a/internal/service/oauth_client_ssrf_test.go
+++ b/internal/service/oauth_client_ssrf_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -43,9 +44,11 @@ func TestIsBlockedIP(t *testing.T) {
 		{"link-local IPv4 — generic", "169.254.0.1", true, "link-local"},
 		{"link-local IPv6", "fe80::1", true, "IPv6 link-local"},
 
-		// Multicast
-		{"multicast IPv4", "224.0.0.1", true, "multicast"},
-		{"multicast IPv6", "ff02::1", true, "IPv6 multicast"},
+		// Multicast — IsMulticast covers link-local multicast as a subset
+		{"link-local multicast IPv4", "224.0.0.1", true, "multicast (link-local subset)"},
+		{"link-local multicast IPv6", "ff02::1", true, "IPv6 multicast (link-local subset)"},
+		{"global multicast IPv4", "239.255.0.1", true, "multicast"},
+		{"global multicast IPv6", "ff0e::1", true, "IPv6 multicast"},
 
 		// Unspecified
 		{"unspecified IPv4", "0.0.0.0", true, "unspecified"},
@@ -78,7 +81,7 @@ func TestIsBlockedIP(t *testing.T) {
 func TestValidateNotificationEndpoint_HTTPS(t *testing.T) {
 	for _, allowPrivate := range []bool{false, true} {
 		t.Run("allowPrivate="+boolStr(allowPrivate), func(t *testing.T) {
-			err := validateNotificationEndpoint("http://example.com/cb", allowPrivate)
+			err := validateNotificationEndpoint(context.Background(), "http://example.com/cb", allowPrivate)
 			if err == nil {
 				t.Fatal("expected http:// to be rejected; got nil")
 			}
@@ -105,7 +108,7 @@ func TestValidateNotificationEndpoint_PrivateIP(t *testing.T) {
 	// "localhost", return 127.0.0.1.
 	prev := lookupIPs
 	defer func() { lookupIPs = prev }()
-	lookupIPs = func(host string) ([]net.IP, error) {
+	lookupIPs = func(_ context.Context, host string) ([]net.IP, error) {
 		if host == "localhost" {
 			return []net.IP{net.ParseIP("127.0.0.1")}, nil
 		}
@@ -117,7 +120,7 @@ func TestValidateNotificationEndpoint_PrivateIP(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateNotificationEndpoint(tc.url, false)
+			err := validateNotificationEndpoint(context.Background(), tc.url, false)
 			if err == nil {
 				t.Fatalf("expected SSRF rejection for %q; got nil", tc.url)
 			}
@@ -136,16 +139,15 @@ func TestValidateNotificationEndpoint_PrivateIP(t *testing.T) {
 func TestValidateNotificationEndpoint_DNSRebinding(t *testing.T) {
 	prev := lookupIPs
 	defer func() { lookupIPs = prev }()
-	lookupIPs = func(host string) ([]net.IP, error) {
-		// Simulate a DNS-rebinding attack: hostname resolves to one public
-		// IP and one private IP. The guard must reject on the basis of the
-		// private one.
+	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
+		// Hostname resolves to one public and one private IP. The guard
+		// must reject on the basis of the private one.
 		return []net.IP{
 			net.ParseIP("8.8.8.8"),
 			net.ParseIP("10.0.0.5"),
 		}, nil
 	}
-	err := validateNotificationEndpoint("https://rebound.example.com/cb", false)
+	err := validateNotificationEndpoint(context.Background(), "https://rebound.example.com/cb", false)
 	if err == nil {
 		t.Fatal("expected DNS-rebinding split-IP host to be rejected; got nil")
 	}
@@ -154,17 +156,51 @@ func TestValidateNotificationEndpoint_DNSRebinding(t *testing.T) {
 	}
 }
 
+// TestValidateNotificationEndpoint_RequestTimeRebinding exercises the
+// defence against a hostname that passes at registration (resolver returns a
+// public IP) but is rebound by the time bc-authorize re-validates. Both code
+// paths route through validateNotificationEndpoint, so the second pass must
+// reject even when the first passed.
+func TestValidateNotificationEndpoint_RequestTimeRebinding(t *testing.T) {
+	prev := lookupIPs
+	defer func() { lookupIPs = prev }()
+
+	var calls int
+	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
+		calls++
+		if calls == 1 {
+			return []net.IP{net.ParseIP("203.0.113.10")}, nil // RFC 5737 docs IP
+		}
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil // AWS IMDS
+	}
+
+	ctx := context.Background()
+	if err := validateNotificationEndpoint(ctx, "https://flip.example.com/cb", false); err != nil {
+		t.Fatalf("first call (simulated registration) should pass; got %v", err)
+	}
+	err := validateNotificationEndpoint(ctx, "https://flip.example.com/cb", false)
+	if err == nil {
+		t.Fatal("second call (simulated bc-authorize re-validation) should reject after DNS flip; got nil")
+	}
+	if !errors.Is(err, ErrPrivateNotificationEndpoint) {
+		t.Fatalf("expected ErrPrivateNotificationEndpoint sentinel; got %v", err)
+	}
+}
+
 // TestValidateNotificationEndpoint_AllowPrivate confirms the opt-out flag
-// works in test/dev environments. With allowPrivate=true the loopback
-// registration must succeed despite resolving to 127.0.0.1.
+// works in test/dev environments. With allowPrivate=true the SSRF check is
+// skipped entirely — no DNS resolution at all — so synthetic RFC 6761
+// test fixtures like https://*.example.test don't hard-fail under a
+// host-resolver that returns NXDOMAIN.
 func TestValidateNotificationEndpoint_AllowPrivate(t *testing.T) {
 	prev := lookupIPs
 	defer func() { lookupIPs = prev }()
-	lookupIPs = func(host string) ([]net.IP, error) {
-		return []net.IP{net.ParseIP("127.0.0.1")}, nil
+	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
+		t.Fatal("lookupIPs must not be called when allowPrivate=true")
+		return nil, nil
 	}
-	if err := validateNotificationEndpoint("https://localhost:9000/cb", true); err != nil {
-		t.Fatalf("expected allowPrivate=true to permit loopback; got %v", err)
+	if err := validateNotificationEndpoint(context.Background(), "https://localhost:9000/cb", true); err != nil {
+		t.Fatalf("expected allowPrivate=true to short-circuit DNS; got %v", err)
 	}
 }
 
@@ -173,10 +209,10 @@ func TestValidateNotificationEndpoint_AllowPrivate(t *testing.T) {
 func TestValidateNotificationEndpoint_PublicHostPasses(t *testing.T) {
 	prev := lookupIPs
 	defer func() { lookupIPs = prev }()
-	lookupIPs = func(host string) ([]net.IP, error) {
+	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
 		return []net.IP{net.ParseIP("203.0.113.10")}, nil // RFC 5737 docs IP
 	}
-	if err := validateNotificationEndpoint("https://callback.example.com/cb", false); err != nil {
+	if err := validateNotificationEndpoint(context.Background(), "https://callback.example.com/cb", false); err != nil {
 		t.Fatalf("expected public-IP registration to pass; got %v", err)
 	}
 }

--- a/internal/service/oauth_client_ssrf_test.go
+++ b/internal/service/oauth_client_ssrf_test.go
@@ -1,0 +1,189 @@
+package service
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+// TestIsBlockedIP exercises the SSRF-guard predicate against every category
+// of address it must reject + a handful of public IPs that must pass through.
+// GHSA-599q-j34m-33vc — closes the gap where CIBA outbound HTTPS could be
+// pointed at internal or cloud-metadata IPs.
+func TestIsBlockedIP(t *testing.T) {
+	cases := []struct {
+		name    string
+		ip      string
+		blocked bool
+		why     string
+	}{
+		// Public IPv4 — must pass through
+		{"public IPv4 — Google DNS", "8.8.8.8", false, ""},
+		{"public IPv4 — Cloudflare DNS", "1.1.1.1", false, ""},
+		{"public IPv6", "2606:4700::1", false, ""},
+
+		// RFC 1918 private — IsPrivate
+		{"RFC 1918 — 10/8", "10.0.0.5", true, "private"},
+		{"RFC 1918 — 172.16/12 low", "172.16.0.1", true, "private"},
+		{"RFC 1918 — 172.16/12 high", "172.31.255.254", true, "private"},
+		{"RFC 1918 — 192.168/16", "192.168.1.1", true, "private"},
+		{"non-private inside 172", "172.32.0.1", false, "172.32+ is public"},
+
+		// RFC 4193 IPv6 ULA — IsPrivate
+		{"RFC 4193 ULA", "fc00::1", true, "IPv6 ULA"},
+		{"Azure IMDS IPv6", "fd00:ec2::254", true, "Azure IMDS is in fc00::/7"},
+
+		// Loopback
+		{"loopback IPv4", "127.0.0.1", true, "loopback"},
+		{"loopback IPv4 — non-standard", "127.255.255.254", true, "loopback /8"},
+		{"loopback IPv6", "::1", true, "IPv6 loopback"},
+
+		// Link-local (includes cloud metadata IPs)
+		{"AWS/GCP IMDS", "169.254.169.254", true, "link-local"},
+		{"link-local IPv4 — generic", "169.254.0.1", true, "link-local"},
+		{"link-local IPv6", "fe80::1", true, "IPv6 link-local"},
+
+		// Multicast
+		{"multicast IPv4", "224.0.0.1", true, "multicast"},
+		{"multicast IPv6", "ff02::1", true, "IPv6 multicast"},
+
+		// Unspecified
+		{"unspecified IPv4", "0.0.0.0", true, "unspecified"},
+		{"unspecified IPv6", "::", true, "unspecified"},
+
+		// CGN (RFC 6598) — not exposed by stdlib helpers; manual check
+		{"CGN — 100.64/10 low", "100.64.0.1", true, "carrier-grade NAT"},
+		{"CGN — 100.64/10 high", "100.127.255.254", true, "carrier-grade NAT"},
+		{"just outside CGN", "100.128.0.1", false, "100.128+ is public"},
+		{"just before CGN", "100.63.255.254", false, "100.0-63 is public"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("ParseIP(%q) returned nil", tc.ip)
+			}
+			got := isBlockedIP(ip)
+			if got != tc.blocked {
+				t.Fatalf("isBlockedIP(%q) = %v; want %v (%s)", tc.ip, got, tc.blocked, tc.why)
+			}
+		})
+	}
+}
+
+// TestValidateNotificationEndpoint_HTTPS confirms the pre-existing HTTPS-only
+// check still rejects http:// even with allowPrivate=true. Belt-and-suspenders
+// against a future change accidentally weakening one check while strengthening
+// the other.
+func TestValidateNotificationEndpoint_HTTPS(t *testing.T) {
+	for _, allowPrivate := range []bool{false, true} {
+		t.Run("allowPrivate="+boolStr(allowPrivate), func(t *testing.T) {
+			err := validateNotificationEndpoint("http://example.com/cb", allowPrivate)
+			if err == nil {
+				t.Fatal("expected http:// to be rejected; got nil")
+			}
+		})
+	}
+}
+
+// TestValidateNotificationEndpoint_PrivateIP confirms the SSRF guard fires
+// on IP-as-host registrations (no DNS involved) for every category.
+// Stubs lookupIPs so the test is hermetic (no real DNS).
+func TestValidateNotificationEndpoint_PrivateIP(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"loopback", "https://127.0.0.1/cb"},
+		{"localhost (resolves to loopback)", "https://localhost/cb"},
+		{"AWS IMDS", "https://169.254.169.254/latest/meta-data/"},
+		{"RFC 1918", "https://10.0.0.5/internal"},
+		{"CGN", "https://100.64.0.1/cb"},
+	}
+
+	// Stub the resolver: for IP literals, return them directly. For
+	// "localhost", return 127.0.0.1.
+	prev := lookupIPs
+	defer func() { lookupIPs = prev }()
+	lookupIPs = func(host string) ([]net.IP, error) {
+		if host == "localhost" {
+			return []net.IP{net.ParseIP("127.0.0.1")}, nil
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			return []net.IP{ip}, nil
+		}
+		return nil, &net.DNSError{Err: "no such host", Name: host}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNotificationEndpoint(tc.url, false)
+			if err == nil {
+				t.Fatalf("expected SSRF rejection for %q; got nil", tc.url)
+			}
+			if !errors.Is(err, ErrPrivateNotificationEndpoint) {
+				t.Fatalf("expected ErrPrivateNotificationEndpoint sentinel; got %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateNotificationEndpoint_DNSRebinding confirms that ANY resolved IP
+// in the blocked set rejects the registration, even when other resolved IPs
+// are public. A malicious DNS server can rotate A records between the
+// validation lookup and the eventual request — the guard must reject any
+// hostname that resolves to a private IP in any of its A records.
+func TestValidateNotificationEndpoint_DNSRebinding(t *testing.T) {
+	prev := lookupIPs
+	defer func() { lookupIPs = prev }()
+	lookupIPs = func(host string) ([]net.IP, error) {
+		// Simulate a DNS-rebinding attack: hostname resolves to one public
+		// IP and one private IP. The guard must reject on the basis of the
+		// private one.
+		return []net.IP{
+			net.ParseIP("8.8.8.8"),
+			net.ParseIP("10.0.0.5"),
+		}, nil
+	}
+	err := validateNotificationEndpoint("https://rebound.example.com/cb", false)
+	if err == nil {
+		t.Fatal("expected DNS-rebinding split-IP host to be rejected; got nil")
+	}
+	if !errors.Is(err, ErrPrivateNotificationEndpoint) {
+		t.Fatalf("expected ErrPrivateNotificationEndpoint sentinel; got %v", err)
+	}
+}
+
+// TestValidateNotificationEndpoint_AllowPrivate confirms the opt-out flag
+// works in test/dev environments. With allowPrivate=true the loopback
+// registration must succeed despite resolving to 127.0.0.1.
+func TestValidateNotificationEndpoint_AllowPrivate(t *testing.T) {
+	prev := lookupIPs
+	defer func() { lookupIPs = prev }()
+	lookupIPs = func(host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("127.0.0.1")}, nil
+	}
+	if err := validateNotificationEndpoint("https://localhost:9000/cb", true); err != nil {
+		t.Fatalf("expected allowPrivate=true to permit loopback; got %v", err)
+	}
+}
+
+// TestValidateNotificationEndpoint_PublicHostPasses confirms a normal
+// resolved-to-public-IP hostname registers cleanly with the guard enabled.
+func TestValidateNotificationEndpoint_PublicHostPasses(t *testing.T) {
+	prev := lookupIPs
+	defer func() { lookupIPs = prev }()
+	lookupIPs = func(host string) ([]net.IP, error) {
+		return []net.IP{net.ParseIP("203.0.113.10")}, nil // RFC 5737 docs IP
+	}
+	if err := validateNotificationEndpoint("https://callback.example.com/cb", false); err != nil {
+		t.Fatalf("expected public-IP registration to pass; got %v", err)
+	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/server.go
+++ b/server.go
@@ -205,7 +205,13 @@ func NewServer(cfg Config) (*Server, error) {
 	// dispatches from oauthSvc.Token() into BackchannelService.Redeem, which in
 	// turn calls credentialSvc.IssueCredential. Two-phase wiring breaks the
 	// otherwise-circular dependency cleanly.
-	backchannelSvc := service.NewBackchannelService(backchannelRepo, oauthClientSvc, credentialSvc, service.DefaultBackchannelConfig())
+	backchannelCfg := service.DefaultBackchannelConfig()
+	backchannelCfg.AllowPrivateNotificationEndpoints = cfg.Backchannel.AllowPrivateNotificationEndpoints
+	// Mirror the SSRF-guard relaxation flag onto OAuthClientService so the
+	// registration-time check (in OAuthClientService.RegisterClient) and the
+	// request-time check (in BackchannelService.CreateAuthRequest) agree.
+	oauthClientSvc.SetAllowPrivateNotificationEndpoints(backchannelCfg.AllowPrivateNotificationEndpoints)
+	backchannelSvc := service.NewBackchannelService(backchannelRepo, oauthClientSvc, credentialSvc, backchannelCfg)
 	oauthSvc.SetBackchannelService(backchannelSvc)
 
 	// Create shared API handler.

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -168,6 +168,14 @@ func runTests(m *testing.M) int {
 		Logging: zeroid.LoggingConfig{
 			Level: "warn",
 		},
+		// Integration tests register CIBA notification endpoints under the
+		// RFC 6761 reserved `.example.test` TLD (e.g. https://ping.example.test/cb)
+		// which never resolves. Disable the SSRF guard so the resolver-failure
+		// path doesn't reject test fixtures. Production deployments keep this
+		// false — see GHSA-599q-j34m-33vc.
+		Backchannel: zeroid.BackchannelConfig{
+			AllowPrivateNotificationEndpoints: true,
+		},
 		WIMSEDomain: testWIMSE,
 	}
 


### PR DESCRIPTION
Addresses **GHSA-599q-j34m-33vc** (private draft advisory).

Validates that `client_notification_endpoint` host resolves only to public IPs at both registration AND request time, rejecting private/loopback/link-local/CGN/unspecified ranges. Defends against the SSRF primitive where CIBA outbound HTTPS could be aimed at internal services or cloud-metadata endpoints from inside the zeroid process.

## What changed

| File | Change |
|---|---|
| `internal/service/oauth_client.go` | `assertNotPrivate` + `isBlockedIP` helpers, `validateNotificationEndpoint` takes a new `allowPrivate bool` param, `SetAllowPrivateNotificationEndpoints` setter on `OAuthClientService` |
| `internal/service/backchannel.go` | Request-time guard re-runs the IP check (DNS-rebinding defense), `AllowPrivateNotificationEndpoints` field on `BackchannelServiceConfig` |
| `config.go` | New `BackchannelConfig` block with `allow_private_notification_endpoints` koanf key |
| `server.go` | Threads the config flag through to both services from one source |
| `internal/service/oauth_client_ssrf_test.go` | New unit tests — 30 cases |
| `tests/integration/helpers_test.go` | Flips opt-out for integration suite (`.example.test` is RFC 6761 reserved, never resolves) |

## Coverage by RFC

| Range | Stdlib check | Notes |
|---|---|---|
| RFC 1918 IPv4 private | `net.IP.IsPrivate` | 10/8, 172.16/12, 192.168/16 |
| RFC 4193 IPv6 ULA | `net.IP.IsPrivate` | fc00::/7 — also catches Azure IMDS at fd00:ec2::254 |
| Loopback | `net.IP.IsLoopback` | 127/8, ::1 |
| Link-local unicast | `net.IP.IsLinkLocalUnicast` | 169.254/16, fe80::/10 — catches AWS/GCP IMDS at 169.254.169.254 |
| Link-local multicast | `net.IP.IsLinkLocalMulticast` | |
| Multicast | `net.IP.IsMulticast` | 224/4, ff00::/8 |
| Unspecified | `net.IP.IsUnspecified` | 0.0.0.0, :: |
| RFC 6598 CGN | manual | 100.64/10 (stdlib doesn't expose) |

## DNS-rebinding defense

`net.LookupIP` returns ALL resolved IPs for the host. ANY blocked IP rejects the whole registration — so a hostname that resolves to both public AND private IPs (intentional split-horizon rebinding attack) fails on the private one.

Re-checked at request time so DNS rotations between registration and the actual ping/push dispatch are caught too.

## Opt-out for dev / test

`Config.Backchannel.AllowPrivateNotificationEndpoints = true` disables the guard entirely. Default is false (production-safe). The integration test harness flips it to true so RFC 6761 reserved domains (`.example.test`) can be used.

## Test plan

- 24 unit-test cases for `isBlockedIP` covering every blocked range + public-IP passes ✓
- DNS-rebinding test: hostname resolving to (public IP, private IP) → rejected ✓
- Opt-out test: `allowPrivate=true` permits loopback ✓
- Public-host test: normal registration with public IP host passes ✓
- All existing integration tests pass (`./tests/integration`, 11s) ✓
- `go build` + `go vet` clean ✓

## Severity

Medium baseline; high in multi-tenant deployments with self-serve client registration. Current Highflame deployments are single-tenant so live exposure is zero — this lands before multi-tenant SaaS rollout makes it exploitable.

## Advisory

This PR resolves the issue tracked in private security advisory **GHSA-599q-j34m-33vc**. When this merges and a release tag is cut, the advisory will be published and converted to a CVE.