### PR TITLE
feat(cli): add CIBA helper commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -8,6 +8,8 @@ npm install -g @highflame/zeroid
 npx @highflame/zeroid <command>
 ```
 
+The package also installs `zid` as a short alias for `zeroid`.
+
 ---
 
 ## Quick start
@@ -196,6 +198,126 @@ zeroid token revoke eyJhbGc...
 |---|---|
 | `--profile <name>` | Profile to use |
 | `--json` | Output raw JSON response |
+
+---
+
+### `zeroid ciba init`
+
+Initiate an OpenID CIBA backchannel authentication request. The CLI sends tenant context in the request body because `/oauth2/bc-authorize` is a public OAuth endpoint.
+
+```bash
+zeroid ciba init \
+  --client-id my-ciba-client \
+  --login-hint user@example.com \
+  --scope "openid profile" \
+  --binding-message "Approve login on Production?" \
+  --requested-expiry 600
+```
+
+For ping or push clients, include the per-request bearer token:
+
+```bash
+zeroid ciba init \
+  --client-id my-ciba-client \
+  --login-hint user@example.com \
+  --client-notification-token opaque-token
+```
+
+| Flag | Description | Default |
+|---|---|---|
+| `--client-id <id>` | OAuth client initiating the request | required |
+| `--login-hint <hint>` | User identifier for the out-of-band prompt | required |
+| `--scope <scopes>` | Space-separated scopes to request | — |
+| `--binding-message <text>` | Context shown to the approving user | — |
+| `--requested-expiry <seconds>` | Requested auth request lifetime | server default |
+| `--client-notification-token <token>` | Required for ping/push delivery clients | — |
+| `--profile <name>` | Profile to use for tenant/base URL | active profile |
+| `--json` | Output raw JSON | — |
+
+**Output:**
+```
+✓  CIBA request initiated
+  auth_req_id: ari_...
+  expires_in:  300s
+  interval:    5s
+```
+
+---
+
+### `zeroid ciba approve <auth_req_id>`
+
+Admin-side helper to approve a pending CIBA request in local demos and test environments.
+
+```bash
+zeroid ciba approve ari_... \
+  --subject-id user@example.com \
+  --subject-email user@example.com \
+  --subject-name "Alice User"
+```
+
+| Flag | Description |
+|---|---|
+| `--subject-id <id>` | Approved end-user identifier; becomes the token `sub` |
+| `--subject-email <email>` | Approved user's email |
+| `--subject-name <name>` | Approved user's display name |
+| `--profile <name>` | Profile to use |
+| `--json` | Output raw JSON |
+
+---
+
+### `zeroid ciba deny <auth_req_id>`
+
+Admin-side helper to deny a pending CIBA request.
+
+```bash
+zeroid ciba deny ari_... --reason "user rejected"
+```
+
+| Flag | Description |
+|---|---|
+| `--reason <text>` | Operator note sent when supported by the server |
+| `--profile <name>` | Profile to use |
+| `--json` | Output raw JSON |
+
+---
+
+### `zeroid ciba poll <auth_req_id>`
+
+Poll `/oauth2/token` with the CIBA grant type until the user approves or denies.
+
+```bash
+zeroid ciba poll ari_... --client-id my-ciba-client
+zeroid ciba poll ari_... --client-id my-ciba-client --watch --interval 5
+zeroid ciba poll ari_... --client-id my-ciba-client --json
+```
+
+| Flag | Description | Default |
+|---|---|---|
+| `--client-id <id>` | OAuth client that initiated the request | required |
+| `--watch` | Keep polling through `authorization_pending` / `slow_down` | off |
+| `--interval <seconds>` | Polling interval for `--watch` | `5` |
+| `--profile <name>` | Profile to use for base URL | active profile |
+| `--json` | Output raw JSON | — |
+
+On success, the command prints the access token. Without `--watch`, OAuth polling errors such as `authorization_pending`, `slow_down`, `access_denied`, and `expired_token` are printed and return exit code `1`.
+
+---
+
+### `zeroid ciba listen`
+
+Run a local HTTPS callback capture endpoint for CIBA ping and push testing. The command creates a self-signed localhost certificate in `~/.zid/ciba-cert/` on first run.
+
+```bash
+zeroid ciba listen --port 8888
+```
+
+Use `https://localhost:8888/cb` as the OAuth client's `client_notification_endpoint` while developing locally. Localhost callbacks require the ZeroID server to allow private notification endpoints in its backchannel configuration.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--port <port>` | HTTPS port to listen on | `8888` |
+| `--host <host>` | Host to bind | `localhost` |
+| `--json` | Output newline-delimited JSON events | off |
 
 ---
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -253,6 +253,11 @@ zeroid ciba approve ari_... \
   --subject-id user@example.com \
   --subject-email user@example.com \
   --subject-name "Alice User"
+
+# Highflame AuthN-style deployments with admin routes mounted at the base URL:
+ZID_INTERNAL_SERVICE=highflame-admin \
+ZID_INTERNAL_SERVICE_SECRET=... \
+zeroid ciba approve ari_... --subject-id user@example.com --admin-prefix ""
 ```
 
 | Flag | Description |
@@ -260,8 +265,14 @@ zeroid ciba approve ari_... \
 | `--subject-id <id>` | Approved end-user identifier; becomes the token `sub` |
 | `--subject-email <email>` | Approved user's email |
 | `--subject-name <name>` | Approved user's display name |
+| `--admin-base-url <url>` | Admin API base URL; defaults to `ZID_ADMIN_BASE_URL` or the profile base URL |
+| `--admin-prefix <path>` | Admin route prefix before `/oauth2/bc-authorize`; defaults to `ZID_ADMIN_PREFIX` or `/api/v1` |
+| `--internal-service <name>` | Adds `X-Internal-Service`; defaults to `ZID_INTERNAL_SERVICE` |
+| `--internal-service-secret <secret>` | Adds `X-Internal-Service-Secret`; defaults to `ZID_INTERNAL_SERVICE_SECRET` |
 | `--profile <name>` | Profile to use |
 | `--json` | Output raw JSON |
+
+Use `--admin-prefix ""` for deployers such as Highflame AuthN that mount ZeroID admin routes directly under the configured base URL. Standalone ZeroID keeps the default `/api/v1` prefix.
 
 ---
 
@@ -271,11 +282,19 @@ Admin-side helper to deny a pending CIBA request.
 
 ```bash
 zeroid ciba deny ari_... --reason "user rejected"
+
+ZID_INTERNAL_SERVICE=highflame-admin \
+ZID_INTERNAL_SERVICE_SECRET=... \
+zeroid ciba deny ari_... --reason "user rejected" --admin-prefix ""
 ```
 
 | Flag | Description |
 |---|---|
 | `--reason <text>` | Operator note sent when supported by the server |
+| `--admin-base-url <url>` | Admin API base URL; defaults to `ZID_ADMIN_BASE_URL` or the profile base URL |
+| `--admin-prefix <path>` | Admin route prefix before `/oauth2/bc-authorize`; defaults to `ZID_ADMIN_PREFIX` or `/api/v1` |
+| `--internal-service <name>` | Adds `X-Internal-Service`; defaults to `ZID_INTERNAL_SERVICE` |
+| `--internal-service-secret <secret>` | Adds `X-Internal-Service-Secret`; defaults to `ZID_INTERNAL_SERVICE_SECRET` |
 | `--profile <name>` | Profile to use |
 | `--json` | Output raw JSON |
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -305,7 +305,7 @@ On success, the command prints the access token. Without `--watch`, OAuth pollin
 
 ### `zeroid ciba listen`
 
-Run a local HTTPS callback capture endpoint for CIBA ping and push testing. The command creates a self-signed localhost certificate in `~/.zid/ciba-cert/` on first run.
+Run a local HTTPS callback capture endpoint for CIBA ping and push testing. The command creates a self-signed localhost certificate in `~/.config/zeroid/ciba-cert/` on first run.
 
 ```bash
 zeroid ciba listen --port 8888

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -14,7 +14,8 @@
         "commander": "^13.1.0"
       },
       "bin": {
-        "zeroid": "dist/index.js"
+        "zeroid": "dist/index.js",
+        "zid": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^20",

--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,8 @@
   "description": "CLI for ZeroID — agent identity for AI systems",
   "type": "module",
   "bin": {
-    "zeroid": "./dist/index.js"
+    "zeroid": "./dist/index.js",
+    "zid": "./dist/index.js"
   },
   "files": [
     "dist"

--- a/cli/src/commands/ciba/api.ts
+++ b/cli/src/commands/ciba/api.ts
@@ -1,6 +1,10 @@
-import { ZeroIDAPIError, ZeroIDClient } from "@highflame/sdk";
-
 export const CIBA_GRANT_TYPE = "urn:openid:params:grant-type:ciba";
+
+export interface CibaTenantContext {
+  base_url: string;
+  account_id: string;
+  project_id: string;
+}
 
 export interface CibaInitResponse {
   auth_req_id: string;
@@ -32,8 +36,20 @@ export interface CibaOAuthError {
   status?: number;
 }
 
+export class CibaHTTPError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly title: string,
+    public readonly detail?: string,
+    public readonly code?: string,
+  ) {
+    super(detail ? `[${status}] ${title}: ${detail}` : `[${status}] ${title}`);
+    this.name = "CibaHTTPError";
+  }
+}
+
 export function toCibaOAuthError(err: unknown): CibaOAuthError {
-  if (err instanceof ZeroIDAPIError) {
+  if (err instanceof CibaHTTPError) {
     return {
       error: err.code || err.title,
       error_description: err.detail || undefined,
@@ -51,17 +67,98 @@ export function isNonTerminalPollError(error: string): boolean {
 }
 
 export async function postPublicJSON<T>(
-  client: ZeroIDClient,
+  baseUrl: string,
   path: string,
   body: Record<string, unknown>,
 ): Promise<T> {
-  return client._postJSON<T>(path, body, undefined, false);
+  return postJSON<T>(baseUrl, path, body);
 }
 
 export async function postTenantJSON<T>(
-  client: ZeroIDClient,
+  context: CibaTenantContext,
   path: string,
   body: Record<string, unknown>,
 ): Promise<T> {
-  return client._postJSON<T>(path, body);
+  return postJSON<T>(context.base_url, path, body, {
+    "X-Account-ID": context.account_id,
+    "X-Project-ID": context.project_id,
+  });
+}
+
+async function postJSON<T>(
+  baseUrl: string,
+  path: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<T> {
+  const response = await fetch(`${trimTrailingSlash(baseUrl)}${ensureLeadingSlash(path)}`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw await parseErrorResponse(response);
+  }
+
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  const text = await response.text();
+  if (!text.trim()) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new CibaHTTPError(response.status, "Invalid JSON response", text);
+  }
+}
+
+async function parseErrorResponse(response: Response): Promise<CibaHTTPError> {
+  const text = await response.text();
+  let title = response.statusText || "Request failed";
+  let detail: string | undefined;
+  let code: string | undefined;
+
+  if (text.trim()) {
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      if (isRecord(parsed)) {
+        code = readString(parsed, "error") ?? readString(parsed, "code");
+        title = code ?? readString(parsed, "title") ?? readString(parsed, "message") ?? title;
+        detail =
+          readString(parsed, "error_description") ??
+          readString(parsed, "detail") ??
+          readString(parsed, "message");
+      }
+    } catch {
+      detail = text;
+    }
+  }
+
+  return new CibaHTTPError(response.status, title, detail, code);
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function ensureLeadingSlash(value: string): string {
+  return value.startsWith("/") ? value : `/${value}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
 }

--- a/cli/src/commands/ciba/api.ts
+++ b/cli/src/commands/ciba/api.ts
@@ -6,6 +6,19 @@ export interface CibaTenantContext {
   project_id: string;
 }
 
+export interface CibaAdminCommandOptions {
+  adminBaseUrl?: string;
+  adminPrefix?: string;
+  internalService?: string;
+  internalServiceSecret?: string;
+}
+
+export interface CibaAdminRequestConfig {
+  baseUrl: string;
+  prefix: string;
+  headers: Record<string, string>;
+}
+
 export interface CibaInitResponse {
   auth_req_id: string;
   expires_in: number;
@@ -78,11 +91,41 @@ export async function postTenantJSON<T>(
   context: CibaTenantContext,
   path: string,
   body: Record<string, unknown>,
+  options: { baseUrl?: string; headers?: Record<string, string | undefined> } = {},
 ): Promise<T> {
-  return postJSON<T>(context.base_url, path, body, {
+  return postJSON<T>(options.baseUrl ?? context.base_url, path, body, cleanHeaders({
     "X-Account-ID": context.account_id,
     "X-Project-ID": context.project_id,
-  });
+    ...options.headers,
+  }));
+}
+
+export function resolveCibaAdminRequest(
+  context: CibaTenantContext,
+  opts: CibaAdminCommandOptions,
+): CibaAdminRequestConfig {
+  const internalService = nonEmpty(opts.internalService) ?? readEnv("ZID_INTERNAL_SERVICE");
+  const internalServiceSecret =
+    nonEmpty(opts.internalServiceSecret) ?? readEnv("ZID_INTERNAL_SERVICE_SECRET");
+
+  if (internalServiceSecret && !internalService) {
+    throw new Error(
+      "--internal-service-secret requires --internal-service or ZID_INTERNAL_SERVICE",
+    );
+  }
+
+  return {
+    baseUrl: nonEmpty(opts.adminBaseUrl) ?? readEnv("ZID_ADMIN_BASE_URL") ?? context.base_url,
+    prefix: readOptionOrEnvAllowEmpty(opts.adminPrefix, "ZID_ADMIN_PREFIX") ?? "/api/v1",
+    headers: cleanHeaders({
+      "X-Internal-Service": internalService,
+      "X-Internal-Service-Secret": internalServiceSecret,
+    }),
+  };
+}
+
+export function buildCibaAdminPath(config: CibaAdminRequestConfig, path: string): string {
+  return joinPath(config.prefix, path);
 }
 
 async function postJSON<T>(
@@ -154,6 +197,24 @@ function ensureLeadingSlash(value: string): string {
   return value.startsWith("/") ? value : `/${value}`;
 }
 
+function joinPath(prefix: string, path: string): string {
+  const cleanPrefix = prefix.trim().replace(/\/+$/, "");
+  if (!cleanPrefix) {
+    return ensureLeadingSlash(path);
+  }
+  return `${ensureLeadingSlash(cleanPrefix)}${ensureLeadingSlash(path)}`;
+}
+
+function cleanHeaders(headers: Record<string, string | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined && value !== "") {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -161,4 +222,23 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function readString(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
   return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function readEnv(name: string): string | undefined {
+  return nonEmpty(process.env[name]);
+}
+
+function readOptionOrEnvAllowEmpty(value: string | undefined, envName: string): string | undefined {
+  if (value !== undefined) {
+    return value;
+  }
+  if (Object.prototype.hasOwnProperty.call(process.env, envName)) {
+    return process.env[envName] ?? "";
+  }
+  return undefined;
 }

--- a/cli/src/commands/ciba/api.ts
+++ b/cli/src/commands/ciba/api.ts
@@ -1,0 +1,67 @@
+import { ZeroIDAPIError, ZeroIDClient } from "@highflame/sdk";
+
+export const CIBA_GRANT_TYPE = "urn:openid:params:grant-type:ciba";
+
+export interface CibaInitResponse {
+  auth_req_id: string;
+  expires_in: number;
+  interval: number;
+}
+
+export interface CibaResolveResponse {
+  auth_req_id: string;
+  status: "approved" | "denied" | string;
+}
+
+export interface CibaTokenResponse {
+  access_token: string;
+  token_type?: string;
+  expires_in: number;
+  scope?: string;
+  refresh_token?: string;
+  jti?: string;
+  iat?: number;
+  account_id?: string;
+  project_id?: string;
+  [key: string]: unknown;
+}
+
+export interface CibaOAuthError {
+  error: string;
+  error_description?: string;
+  status?: number;
+}
+
+export function toCibaOAuthError(err: unknown): CibaOAuthError {
+  if (err instanceof ZeroIDAPIError) {
+    return {
+      error: err.code || err.title,
+      error_description: err.detail || undefined,
+      status: err.status,
+    };
+  }
+  if (err instanceof Error) {
+    return { error: "client_error", error_description: err.message };
+  }
+  return { error: "client_error", error_description: String(err) };
+}
+
+export function isNonTerminalPollError(error: string): boolean {
+  return error === "authorization_pending" || error === "slow_down";
+}
+
+export async function postPublicJSON<T>(
+  client: ZeroIDClient,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  return client._postJSON<T>(path, body, undefined, false);
+}
+
+export async function postTenantJSON<T>(
+  client: ZeroIDClient,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  return client._postJSON<T>(path, body);
+}

--- a/cli/src/commands/ciba/approve.ts
+++ b/cli/src/commands/ciba/approve.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import { makeTenantClient } from "../../lib/client.js";
+import { requireTenantContext } from "../../lib/config.js";
 import { handleError, printJSON, printSuccess } from "../../lib/output.js";
 import { type CibaResolveResponse, postTenantJSON } from "./api.js";
 
@@ -22,12 +22,12 @@ export function registerCibaApprove(cibaCmd: Command): void {
     )
     .action(async (authReqID: string, opts) => {
       try {
-        const client = makeTenantClient(
+        const context = requireTenantContext(
           opts.profile as string | undefined,
           "zeroid ciba approve",
         );
         const response = await postTenantJSON<CibaResolveResponse>(
-          client,
+          context,
           `/api/v1/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/approve`,
           {
             subject_id: opts.subjectId as string,

--- a/cli/src/commands/ciba/approve.ts
+++ b/cli/src/commands/ciba/approve.ts
@@ -1,0 +1,54 @@
+/**
+ * zeroid ciba approve <auth_req_id> — approve a pending CIBA request.
+ */
+
+import { Command } from "commander";
+import { makeTenantClient } from "../../lib/client.js";
+import { handleError, printJSON, printSuccess } from "../../lib/output.js";
+import { type CibaResolveResponse, postTenantJSON } from "./api.js";
+
+export function registerCibaApprove(cibaCmd: Command): void {
+  cibaCmd
+    .command("approve <auth-req-id>")
+    .description("Approve a pending CIBA request (admin-side simulation)")
+    .requiredOption("--subject-id <id>", "Approved end-user identifier; becomes token sub")
+    .option("--subject-email <email>", "Approved user's email")
+    .option("--subject-name <name>", "Approved user's display name")
+    .option("--profile <profile>", "Config profile to use")
+    .option("--json", "Output raw JSON")
+    .addHelpText(
+      "after",
+      "\nCIBA Core references: §8 End-User Consent/Authorization, §10 Getting the Authentication Result.",
+    )
+    .action(async (authReqID: string, opts) => {
+      try {
+        const client = makeTenantClient(
+          opts.profile as string | undefined,
+          "zeroid ciba approve",
+        );
+        const response = await postTenantJSON<CibaResolveResponse>(
+          client,
+          `/api/v1/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/approve`,
+          {
+            subject_id: opts.subjectId as string,
+            subject_email: nonEmpty(opts.subjectEmail as string | undefined),
+            subject_name: nonEmpty(opts.subjectName as string | undefined),
+          },
+        );
+
+        if (opts.json) {
+          printJSON(response);
+          return;
+        }
+
+        printSuccess(`CIBA request approved (${response.auth_req_id})`);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/cli/src/commands/ciba/approve.ts
+++ b/cli/src/commands/ciba/approve.ts
@@ -5,7 +5,12 @@
 import { Command } from "commander";
 import { requireTenantContext } from "../../lib/config.js";
 import { handleError, printJSON, printSuccess } from "../../lib/output.js";
-import { type CibaResolveResponse, postTenantJSON } from "./api.js";
+import {
+  buildCibaAdminPath,
+  type CibaResolveResponse,
+  postTenantJSON,
+  resolveCibaAdminRequest,
+} from "./api.js";
 
 export function registerCibaApprove(cibaCmd: Command): void {
   cibaCmd
@@ -14,6 +19,13 @@ export function registerCibaApprove(cibaCmd: Command): void {
     .requiredOption("--subject-id <id>", "Approved end-user identifier; becomes token sub")
     .option("--subject-email <email>", "Approved user's email")
     .option("--subject-name <name>", "Approved user's display name")
+    .option("--admin-base-url <url>", "Admin API base URL (defaults to profile base URL)")
+    .option(
+      "--admin-prefix <path>",
+      'Admin route prefix before /oauth2/bc-authorize (default: /api/v1; use "" for AuthN)',
+    )
+    .option("--internal-service <name>", "Internal service name header for protected admin routes")
+    .option("--internal-service-secret <secret>", "Internal service secret header")
     .option("--profile <profile>", "Config profile to use")
     .option("--json", "Output raw JSON")
     .addHelpText(
@@ -26,14 +38,24 @@ export function registerCibaApprove(cibaCmd: Command): void {
           opts.profile as string | undefined,
           "zeroid ciba approve",
         );
+        const admin = resolveCibaAdminRequest(context, {
+          adminBaseUrl: opts.adminBaseUrl as string | undefined,
+          adminPrefix: opts.adminPrefix as string | undefined,
+          internalService: opts.internalService as string | undefined,
+          internalServiceSecret: opts.internalServiceSecret as string | undefined,
+        });
         const response = await postTenantJSON<CibaResolveResponse>(
           context,
-          `/api/v1/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/approve`,
+          buildCibaAdminPath(
+            admin,
+            `/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/approve`,
+          ),
           {
             subject_id: opts.subjectId as string,
             subject_email: nonEmpty(opts.subjectEmail as string | undefined),
             subject_name: nonEmpty(opts.subjectName as string | undefined),
           },
+          { baseUrl: admin.baseUrl, headers: admin.headers },
         );
 
         if (opts.json) {

--- a/cli/src/commands/ciba/deny.ts
+++ b/cli/src/commands/ciba/deny.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import { makeTenantClient } from "../../lib/client.js";
+import { requireTenantContext } from "../../lib/config.js";
 import { handleError, printJSON, printSuccess } from "../../lib/output.js";
 import { type CibaResolveResponse, postTenantJSON } from "./api.js";
 
@@ -20,9 +20,9 @@ export function registerCibaDeny(cibaCmd: Command): void {
     )
     .action(async (authReqID: string, opts) => {
       try {
-        const client = makeTenantClient(opts.profile as string | undefined, "zeroid ciba deny");
+        const context = requireTenantContext(opts.profile as string | undefined, "zeroid ciba deny");
         const response = await postTenantJSON<CibaResolveResponse>(
-          client,
+          context,
           `/api/v1/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/deny`,
           { reason: nonEmpty(opts.reason as string | undefined) },
         );

--- a/cli/src/commands/ciba/deny.ts
+++ b/cli/src/commands/ciba/deny.ts
@@ -1,0 +1,45 @@
+/**
+ * zeroid ciba deny <auth_req_id> — deny a pending CIBA request.
+ */
+
+import { Command } from "commander";
+import { makeTenantClient } from "../../lib/client.js";
+import { handleError, printJSON, printSuccess } from "../../lib/output.js";
+import { type CibaResolveResponse, postTenantJSON } from "./api.js";
+
+export function registerCibaDeny(cibaCmd: Command): void {
+  cibaCmd
+    .command("deny <auth-req-id>")
+    .description("Deny a pending CIBA request (admin-side simulation)")
+    .option("--reason <text>", "Operator note to send with the denial when supported by the server")
+    .option("--profile <profile>", "Config profile to use")
+    .option("--json", "Output raw JSON")
+    .addHelpText(
+      "after",
+      "\nCIBA Core references: §8 End-User Consent/Authorization, §12 Push Error Payload.",
+    )
+    .action(async (authReqID: string, opts) => {
+      try {
+        const client = makeTenantClient(opts.profile as string | undefined, "zeroid ciba deny");
+        const response = await postTenantJSON<CibaResolveResponse>(
+          client,
+          `/api/v1/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/deny`,
+          { reason: nonEmpty(opts.reason as string | undefined) },
+        );
+
+        if (opts.json) {
+          printJSON(response);
+          return;
+        }
+
+        printSuccess(`CIBA request denied (${response.auth_req_id})`);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/cli/src/commands/ciba/deny.ts
+++ b/cli/src/commands/ciba/deny.ts
@@ -5,13 +5,25 @@
 import { Command } from "commander";
 import { requireTenantContext } from "../../lib/config.js";
 import { handleError, printJSON, printSuccess } from "../../lib/output.js";
-import { type CibaResolveResponse, postTenantJSON } from "./api.js";
+import {
+  buildCibaAdminPath,
+  type CibaResolveResponse,
+  postTenantJSON,
+  resolveCibaAdminRequest,
+} from "./api.js";
 
 export function registerCibaDeny(cibaCmd: Command): void {
   cibaCmd
     .command("deny <auth-req-id>")
     .description("Deny a pending CIBA request (admin-side simulation)")
     .option("--reason <text>", "Operator note to send with the denial when supported by the server")
+    .option("--admin-base-url <url>", "Admin API base URL (defaults to profile base URL)")
+    .option(
+      "--admin-prefix <path>",
+      'Admin route prefix before /oauth2/bc-authorize (default: /api/v1; use "" for AuthN)',
+    )
+    .option("--internal-service <name>", "Internal service name header for protected admin routes")
+    .option("--internal-service-secret <secret>", "Internal service secret header")
     .option("--profile <profile>", "Config profile to use")
     .option("--json", "Output raw JSON")
     .addHelpText(
@@ -21,10 +33,17 @@ export function registerCibaDeny(cibaCmd: Command): void {
     .action(async (authReqID: string, opts) => {
       try {
         const context = requireTenantContext(opts.profile as string | undefined, "zeroid ciba deny");
+        const admin = resolveCibaAdminRequest(context, {
+          adminBaseUrl: opts.adminBaseUrl as string | undefined,
+          adminPrefix: opts.adminPrefix as string | undefined,
+          internalService: opts.internalService as string | undefined,
+          internalServiceSecret: opts.internalServiceSecret as string | undefined,
+        });
         const response = await postTenantJSON<CibaResolveResponse>(
           context,
-          `/api/v1/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/deny`,
+          buildCibaAdminPath(admin, `/oauth2/bc-authorize/${encodeURIComponent(authReqID)}/deny`),
           { reason: nonEmpty(opts.reason as string | undefined) },
+          { baseUrl: admin.baseUrl, headers: admin.headers },
         );
 
         if (opts.json) {

--- a/cli/src/commands/ciba/index.ts
+++ b/cli/src/commands/ciba/index.ts
@@ -1,0 +1,22 @@
+/**
+ * zeroid ciba — OpenID CIBA helper commands.
+ */
+
+import { Command } from "commander";
+import { registerCibaApprove } from "./approve.js";
+import { registerCibaDeny } from "./deny.js";
+import { registerCibaInit } from "./init.js";
+import { registerCibaListen } from "./listen.js";
+import { registerCibaPoll } from "./poll.js";
+
+export function registerCiba(program: Command): void {
+  const cibaCmd = program
+    .command("ciba")
+    .description("OpenID CIBA backchannel authentication helpers");
+
+  registerCibaInit(cibaCmd);
+  registerCibaApprove(cibaCmd);
+  registerCibaDeny(cibaCmd);
+  registerCibaPoll(cibaCmd);
+  registerCibaListen(cibaCmd);
+}

--- a/cli/src/commands/ciba/init.ts
+++ b/cli/src/commands/ciba/init.ts
@@ -3,7 +3,6 @@
  */
 
 import { Command } from "commander";
-import { makeClientFromContext } from "../../lib/client.js";
 import { requireTenantContext } from "../../lib/config.js";
 import { handleError, printJSON, printSuccess } from "../../lib/output.js";
 import { type CibaInitResponse, postPublicJSON } from "./api.js";
@@ -27,10 +26,9 @@ export function registerCibaInit(cibaCmd: Command): void {
     .action(async (opts) => {
       try {
         const context = requireTenantContext(opts.profile as string | undefined, "zeroid ciba init");
-        const client = makeClientFromContext(context);
         const requestedExpiry = parsePositiveInt(opts.requestedExpiry as string | undefined);
 
-        const response = await postPublicJSON<CibaInitResponse>(client, "/oauth2/bc-authorize", {
+        const response = await postPublicJSON<CibaInitResponse>(context.base_url, "/oauth2/bc-authorize", {
           client_id: opts.clientId as string,
           account_id: context.account_id,
           project_id: context.project_id,

--- a/cli/src/commands/ciba/init.ts
+++ b/cli/src/commands/ciba/init.ts
@@ -1,0 +1,73 @@
+/**
+ * zeroid ciba init — initiate an OpenID CIBA backchannel auth request.
+ */
+
+import { Command } from "commander";
+import { makeClientFromContext } from "../../lib/client.js";
+import { requireTenantContext } from "../../lib/config.js";
+import { handleError, printJSON, printSuccess } from "../../lib/output.js";
+import { type CibaInitResponse, postPublicJSON } from "./api.js";
+
+export function registerCibaInit(cibaCmd: Command): void {
+  cibaCmd
+    .command("init")
+    .description("Initiate a CIBA backchannel authentication request (Core §7)")
+    .requiredOption("--client-id <id>", "OAuth client initiating the CIBA request")
+    .requiredOption("--login-hint <hint>", "User identifier to send to the backchannel notifier")
+    .option("--scope <scopes>", "Space-separated scopes to request", "")
+    .option("--binding-message <text>", "Human-readable context shown to the approving user")
+    .option("--requested-expiry <seconds>", "Requested auth request lifetime in seconds")
+    .option("--client-notification-token <token>", "Bearer token required for ping/push clients")
+    .option("--profile <profile>", "Config profile to use")
+    .option("--json", "Output raw JSON")
+    .addHelpText(
+      "after",
+      "\nCIBA Core references: §7 Backchannel Authentication Endpoint, §7.3 Successful Authentication Request Acknowledgement.",
+    )
+    .action(async (opts) => {
+      try {
+        const context = requireTenantContext(opts.profile as string | undefined, "zeroid ciba init");
+        const client = makeClientFromContext(context);
+        const requestedExpiry = parsePositiveInt(opts.requestedExpiry as string | undefined);
+
+        const response = await postPublicJSON<CibaInitResponse>(client, "/oauth2/bc-authorize", {
+          client_id: opts.clientId as string,
+          account_id: context.account_id,
+          project_id: context.project_id,
+          login_hint: opts.loginHint as string,
+          scope: nonEmpty(opts.scope as string | undefined),
+          binding_message: nonEmpty(opts.bindingMessage as string | undefined),
+          requested_expiry: requestedExpiry,
+          client_notification_token: nonEmpty(opts.clientNotificationToken as string | undefined),
+        });
+
+        if (opts.json) {
+          printJSON(response);
+          return;
+        }
+
+        printSuccess("CIBA request initiated");
+        console.log(`  auth_req_id: ${response.auth_req_id}`);
+        console.log(`  expires_in:  ${response.expires_in}s`);
+        console.log(`  interval:    ${response.interval}s`);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim() === "") {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error("--requested-expiry must be a positive integer");
+  }
+  return parsed;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/cli/src/commands/ciba/listen.ts
+++ b/cli/src/commands/ciba/listen.ts
@@ -1,0 +1,179 @@
+/**
+ * zeroid ciba listen — local HTTPS capture endpoint for ping/push callbacks.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer } from "node:https";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+import { handleError, printSuccess } from "../../lib/output.js";
+
+interface ListenEvent {
+  event: "listening" | "notification";
+  url?: string;
+  method?: string;
+  path?: string;
+  authorization?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  body?: unknown;
+  raw_body?: string;
+  received_at?: string;
+}
+
+export function registerCibaListen(cibaCmd: Command): void {
+  cibaCmd
+    .command("listen")
+    .description("Run a local HTTPS callback capture endpoint for CIBA ping/push")
+    .option("--port <port>", "HTTPS port to listen on", "8888")
+    .option("--host <host>", "Host to bind", "localhost")
+    .option("--json", "Output newline-delimited JSON events")
+    .addHelpText(
+      "after",
+      "\nCIBA Core references: §9 Client Notification Endpoint, §10.2 Ping Callback, §10.3 Push Callback.",
+    )
+    .action(async (opts) => {
+      try {
+        const port = parsePort(opts.port as string);
+        const host = opts.host as string;
+        const cert = ensureSelfSignedCert();
+        const server = createServer(cert, (req, res) => {
+          void handleNotification(req, res, Boolean(opts.json));
+        });
+
+        await new Promise<void>((resolve) => {
+          server.listen(port, host, resolve);
+        });
+
+        const url = `https://${host}:${port}/cb`;
+        printEvent({ event: "listening", url }, Boolean(opts.json));
+
+        process.on("SIGINT", () => {
+          server.close(() => process.exit(0));
+        });
+        process.on("SIGTERM", () => {
+          server.close(() => process.exit(0));
+        });
+      } catch (err) {
+        handleError(err);
+      }
+    });
+}
+
+async function handleNotification(
+  req: IncomingMessage,
+  res: ServerResponse,
+  json: boolean,
+): Promise<void> {
+  const rawBody = await readRequestBody(req);
+  let parsedBody: unknown;
+  try {
+    parsedBody = rawBody ? JSON.parse(rawBody) : undefined;
+  } catch {
+    parsedBody = undefined;
+  }
+
+  printEvent(
+    {
+      event: "notification",
+      method: req.method,
+      path: req.url,
+      authorization: req.headers.authorization,
+      headers: req.headers,
+      body: parsedBody,
+      raw_body: parsedBody === undefined ? rawBody : undefined,
+      received_at: new Date().toISOString(),
+    },
+    json,
+  );
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: true }) + "\n");
+}
+
+function printEvent(event: ListenEvent, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(event));
+    return;
+  }
+
+  if (event.event === "listening") {
+    printSuccess(`CIBA callback listener ready at ${event.url}`);
+    console.log("  Use this as your client_notification_endpoint for local ping/push tests.");
+    return;
+  }
+
+  console.log(`\n${event.received_at} ${event.method ?? ""} ${event.path ?? ""}`.trim());
+  if (event.authorization) {
+    console.log(`  authorization: ${event.authorization}`);
+  }
+  if (event.body !== undefined) {
+    console.log(JSON.stringify(event.body, null, 2));
+  } else if (event.raw_body) {
+    console.log(event.raw_body);
+  } else {
+    console.log("{}");
+  }
+}
+
+function ensureSelfSignedCert(): { key: Buffer; cert: Buffer } {
+  const dir = join(homedir(), ".zid", "ciba-cert");
+  const keyPath = join(dir, "localhost-key.pem");
+  const certPath = join(dir, "localhost-cert.pem");
+
+  if (!existsSync(keyPath) || !existsSync(certPath)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    const result = spawnSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-sha256",
+        "-days",
+        "365",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
+        "subjectAltName=DNS:localhost,IP:127.0.0.1",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    if (result.status !== 0) {
+      throw new Error(
+        "Failed to generate a self-signed certificate with openssl. Install openssl or create ~/.zid/ciba-cert/localhost-key.pem and localhost-cert.pem manually.",
+      );
+    }
+  }
+
+  return {
+    key: readFileSync(keyPath),
+    cert: readFileSync(certPath),
+  };
+}
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function parsePort(value: string): number {
+  const port = Number.parseInt(value, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error("--port must be an integer between 1 and 65535");
+  }
+  return port;
+}

--- a/cli/src/commands/ciba/listen.ts
+++ b/cli/src/commands/ciba/listen.ts
@@ -9,7 +9,7 @@ import { createServer } from "node:https";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
-import { handleError, printSuccess } from "../../lib/output.js";
+import { handleError, printError, printSuccess } from "../../lib/output.js";
 
 interface ListenEvent {
   event: "listening" | "notification";
@@ -22,6 +22,9 @@ interface ListenEvent {
   raw_body?: string;
   received_at?: string;
 }
+
+const CALLBACK_CERT_DIR = join(homedir(), ".config", "zeroid", "ciba-cert");
+const MAX_CALLBACK_BODY_BYTES = 1024 * 1024;
 
 export function registerCibaListen(cibaCmd: Command): void {
   cibaCmd
@@ -40,22 +43,16 @@ export function registerCibaListen(cibaCmd: Command): void {
         const host = opts.host as string;
         const cert = ensureSelfSignedCert();
         const server = createServer(cert, (req, res) => {
-          void handleNotification(req, res, Boolean(opts.json));
+          handleNotification(req, res, Boolean(opts.json)).catch((err) => {
+            printError(`CIBA callback handler failed: ${messageForError(err)}`);
+            writeNotificationErrorResponse(res, err);
+          });
         });
 
-        await new Promise<void>((resolve) => {
-          server.listen(port, host, resolve);
-        });
+        await listen(server, port, host);
 
         const url = `https://${host}:${port}/cb`;
         printEvent({ event: "listening", url }, Boolean(opts.json));
-
-        process.on("SIGINT", () => {
-          server.close(() => process.exit(0));
-        });
-        process.on("SIGTERM", () => {
-          server.close(() => process.exit(0));
-        });
       } catch (err) {
         handleError(err);
       }
@@ -93,6 +90,41 @@ async function handleNotification(
   res.end(JSON.stringify({ ok: true }) + "\n");
 }
 
+function listen(server: ReturnType<typeof createServer>, port: number, host: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error) => {
+      reject(err);
+    };
+
+    server.once("error", onError);
+    server.listen(port, host, () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+}
+
+function writeNotificationErrorResponse(res: ServerResponse, err: unknown): void {
+  if (res.destroyed || res.writableEnded) {
+    return;
+  }
+
+  const tooLarge = err instanceof RequestBodyLimitError;
+  const status = tooLarge ? 413 : 500;
+  const body = {
+    error: tooLarge ? "payload_too_large" : "internal_server_error",
+    message: messageForError(err),
+  };
+
+  if (!res.headersSent) {
+    res.writeHead(status, {
+      "Content-Type": "application/json",
+      Connection: "close",
+    });
+  }
+  res.end(JSON.stringify(body) + "\n");
+}
+
 function printEvent(event: ListenEvent, json: boolean): void {
   if (json) {
     console.log(JSON.stringify(event));
@@ -119,7 +151,7 @@ function printEvent(event: ListenEvent, json: boolean): void {
 }
 
 function ensureSelfSignedCert(): { key: Buffer; cert: Buffer } {
-  const dir = join(homedir(), ".zid", "ciba-cert");
+  const dir = CALLBACK_CERT_DIR;
   const keyPath = join(dir, "localhost-key.pem");
   const certPath = join(dir, "localhost-cert.pem");
 
@@ -150,7 +182,7 @@ function ensureSelfSignedCert(): { key: Buffer; cert: Buffer } {
 
     if (result.status !== 0) {
       throw new Error(
-        "Failed to generate a self-signed certificate with openssl. Install openssl or create ~/.zid/ciba-cert/localhost-key.pem and localhost-cert.pem manually.",
+        "Failed to generate a self-signed certificate with openssl. Install openssl or create ~/.config/zeroid/ciba-cert/localhost-key.pem and localhost-cert.pem manually.",
       );
     }
   }
@@ -164,10 +196,51 @@ function ensureSelfSignedCert(): { key: Buffer; cert: Buffer } {
 function readRequestBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
-    req.on("data", (chunk: Buffer) => chunks.push(chunk));
-    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
-    req.on("error", reject);
+    let length = 0;
+    let settled = false;
+
+    const fail = (err: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(err);
+    };
+
+    req.on("data", (chunk: Buffer) => {
+      if (settled) {
+        return;
+      }
+
+      length += chunk.length;
+      if (length > MAX_CALLBACK_BODY_BYTES) {
+        fail(new RequestBodyLimitError(MAX_CALLBACK_BODY_BYTES));
+        req.destroy();
+        return;
+      }
+
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+    req.on("error", fail);
   });
+}
+
+class RequestBodyLimitError extends Error {
+  constructor(limitBytes: number) {
+    super(`Request body exceeds ${Math.floor(limitBytes / 1024 / 1024)}MB limit`);
+    this.name = "RequestBodyLimitError";
+  }
+}
+
+function messageForError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function parsePort(value: string): number {

--- a/cli/src/commands/ciba/poll.ts
+++ b/cli/src/commands/ciba/poll.ts
@@ -1,0 +1,115 @@
+/**
+ * zeroid ciba poll <auth_req_id> — poll /oauth2/token for a CIBA token.
+ */
+
+import { Command } from "commander";
+import { makeBaseUrlClient } from "../../lib/client.js";
+import { printError, printJSON, printSuccess, printWarning } from "../../lib/output.js";
+import {
+  CIBA_GRANT_TYPE,
+  isNonTerminalPollError,
+  postPublicJSON,
+  type CibaOAuthError,
+  type CibaTokenResponse,
+  toCibaOAuthError,
+} from "./api.js";
+
+export function registerCibaPoll(cibaCmd: Command): void {
+  cibaCmd
+    .command("poll <auth-req-id>")
+    .description("Poll the token endpoint with the CIBA grant (Core §10.1)")
+    .requiredOption("--client-id <id>", "OAuth client that initiated the request")
+    .option("--watch", "Keep polling until success or terminal error")
+    .option("--interval <seconds>", "Polling interval for --watch", "5")
+    .option("--profile <profile>", "Config profile to use")
+    .option("--json", "Output raw JSON")
+    .addHelpText(
+      "after",
+      "\nCIBA Core references: §10.1 Token Request Using CIBA Grant Type, §11 Polling Error Responses.",
+    )
+    .action(async (authReqID: string, opts) => {
+      const client = makeBaseUrlClient(opts.profile as string | undefined);
+      let intervalSeconds = parseInterval(opts.interval as string);
+
+      for (;;) {
+        const result = await pollOnce(client, authReqID, opts.clientId as string);
+        if ("access_token" in result) {
+          printToken(result, Boolean(opts.json));
+          return;
+        }
+
+        if (!opts.watch || !isNonTerminalPollError(result.error)) {
+          printPollError(result, Boolean(opts.json));
+          process.exit(1);
+        }
+
+        if (!opts.json) {
+          const suffix = result.error_description ? `: ${result.error_description}` : "";
+          printWarning(`${result.error}${suffix}`);
+        } else {
+          printJSON(result);
+        }
+
+        if (result.error === "slow_down") {
+          intervalSeconds += 5;
+        }
+        await sleep(intervalSeconds * 1000);
+      }
+    });
+}
+
+async function pollOnce(
+  client: ReturnType<typeof makeBaseUrlClient>,
+  authReqID: string,
+  clientID: string,
+): Promise<CibaTokenResponse | CibaOAuthError> {
+  try {
+    return await postPublicJSON<CibaTokenResponse>(client, "/oauth2/token", {
+      grant_type: CIBA_GRANT_TYPE,
+      auth_req_id: authReqID,
+      client_id: clientID,
+    });
+  } catch (err) {
+    return toCibaOAuthError(err);
+  }
+}
+
+function printToken(token: CibaTokenResponse, json: boolean): void {
+  if (json) {
+    printJSON(token);
+    return;
+  }
+
+  printSuccess("CIBA token issued");
+  console.log(`  access_token: ${token.access_token}`);
+  console.log(`  token_type:   ${token.token_type ?? "Bearer"}`);
+  console.log(`  expires_in:   ${token.expires_in}s`);
+  if (token.scope) {
+    console.log(`  scope:        ${token.scope}`);
+  }
+  if (token.refresh_token) {
+    console.log(`  refresh_token: ${token.refresh_token}`);
+  }
+}
+
+function printPollError(error: CibaOAuthError, json: boolean): void {
+  if (json) {
+    printJSON(error);
+    return;
+  }
+
+  const suffix = error.error_description ? `: ${error.error_description}` : "";
+  printError(`${error.error}${suffix}`);
+}
+
+function parseInterval(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error("--interval must be a non-negative number of seconds");
+  }
+  return parsed;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/cli/src/commands/ciba/poll.ts
+++ b/cli/src/commands/ciba/poll.ts
@@ -3,7 +3,7 @@
  */
 
 import { Command } from "commander";
-import { makeBaseUrlClient } from "../../lib/client.js";
+import { requireBaseURL } from "../../lib/config.js";
 import { printError, printJSON, printSuccess, printWarning } from "../../lib/output.js";
 import {
   CIBA_GRANT_TYPE,
@@ -28,11 +28,11 @@ export function registerCibaPoll(cibaCmd: Command): void {
       "\nCIBA Core references: §10.1 Token Request Using CIBA Grant Type, §11 Polling Error Responses.",
     )
     .action(async (authReqID: string, opts) => {
-      const client = makeBaseUrlClient(opts.profile as string | undefined);
+      const baseUrl = requireBaseURL(opts.profile as string | undefined);
       let intervalSeconds = parseInterval(opts.interval as string);
 
       for (;;) {
-        const result = await pollOnce(client, authReqID, opts.clientId as string);
+        const result = await pollOnce(baseUrl, authReqID, opts.clientId as string);
         if ("access_token" in result) {
           printToken(result, Boolean(opts.json));
           return;
@@ -59,12 +59,12 @@ export function registerCibaPoll(cibaCmd: Command): void {
 }
 
 async function pollOnce(
-  client: ReturnType<typeof makeBaseUrlClient>,
+  baseUrl: string,
   authReqID: string,
   clientID: string,
 ): Promise<CibaTokenResponse | CibaOAuthError> {
   try {
-    return await postPublicJSON<CibaTokenResponse>(client, "/oauth2/token", {
+    return await postPublicJSON<CibaTokenResponse>(baseUrl, "/oauth2/token", {
       grant_type: CIBA_GRANT_TYPE,
       auth_req_id: authReqID,
       client_id: clientID,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -18,6 +18,7 @@ import { registerDeactivate } from "./commands/agents/deactivate.js";
 import { registerCredsList } from "./commands/creds/list.js";
 import { registerSignal } from "./commands/signal.js";
 import { registerConfig } from "./commands/config.js";
+import { registerCiba } from "./commands/ciba/index.js";
 
 const program = new Command();
 
@@ -29,6 +30,7 @@ program
 registerInit(program);
 registerSignal(program);
 registerConfig(program);
+registerCiba(program);
 
 const tokenCmd = program.command("token").description("Token operations");
 registerIssue(tokenCmd);

--- a/cli/tests/commands/ciba.test.ts
+++ b/cli/tests/commands/ciba.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for `zeroid ciba` subcommands.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { runCLI, BASE_URL } from "../helpers.js";
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const INIT_RESPONSE = {
+  auth_req_id: "ari_test_123",
+  expires_in: 300,
+  interval: 5,
+};
+
+const TOKEN_RESPONSE = {
+  access_token: "eyJhbGciOiJSUzI1NiJ9.ciba.sig",
+  token_type: "Bearer",
+  expires_in: 900,
+  jti: "jti_ciba_123",
+  iat: Math.floor(Date.now() / 1000),
+  account_id: "acct_test",
+  project_id: "proj_test",
+};
+
+describe("zeroid ciba init", () => {
+  it("posts to /oauth2/bc-authorize with tenant fields in the body", async () => {
+    let captured: Record<string, unknown> = {};
+    let accountHeader: string | null = "";
+
+    server.use(
+      http.post(`${BASE_URL}/oauth2/bc-authorize`, async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        accountHeader = request.headers.get("x-account-id");
+        return HttpResponse.json(INIT_RESPONSE);
+      }),
+    );
+
+    const { stdout, exitCode } = await runCLI([
+      "ciba",
+      "init",
+      "--client-id",
+      "my-ciba-client",
+      "--login-hint",
+      "user@example.com",
+      "--scope",
+      "openid profile",
+      "--binding-message",
+      "Approve login?",
+      "--requested-expiry",
+      "600",
+      "--client-notification-token",
+      "opaque-token",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(captured["client_id"]).toBe("my-ciba-client");
+    expect(captured["account_id"]).toBe("acct_test");
+    expect(captured["project_id"]).toBe("proj_test");
+    expect(captured["login_hint"]).toBe("user@example.com");
+    expect(captured["scope"]).toBe("openid profile");
+    expect(captured["binding_message"]).toBe("Approve login?");
+    expect(captured["requested_expiry"]).toBe(600);
+    expect(captured["client_notification_token"]).toBe("opaque-token");
+    expect(accountHeader).toBeNull();
+    expect(stdout.join("\n")).toContain("ari_test_123");
+  });
+
+  it("outputs raw JSON with --json", async () => {
+    server.use(http.post(`${BASE_URL}/oauth2/bc-authorize`, () => HttpResponse.json(INIT_RESPONSE)));
+
+    const { stdout } = await runCLI([
+      "ciba",
+      "init",
+      "--client-id",
+      "my-ciba-client",
+      "--login-hint",
+      "user@example.com",
+      "--json",
+    ]);
+
+    expect(JSON.parse(stdout.join(""))).toEqual(INIT_RESPONSE);
+  });
+});
+
+describe("zeroid ciba approve", () => {
+  it("posts approval details with tenant headers", async () => {
+    let captured: Record<string, unknown> = {};
+    let accountHeader = "";
+    let projectHeader = "";
+
+    server.use(
+      http.post(`${BASE_URL}/api/v1/oauth2/bc-authorize/ari_test_123/approve`, async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        accountHeader = request.headers.get("x-account-id") ?? "";
+        projectHeader = request.headers.get("x-project-id") ?? "";
+        return HttpResponse.json({ auth_req_id: "ari_test_123", status: "approved" });
+      }),
+    );
+
+    const { stdout, exitCode } = await runCLI([
+      "ciba",
+      "approve",
+      "ari_test_123",
+      "--subject-id",
+      "user@example.com",
+      "--subject-email",
+      "user@example.com",
+      "--subject-name",
+      "Alice User",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(accountHeader).toBe("acct_test");
+    expect(projectHeader).toBe("proj_test");
+    expect(captured["subject_id"]).toBe("user@example.com");
+    expect(captured["subject_email"]).toBe("user@example.com");
+    expect(captured["subject_name"]).toBe("Alice User");
+    expect(stdout.join("")).toMatch(/approved/i);
+  });
+});
+
+describe("zeroid ciba deny", () => {
+  it("posts denial with tenant headers and optional reason", async () => {
+    let captured: Record<string, unknown> = {};
+    let accountHeader = "";
+
+    server.use(
+      http.post(`${BASE_URL}/api/v1/oauth2/bc-authorize/ari_test_123/deny`, async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        accountHeader = request.headers.get("x-account-id") ?? "";
+        return HttpResponse.json({ auth_req_id: "ari_test_123", status: "denied" });
+      }),
+    );
+
+    const { stdout, exitCode } = await runCLI([
+      "ciba",
+      "deny",
+      "ari_test_123",
+      "--reason",
+      "user rejected",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(accountHeader).toBe("acct_test");
+    expect(captured["reason"]).toBe("user rejected");
+    expect(stdout.join("")).toMatch(/denied/i);
+  });
+});
+
+describe("zeroid ciba poll", () => {
+  it("posts the CIBA grant to /oauth2/token and prints the token", async () => {
+    let captured: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`${BASE_URL}/oauth2/token`, async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(TOKEN_RESPONSE);
+      }),
+    );
+
+    const { stdout, exitCode } = await runCLI([
+      "ciba",
+      "poll",
+      "ari_test_123",
+      "--client-id",
+      "my-ciba-client",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(captured["grant_type"]).toBe("urn:openid:params:grant-type:ciba");
+    expect(captured["auth_req_id"]).toBe("ari_test_123");
+    expect(captured["client_id"]).toBe("my-ciba-client");
+    expect(stdout.join("\n")).toContain(TOKEN_RESPONSE.access_token);
+  });
+
+  it("prints OAuth polling errors as JSON and exits 1", async () => {
+    server.use(
+      http.post(`${BASE_URL}/oauth2/token`, () =>
+        HttpResponse.json(
+          {
+            error: "authorization_pending",
+            error_description: "the user has not yet acted",
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const { stdout, exitCode } = await runCLI([
+      "ciba",
+      "poll",
+      "ari_test_123",
+      "--client-id",
+      "my-ciba-client",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout.join(""));
+    expect(parsed.error).toBe("authorization_pending");
+  });
+
+  it("with --watch keeps polling through authorization_pending", async () => {
+    let attempts = 0;
+
+    server.use(
+      http.post(`${BASE_URL}/oauth2/token`, () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return HttpResponse.json(
+            {
+              error: "authorization_pending",
+              error_description: "the user has not yet acted",
+            },
+            { status: 400 },
+          );
+        }
+        return HttpResponse.json(TOKEN_RESPONSE);
+      }),
+    );
+
+    const { stdout, exitCode } = await runCLI([
+      "ciba",
+      "poll",
+      "ari_test_123",
+      "--client-id",
+      "my-ciba-client",
+      "--watch",
+      "--interval",
+      "0",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(attempts).toBe(2);
+    expect(stdout.join("\n")).toContain(TOKEN_RESPONSE.access_token);
+  });
+});

--- a/cli/tests/commands/ciba.test.ts
+++ b/cli/tests/commands/ciba.test.ts
@@ -123,6 +123,47 @@ describe("zeroid ciba approve", () => {
     expect(captured["subject_name"]).toBe("Alice User");
     expect(stdout.join("")).toMatch(/approved/i);
   });
+
+  it("supports AuthN-mounted approval routes with internal service headers", async () => {
+    let captured: Record<string, unknown> = {};
+    let accountHeader = "";
+    let projectHeader = "";
+    let internalServiceHeader = "";
+    let internalSecretHeader = "";
+
+    server.use(
+      http.post(`${BASE_URL}/oauth2/bc-authorize/ari_test_123/approve`, async ({ request }) => {
+        captured = (await request.json()) as Record<string, unknown>;
+        accountHeader = request.headers.get("x-account-id") ?? "";
+        projectHeader = request.headers.get("x-project-id") ?? "";
+        internalServiceHeader = request.headers.get("x-internal-service") ?? "";
+        internalSecretHeader = request.headers.get("x-internal-service-secret") ?? "";
+        return HttpResponse.json({ auth_req_id: "ari_test_123", status: "approved" });
+      }),
+    );
+
+    const { stdout, exitCode } = await runCLI([
+      "ciba",
+      "approve",
+      "ari_test_123",
+      "--subject-id",
+      "user@example.com",
+      "--admin-prefix",
+      "",
+      "--internal-service",
+      "highflame-admin",
+      "--internal-service-secret",
+      "dev-secret",
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(accountHeader).toBe("acct_test");
+    expect(projectHeader).toBe("proj_test");
+    expect(internalServiceHeader).toBe("highflame-admin");
+    expect(internalSecretHeader).toBe("dev-secret");
+    expect(captured["subject_id"]).toBe("user@example.com");
+    expect(stdout.join("")).toMatch(/approved/i);
+  });
 });
 
 describe("zeroid ciba deny", () => {
@@ -149,6 +190,45 @@ describe("zeroid ciba deny", () => {
     expect(exitCode).toBeUndefined();
     expect(accountHeader).toBe("acct_test");
     expect(captured["reason"]).toBe("user rejected");
+    expect(stdout.join("")).toMatch(/denied/i);
+  });
+
+  it("honors admin prefix and internal service headers from env", async () => {
+    let accountHeader = "";
+    let projectHeader = "";
+    let internalServiceHeader = "";
+    let internalSecretHeader = "";
+
+    server.use(
+      http.post(`${BASE_URL}/oauth2/bc-authorize/ari_test_123/deny`, async ({ request }) => {
+        accountHeader = request.headers.get("x-account-id") ?? "";
+        projectHeader = request.headers.get("x-project-id") ?? "";
+        internalServiceHeader = request.headers.get("x-internal-service") ?? "";
+        internalSecretHeader = request.headers.get("x-internal-service-secret") ?? "";
+        return HttpResponse.json({ auth_req_id: "ari_test_123", status: "denied" });
+      }),
+    );
+
+    const { stdout, exitCode } = await runCLI(
+      [
+        "ciba",
+        "deny",
+        "ari_test_123",
+        "--reason",
+        "user rejected",
+      ],
+      {
+        ZID_ADMIN_PREFIX: "",
+        ZID_INTERNAL_SERVICE: "highflame-admin",
+        ZID_INTERNAL_SERVICE_SECRET: "dev-secret",
+      },
+    );
+
+    expect(exitCode).toBeUndefined();
+    expect(accountHeader).toBe("acct_test");
+    expect(projectHeader).toBe("proj_test");
+    expect(internalServiceHeader).toBe("highflame-admin");
+    expect(internalSecretHeader).toBe("dev-secret");
     expect(stdout.join("")).toMatch(/denied/i);
   });
 });

--- a/cli/tests/helpers.ts
+++ b/cli/tests/helpers.ts
@@ -21,6 +21,7 @@ import { registerDeactivate } from "../src/commands/agents/deactivate.js";
 import { registerCredsList } from "../src/commands/creds/list.js";
 import { registerSignal } from "../src/commands/signal.js";
 import { registerConfig } from "../src/commands/config.js";
+import { registerCiba } from "../src/commands/ciba/index.js";
 
 export const BASE_URL = "http://zeroid.test";
 
@@ -47,6 +48,7 @@ export function makeProgram(): Command {
   registerInit(program);
   registerSignal(program);
   registerConfig(program);
+  registerCiba(program);
 
   const tokenCmd = program.command("token");
   registerIssue(tokenCmd);


### PR DESCRIPTION
## Summary

Closes #141.

Adds a `zeroid ciba` CLI command group for OpenID CIBA workflows:

- `zeroid ciba init` for `/oauth2/bc-authorize`
- `zeroid ciba approve` / `deny` for admin-side local/test resolution
- `zeroid ciba poll` with `--watch`, OAuth polling error handling, and JSON output
- `zeroid ciba listen` for local HTTPS ping/push callback capture
- `zid` as a package bin alias
- README coverage and CLI tests

## Testing

- `npm test -- tests/commands/ciba.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test` (`108 passed`)
- `npm run build`
- `GOEXPERIMENT=jsonv2 go test ./tests/integration -run CIBA -v -count=1 -timeout=180s`

Live local container smoke test against `http://localhost:8899`:

- registered a disposable poll-mode CIBA OAuth client
- ran `ciba init` and received a real `auth_req_id`
- verified pre-approval `ciba poll` returns `authorization_pending`
- ran `ciba approve`
- ran `ciba poll` again and received a real access token
- decoded the token and verified `grant_type`, `sub`, and `backchannel_client_id`

Dev deployment check:

- `https://control-dev.highflame.dev/v1/auth/health` is healthy
- `https://control-dev.highflame.dev/v1/auth/.well-known/jwks.json` works
- `POST /v1/auth/oauth2/bc-authorize` currently returns `501 Not Implemented: CIBA not yet implemented`, so the dev AuthN wrapper is not yet running a ZeroID build with the CIBA server implementation
- protected dev admin routes require remote `X-Internal-Service` credentials; the local-deploy shared secret is not valid for dev

## Notes

The CLI sends `deny --reason` when provided, but the current ZeroID backend does not persist or use denial reasons yet. That remains a backend/product follow-up if the reason needs durable semantics.
