### PR TITLE
docs: move CIBA from Planned to Released, add usage pattern (closes #136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ OAuth/OIDC authenticates a human to a service. **ZeroID implements true delegate
 ## Features
 
 - **Agent Identity Registry** — Register agents, MCP servers, services, and applications as first-class entities. Classify by role (`orchestrator`, `autonomous`, `tool_agent`), enrich with metadata (`framework`, `version`, `publisher`, `capabilities`), assign trust levels, and manage the full lifecycle: register → activate → deactivate → de-provision.
-- **OAuth 2.1 Token Issuance** — Full OAuth 2.1 support: `client_credentials`, `jwt_bearer` (RFC 7523), `token_exchange` (RFC 8693) for delegation, `api_key`, `authorization_code` (PKCE), `refresh_token`.
+- **OAuth 2.1 Token Issuance** — Full OAuth 2.1 support: `client_credentials`, `jwt_bearer` (RFC 7523), `token_exchange` (RFC 8693) for delegation, `api_key`, `authorization_code` (PKCE), `refresh_token`, `urn:openid:params:grant-type:ciba` (OpenID CIBA Core 1.0).
+- **CIBA Backchannel Approval** — OpenID Client-Initiated Backchannel Authentication (CIBA Core 1.0). Agent posts to `/oauth2/bc-authorize` with a `binding_message`; the deployer's `BackchannelNotifier` prompts the end user out-of-band (email, Slack, mobile push); user approves or denies; agent receives the resulting token via poll, ping callback, or push delivery. SSRF-guarded outbound callbacks, per-tenant audit, single-use `auth_req_id`s.
 - **On-Behalf-Of (OBO) Delegation** — RFC 8693 token exchange with automatic scope attenuation at each hop, delegation depth tracking, and cascade revocation when any upstream credential is revoked. The `act` claim carries the full chain per RFC 8693, closing the auditability gap that plagues shared service accounts.
 - **WIMSE/SPIFFE URIs** — Stable, globally unique identity URIs: `spiffe://{domain}/{account}/{project}/{type}/{id}` for every agent. Tokens carry the WIMSE URI as `sub`, so every downstream system receives a meaningful, verifiable identity—not just a client ID.
 - **Credential Policies** — Governance templates that enforce TTL, allowed grant types, required trust levels, and max delegation depth. Defines each agent's operational envelope programmatically, replacing per-action consent with policy-based controls.
@@ -110,6 +111,7 @@ ZeroID covers every agentic deployment pattern — from a single autonomous agen
 | **Multi-hop agent chain** | `token_exchange` chained | No | Sub-agent delegates further to a tool agent (depth 2), and so on. `delegation_depth` increments at each hop. `CredentialPolicy.max_delegation_depth` caps how far the chain can go. The full `act` claim chain is preserved at every level. |
 | **Service-to-service (no user context)** | `client_credentials` | No | Agent authenticates as itself with no user association. Used for background jobs, scheduled tasks, and internal services where no human delegation chain exists. |
 | **Long-running / async agent** | `refresh_token` | No | Agent refreshes its access token without re-authenticating. Used for agents executing multi-day workflows where the original access token would otherwise expire. |
+| **Out-of-band user approval** | `urn:openid:params:grant-type:ciba` (OpenID CIBA Core 1.0) | Yes, asynchronous | Agent calls `/oauth2/bc-authorize` with `login_hint` + `binding_message`. The deployer's `BackchannelNotifier` prompts the user out-of-band (email, Slack, mobile push). User approves or denies. Agent retrieves the token via poll, ping callback, or push delivery. Token `sub` = approving user; `backchannel_client_id` identifies the initiating agent. |
 
 **Revocation works across all flows.** A single `revoke` call on any token in a chain invalidates it and everything downstream, in real time.
 
@@ -660,6 +662,50 @@ def handle_query_database(request_headers: dict, query: str) -> dict:
 
 ---
 
+### Pattern 6: Agent pauses for out-of-band user approval (CIBA)
+
+**Scenario:** An autonomous agent needs to perform a high-trust action — read a user's email, transfer money, deploy to production — and must obtain real-time consent from the human owner before proceeding. The agent and the human are not in the same session; the human may not even be online when the agent starts.
+
+**The problem without ZeroID:** There is no standard way for a backend agent to request "ask the user" without standing up a custom approval queue, push-notification pipeline, and reconciliation logic. Most teams hand-roll this and end up with no audit trail.
+
+**With ZeroID:** OpenID CIBA Core 1.0 is the standard for this. The agent posts to `/oauth2/bc-authorize` with a `binding_message` describing the action. The deployer's `BackchannelNotifier` delivers the prompt out-of-band (email, Slack, mobile push). When the user approves, the agent retrieves a scoped, audit-trailed token via poll, ping callback, or push delivery.
+
+```bash
+# 1. Agent initiates the request — supplies the user identifier (login_hint),
+#    requested scope, and a human-readable binding_message the user will see
+#    in the approval prompt.
+curl -s -X POST https://auth.highflame.ai/oauth2/bc-authorize \
+  -d 'client_id=alice-agent' \
+  -d 'login_hint=alice@example.com' \
+  -d 'scope=gmail:read' \
+  -d 'binding_message=alice-agent wants to read your unread Gmail'
+# → {"auth_req_id":"…","expires_in":300,"interval":5}
+
+# 2. Deployer's BackchannelNotifier (configured via Server.SetBackchannelNotifier)
+#    pushes an approval prompt to Alice — typically email or Slack with
+#    one-click Approve / Deny buttons.
+
+# 3. Agent polls /oauth2/token until the user resolves the request. Poll
+#    returns one of: authorization_pending, slow_down, access_denied,
+#    expired_token, or — on approval — the access token.
+curl -s -X POST https://auth.highflame.ai/oauth2/token \
+  -d 'grant_type=urn:openid:params:grant-type:ciba' \
+  -d 'auth_req_id=<auth_req_id>' \
+  -d 'client_id=alice-agent'
+# After Alice approves:
+# {
+#   "access_token": "...",       ← sub = alice@example.com, backchannel_client_id = alice-agent
+#   "token_type": "Bearer",
+#   "expires_in": 900
+# }
+```
+
+**Ping mode** delivers a callback to the client's registered `client_notification_endpoint` the moment the user resolves — agents that don't want to poll can wait for the ping and then call `/oauth2/token` once. **Push mode** delivers the full access token to the callback directly. Both modes require `backchannel_token_delivery_mode` set on the client at registration; the callback endpoint is SSRF-guarded.
+
+**Why this matters:** Every CIBA approval produces a token whose `sub` is the approving user and whose `backchannel_client_id` claim identifies the agent that asked. Downstream systems get a real, attributable consent trail — "alice-agent acted with Alice's explicit approval at 14:32, with binding message X" — without you building approval infrastructure.
+
+---
+
 ## Architecture
 
 ```mermaid
@@ -667,7 +713,7 @@ graph TD
     subgraph ZEROID ["ZeroID"]
         direction TB
         IR[Identity Registry] --> CS[Credential Service<br/><i>ES256 signing · Policy enforcement · Audit</i>]
-        OG[OAuth2 Grants<br/><i>client_credentials · jwt_bearer · api_key<br/>authorization_code · refresh_token</i>] --> CS
+        OG[OAuth2 Grants<br/><i>client_credentials · jwt_bearer · api_key<br/>authorization_code · refresh_token · ciba</i>] --> CS
         DL[Delegation Engine<br/><i>RFC 8693 token_exchange</i>] --> CS
 
         CS --> AT[Attestation]
@@ -703,6 +749,7 @@ graph TD
 | Delegated (`token_exchange`) | ES256 | 1 hour | Sub-agent WIMSE URI | `act.sub` = orchestrator URI |
 | CLI (`authorization_code`) | RS256 | 90 days | User ID | — |
 | MCP (`authorization_code` + refresh) | RS256 | 1 hour | User ID | — |
+| CIBA (`urn:openid:params:grant-type:ciba`) | RS256 | 15 min | Approving user ID | `email`, `name`, `backchannel_client_id`, `token_exchange="ciba"` |
 
 ---
 
@@ -716,12 +763,15 @@ graph TD
 | GET | `/ready` | Readiness check |
 | GET | `/.well-known/jwks.json` | JWKS public keys |
 | GET | `/.well-known/oauth-authorization-server` | OAuth2 server metadata |
-| POST | `/oauth2/token` | Issue token (6 grant types) |
+| POST | `/oauth2/token` | Issue token (7 grant types, including `urn:openid:params:grant-type:ciba`) |
 | POST | `/oauth2/token/introspect` | Token introspection (RFC 7662) |
 | POST | `/oauth2/token/revoke` | Token revocation (RFC 7009) |
+| POST | `/oauth2/bc-authorize` | CIBA backchannel authorization request (OpenID CIBA Core §7) |
 | GET | `/oauth2/token/verify` | Forward-auth endpoint for reverse proxies (nginx `auth_request`, Caddy `forward_auth`) |
 
-### Admin (`/api/v1/*` — protect at network layer)
+### Admin (protect at network layer)
+
+Most admin endpoints live under `/api/v1/*`; the CIBA approve/deny endpoints sit under `/oauth2/bc-authorize/{auth_req_id}/*` because the deployer's user-auth gateway authenticates the end user before forwarding to them.
 
 | Method | Path | Description |
 |--------|------|-------------|
@@ -751,6 +801,8 @@ graph TD
 | GET | `/api/v1/signals/stream` | SSE signal stream |
 | POST | `/api/v1/proofs/generate` | Generate WIMSE proof token |
 | POST | `/api/v1/proofs/verify` | Verify WIMSE proof token |
+| POST | `/oauth2/bc-authorize/{auth_req_id}/approve` | Approve a pending CIBA request (tenant-scoped) |
+| POST | `/oauth2/bc-authorize/{auth_req_id}/deny` | Deny a pending CIBA request (tenant-scoped) |
 
 Full interactive docs at `GET /docs` when running.
 
@@ -774,6 +826,7 @@ References: [OpenID Agentic AI](https://openid.net/wp-content/uploads/2025/10/Id
 | WIMSE / SPIFFE | IETF Draft | Agent workload identity URIs |
 | Shared Signals Framework (SSF) | OpenID SSF | Real-time revocation event propagation |
 | CAEP | OpenID CAEP | Continuous access evaluation signals |
+| CIBA | OpenID CIBA Core 1.0 | Out-of-band user approval for agent-initiated actions (poll / ping / push) |
 
 ---
 
@@ -786,9 +839,9 @@ References: [OpenID Agentic AI](https://openid.net/wp-content/uploads/2025/10/Id
 - Structured errors — `ZeroIDError.code` / `.message` / `.status` with OAuth2 error codes across all three SDKs
 - Coding agent task claims — `session_id`, `task_id`, `task_type`, `allowed_tools`, `workspace`, `environment` as typed fields on `ZeroIDIdentity`; `has_tool()` helper alongside `has_scope()`
 - Ecosystem integrations (LangGraph, CrewAI, Strands)
+- **CIBA (Client-Initiated Backchannel Authentication)** — full OpenID CIBA Core 1.0 server-side flow with poll, ping, and push delivery modes; deployer-pluggable `BackchannelNotifier` for out-of-band user prompts (email, Slack, push); SSRF-guarded outbound callbacks
 
 **Planned**
-- CIBA (Client-Initiated Backchannel Authentication) — agents pause long-running workflows and request out-of-band user authorization without blocking
 - Human-in-the-loop approval workflow (`/api/v1/approvals`)
 - `zeroid` CLI
 - GitHub Actions OIDC upstream validator — stamp `environment=ci` claims verified against GitHub's JWKS


### PR DESCRIPTION
## Summary

CIBA poll/ping/push (#131, #132, #133) + the SSRF guard on outbound notification callbacks (#143) are all on main. The README still listed CIBA under \"Planned\". This PR closes #136 by bringing the README in sync with what the server actually does today, and adds a curl-based usage example as the issue requested.

## What changed in README.md

- **Features list**: extend the OAuth 2.1 grants line + add a dedicated CIBA Backchannel Approval bullet
- **Supported Agent Flows table**: new row \"Out-of-band user approval\" for the CIBA grant
- **Architecture diagram**: add `ciba` to the OAuth2 Grants box
- **Token characteristics table**: new row for the CIBA grant (RS256, 15 min TTL, sub = approving user, `backchannel_client_id` + `token_exchange=\"ciba\"` claims)
- **Public API table**: bump \"Issue token (6 grant types)\" → 7; add `POST /oauth2/bc-authorize`
- **Admin API table**: loosen the section header so it no longer claims everything lives under `/api/v1/*`; add both CIBA approve/deny rows with a short note on why they're scoped under `/oauth2/...`
- **Real-World Patterns**: new \"Pattern 6: Agent pauses for out-of-band user approval (CIBA)\" with a curl walkthrough of bc-authorize → notifier → poll, and a note on ping/push delivery modes
- **Standards table**: new CIBA row
- **Roadmap**: move CIBA from Planned into Released

## Commit prefix

`docs:` per highflame-workflow's commit-prefix check. Goreleaser filters `docs:` commits out of release notes — intentional here because CIBA shipping is already visible in the release body via #131/#132/#133's `feat:` commits.

## Test plan

- [x] `grep -n CIBA README.md` — every relevant table, list, and section has a CIBA row or mention
- [x] Markdown syntax double-checked (tables align, code fence closes, no stray heading levels)
- [ ] GitHub Markdown preview on this PR — visually verify the new Pattern 6 code block renders and the table rows align with siblings

## Related

- Closes #136
- Builds on #131, #132, #133, #143 (all merged)