### PR TITLE
feat: workload-attested ephemeral signing credentials

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,14 @@ import (
 // this via ServerConfig.AdminPathPrefix.
 const DefaultAdminPathPrefix = "/api/v1"
 
+// DefaultSigningJWKSName is the default suffix for the workload-attested
+// signing-credential verification JWKS, served at
+// /.well-known/<name>. It is intentionally generic: ZeroID is
+// product-agnostic. Deployers brand it via
+// SigningCredsConfig.WellKnownJWKSName (e.g. a product publishes its
+// receipt-verification keys at /.well-known/<product>-receipt-keys).
+const DefaultSigningJWKSName = "signing-keys"
+
 // Config holds the complete ZeroID service configuration.
 type Config struct {
 	Server      ServerConfig      `koanf:"server"`
@@ -86,6 +94,24 @@ type SigningCredsConfig struct {
 	// verifiable after attestation (default 400 — covers a >1y audit
 	// window so historical receipts verify long after key rotation).
 	AuditRetentionDays int `koanf:"audit_retention_days"`
+	// AllowedPurposes is the deployer-supplied allowlist of purpose
+	// strings a workload may attest a key for. ZeroID is
+	// product-agnostic: it ships EMPTY (no purpose accepted) so a
+	// deployment must explicitly opt in and name its own purposes
+	// (e.g. a product allows "receipt", "authz_audit"). An attest
+	// request whose purpose is not in this list is rejected.
+	AllowedPurposes []string `koanf:"allowed_purposes"`
+	// JWKSPurpose selects which purpose's keys the well-known
+	// verification JWKS publishes. The well-known path is inherently
+	// purpose-specific (it is the verification endpoint for one class
+	// of receipts), so a deployer that publishes more than one purpose
+	// runs more than one ZeroID-fronting alias. Empty ⇒ the JWKS route
+	// is not registered (feature dormant).
+	JWKSPurpose string `koanf:"jwks_purpose"`
+	// WellKnownJWKSName is the /.well-known/<name> suffix the
+	// verification JWKS is served at. Defaults to DefaultSigningJWKSName
+	// ("signing-keys"); deployers brand it (e.g. "<product>-receipt-keys").
+	WellKnownJWKSName string `koanf:"well_known_jwks_name"`
 }
 
 // ServerConfig holds HTTP server settings.
@@ -331,6 +357,10 @@ func loadDefaults(k *koanf.Koanf) error {
 		// historical attestations verify long after rotation.
 		"signing_credentials.max_ttl_seconds":      3600,
 		"signing_credentials.audit_retention_days": 400,
+		// Product-agnostic by default: no purpose accepted and the
+		// generic well-known name. A deployment opts in by configuring
+		// allowed_purposes + jwks_purpose (+ optionally branding the name).
+		"signing_credentials.well_known_jwks_name": DefaultSigningJWKSName,
 
 		// Logging
 		"logging.level": "info",
@@ -371,6 +401,8 @@ func loadEnvVars(k *koanf.Koanf) error {
 
 		"ZEROID_SIGNING_CREDS_MAX_TTL_SECONDS":      "signing_credentials.max_ttl_seconds",
 		"ZEROID_SIGNING_CREDS_AUDIT_RETENTION_DAYS": "signing_credentials.audit_retention_days",
+		"ZEROID_SIGNING_CREDS_JWKS_PURPOSE":         "signing_credentials.jwks_purpose",
+		"ZEROID_SIGNING_CREDS_WELL_KNOWN_JWKS_NAME": "signing_credentials.well_known_jwks_name",
 
 		// Token
 		"ZEROID_ISSUER":                "token.issuer",

--- a/config.go
+++ b/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	Attestation AttestationConfig `koanf:"attestation"`
 	Backchannel BackchannelConfig `koanf:"backchannel"`
 
+	SigningCreds SigningCredsConfig `koanf:"signing_credentials"`
+
 	// WIMSEDomain is the domain prefix for SPIFFE/WIMSE URIs (e.g. "zeroid.dev").
 	WIMSEDomain string `koanf:"wimse_domain"`
 }
@@ -69,6 +71,21 @@ type AttestationConfig struct {
 	// should set ZEROID_ALLOW_UNSAFE_DEV_STUB=false. The OIDC verifier
 	// (the only real verifier shipped) is unaffected by this flag.
 	AllowUnsafeDevStub bool `koanf:"allow_unsafe_dev_stub"`
+}
+
+// SigningCredsConfig governs workload-attested ephemeral signing
+// credentials. The two clocks are deliberately decoupled: MaxTTLSeconds
+// bounds how long an attested key may SIGN; AuditRetentionDays bounds how
+// long its public key stays resolvable for VERIFYING historical
+// attestations (>> MaxTTLSeconds). See domain/signing_credential.go.
+type SigningCredsConfig struct {
+	// MaxTTLSeconds caps the operational signing window an attestation
+	// may request (default 1h — keys are ephemeral, rotated often).
+	MaxTTLSeconds int `koanf:"max_ttl_seconds"`
+	// AuditRetentionDays is how long a non-revoked public key remains
+	// verifiable after attestation (default 400 — covers a >1y audit
+	// window so historical receipts verify long after key rotation).
+	AuditRetentionDays int `koanf:"audit_retention_days"`
 }
 
 // ServerConfig holds HTTP server settings.
@@ -308,6 +325,13 @@ func loadDefaults(k *koanf.Koanf) error {
 		// submit those proof types (or once real verifiers land).
 		"attestation.allow_unsafe_dev_stub": true,
 
+		// Workload-attested signing credentials. Operational signing
+		// window is short (1h, keys are ephemeral + rotated); the public
+		// key stays verifiable for a long audit window (400d) so
+		// historical attestations verify long after rotation.
+		"signing_credentials.max_ttl_seconds":      3600,
+		"signing_credentials.audit_retention_days": 400,
+
 		// Logging
 		"logging.level": "info",
 	}
@@ -344,6 +368,9 @@ func loadEnvVars(k *koanf.Koanf) error {
 		"ZEROID_RSA_PRIVATE_KEY_PATH": "keys.rsa_private_key_path",
 		"ZEROID_RSA_PUBLIC_KEY_PATH":  "keys.rsa_public_key_path",
 		"ZEROID_RSA_KEY_ID":           "keys.rsa_key_id",
+
+		"ZEROID_SIGNING_CREDS_MAX_TTL_SECONDS":      "signing_credentials.max_ttl_seconds",
+		"ZEROID_SIGNING_CREDS_AUDIT_RETENTION_DAYS": "signing_credentials.audit_retention_days",
 
 		// Token
 		"ZEROID_ISSUER":                "token.issuer",

--- a/domain/signing_credential.go
+++ b/domain/signing_credential.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// SigningCredential is a workload-attested ephemeral signing key. A
+// workload generates an Ed25519 keypair in memory and attests the PUBLIC
+// half here; ZeroID never sees or stores the private key. See
+// migrations/023_signing_credentials.up.sql for the two-clock model.
+type SigningCredential struct {
+	bun.BaseModel `bun:"table:signing_credentials,alias:sc"`
+
+	ID                  string     `bun:"id,pk,type:uuid,default:gen_random_uuid()" json:"id"`
+	AccountID           string     `bun:"account_id"                                json:"account_id,omitempty"`
+	ProjectID           string     `bun:"project_id"                                json:"project_id,omitempty"`
+	KID                 string     `bun:"kid"                                       json:"kid"`
+	Workload            string     `bun:"workload"                                  json:"workload"`
+	Purpose             string     `bun:"purpose"                                   json:"purpose"`
+	Algorithm           string     `bun:"algorithm"                                 json:"algorithm"`
+	PublicKey           string     `bun:"public_key"                                json:"-"` // never logged/returned
+	NotAfter            time.Time  `bun:"not_after"                                 json:"not_after"`
+	AuditRetentionUntil time.Time  `bun:"audit_retention_until"                     json:"audit_retention_until"`
+	Revoked             bool       `bun:"revoked"                                   json:"revoked"`
+	RevokedReason       string     `bun:"revoked_reason"                            json:"revoked_reason,omitempty"`
+	RevokedAt           *time.Time `bun:"revoked_at"                                json:"revoked_at,omitempty"`
+	CreatedAt           time.Time  `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
+}
+
+// SigningCredentialPurposes is the launch allowlist of purposes a
+// workload may attest a key for. Mirrors the design doc.
+const (
+	SigningPurposeReceipt    = "receipt"
+	SigningPurposeAuthZAudit = "authz_audit"
+)
+
+// SigningAlgorithmEdDSA is the only supported signing algorithm at launch.
+const SigningAlgorithmEdDSA = "EdDSA"
+
+// VerifiableNow reports whether this credential's public key may still be
+// used to VERIFY an attestation right now. The rule is the correctness
+// crux: a merely-expired key (past NotAfter) still verifies historical
+// receipts while inside the audit-retention window; only a *revoked* key
+// is rejected outright.
+func (c *SigningCredential) VerifiableNow(now time.Time) bool {
+	if c.Revoked {
+		return false
+	}
+	return now.Before(c.AuditRetentionUntil)
+}
+
+// SignableNow reports whether this key is still within its OPERATIONAL
+// window (may be used to produce new signatures). Distinct from
+// VerifiableNow — a key stops being signable long before it stops being
+// verifiable.
+func (c *SigningCredential) SignableNow(now time.Time) bool {
+	return !c.Revoked && now.Before(c.NotAfter)
+}

--- a/domain/signing_credential.go
+++ b/domain/signing_credential.go
@@ -29,12 +29,10 @@ type SigningCredential struct {
 	CreatedAt           time.Time  `bun:"created_at,nullzero,notnull,default:current_timestamp" json:"created_at"`
 }
 
-// SigningCredentialPurposes is the launch allowlist of purposes a
-// workload may attest a key for. Mirrors the design doc.
-const (
-	SigningPurposeReceipt    = "receipt"
-	SigningPurposeAuthZAudit = "authz_audit"
-)
+// Purpose is an opaque, deployer-defined string (e.g. what the attested
+// key signs). ZeroID does not enumerate purposes — it is product-
+// agnostic; the accepted set comes from SigningCredsConfig.AllowedPurposes
+// supplied by the deployment, not from constants here.
 
 // SigningAlgorithmEdDSA is the only supported signing algorithm at launch.
 const SigningAlgorithmEdDSA = "EdDSA"
@@ -42,8 +40,8 @@ const SigningAlgorithmEdDSA = "EdDSA"
 // VerifiableNow reports whether this credential's public key may still be
 // used to VERIFY an attestation right now. The rule is the correctness
 // crux: a merely-expired key (past NotAfter) still verifies historical
-// receipts while inside the audit-retention window; only a *revoked* key
-// is rejected outright.
+// attestations while inside the audit-retention window; only a *revoked*
+// key is rejected outright.
 func (c *SigningCredential) VerifiableNow(now time.Time) bool {
 	if c.Revoked {
 		return false

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -35,6 +35,7 @@ type API struct {
 	auditSvc             *service.AuditService
 	backchannelSvc       *service.BackchannelService
 	jwksSvc              *signing.JWKSService
+	signingCredSvc       *service.SigningCredentialService
 	db                   *bun.DB
 	issuer               string
 	baseURL              string
@@ -57,6 +58,7 @@ func NewAPI(
 	auditSvc *service.AuditService,
 	backchannelSvc *service.BackchannelService,
 	jwksSvc *signing.JWKSService,
+	signingCredSvc *service.SigningCredentialService,
 	db *bun.DB,
 	issuer, baseURL string,
 ) *API {
@@ -75,6 +77,7 @@ func NewAPI(
 		auditSvc:             auditSvc,
 		backchannelSvc:       backchannelSvc,
 		jwksSvc:              jwksSvc,
+		signingCredSvc:       signingCredSvc,
 		db:                   db,
 		issuer:               issuer,
 		baseURL:              baseURL,
@@ -105,6 +108,7 @@ func NewHumaAPI(router chi.Router) huma.API {
 func (a *API) RegisterPublic(api huma.API, router chi.Router) {
 	a.registerHealthRoutes(api)
 	a.registerWellKnownRoutes(api)
+	a.registerSigningJWKSRoute(api)
 	a.registerOAuthRoutes(api)
 	a.registerAuthVerifyRoute(router)
 }
@@ -126,6 +130,7 @@ func (a *API) RegisterAdmin(api huma.API, router chi.Router) {
 	a.registerAuditRoutes(api)
 	a.registerBackchannelAdminRoutes(api)
 	a.registerExpiringSoonRoute(api)
+	a.registerSigningCredentialRoutes(api)
 }
 
 // RegisterAgentAuth registers endpoints requiring agent-auth middleware (proof generation).

--- a/internal/handler/signing_credential.go
+++ b/internal/handler/signing_credential.go
@@ -1,0 +1,137 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/highflame-ai/zeroid/internal/service"
+)
+
+// ── Workload-attested ephemeral signing credentials ──────────────────────────
+//
+// Attest + revoke are ADMIN routes: the deployer's admin-auth middleware
+// (AuthN's InternalServiceAuth) only lets trusted internal services
+// reach them and validates X-Internal-Service against the shared secret,
+// so by the time these handlers run the caller is a proven trusted
+// service and X-Internal-Service is its identity. The verification JWKS
+// is a PUBLIC route — offline verification by any party is the point;
+// only non-secret public keys are exposed.
+
+type attestSigningKeyInput struct {
+	Workload  string `header:"X-Internal-Service" doc:"Attesting workload (validated by admin auth)"`
+	AccountID string `header:"X-Account-ID"`
+	ProjectID string `header:"X-Project-ID"`
+	Body      struct {
+		PublicKey  string `json:"public_key"  doc:"base64url Ed25519 public key (32 bytes)"`
+		Algorithm  string `json:"algorithm"   doc:"EdDSA"`
+		Purpose    string `json:"purpose"     doc:"receipt | authz_audit"`
+		TTLSeconds int    `json:"ttl_seconds" doc:"requested operational signing window"`
+	}
+}
+
+type attestSigningKeyOutput struct {
+	Body service.AttestResult
+}
+
+type revokeSigningKeyInput struct {
+	KID      string `path:"kid"`
+	Workload string `header:"X-Internal-Service"`
+	Body     struct {
+		Reason string `json:"reason,omitempty"`
+	}
+}
+
+type revokeSigningKeyOutput struct {
+	Body struct {
+		KID     string `json:"kid"`
+		Revoked bool   `json:"revoked"`
+	}
+}
+
+type signingJWKSOutput struct {
+	Body *service.JWKS
+}
+
+func (a *API) registerSigningCredentialRoutes(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "attest-signing-credential",
+		Method:      http.MethodPost,
+		Path:        "/signing-credentials",
+		Summary:     "Attest a workload's ephemeral signing public key",
+		Tags:        []string{"Attestation"},
+	}, a.attestSigningKeyOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "revoke-signing-credential",
+		Method:      http.MethodPost,
+		Path:        "/signing-credentials/{kid}/revoke",
+		Summary:     "Revoke an attested signing credential (CAE / manual)",
+		Tags:        []string{"Attestation"},
+	}, a.revokeSigningKeyOp)
+}
+
+// registerSigningJWKSRoute is PUBLIC (no auth) — registered on the public
+// group so AuthN exposes it unauthenticated for offline verification.
+func (a *API) registerSigningJWKSRoute(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "receipt-jwks",
+		Method:      http.MethodGet,
+		Path:        "/.well-known/highflame-receipt-keys",
+		Summary:     "Receipt verification JWKS (non-revoked, audit-retained)",
+		Tags:        []string{"Discovery"},
+	}, a.signingJWKSOp)
+}
+
+func (a *API) attestSigningKeyOp(ctx context.Context, in *attestSigningKeyInput) (*attestSigningKeyOutput, error) {
+	res, err := a.signingCredSvc.Attest(ctx, service.AttestRequest{
+		Workload:   in.Workload,
+		AccountID:  in.AccountID,
+		ProjectID:  in.ProjectID,
+		PublicKey:  in.Body.PublicKey,
+		Algorithm:  in.Body.Algorithm,
+		Purpose:    in.Body.Purpose,
+		TTLSeconds: in.Body.TTLSeconds,
+	})
+	if err != nil {
+		if errors.Is(err, service.ErrSigningCredInvalid) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+
+		return nil, huma.Error500InternalServerError("failed to attest signing credential")
+	}
+
+	return &attestSigningKeyOutput{Body: *res}, nil
+}
+
+func (a *API) revokeSigningKeyOp(ctx context.Context, in *revokeSigningKeyInput) (*revokeSigningKeyOutput, error) {
+	if in.Workload == "" {
+		return nil, huma.Error401Unauthorized("caller is not a trusted internal service")
+	}
+
+	revoked, err := a.signingCredSvc.RevokeKID(ctx, in.KID, in.Workload, in.Body.Reason)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to revoke signing credential")
+	}
+
+	if !revoked {
+		return nil, huma.Error404NotFound("no active credential with that kid for this workload")
+	}
+
+	out := &revokeSigningKeyOutput{}
+	out.Body.KID = in.KID
+	out.Body.Revoked = true
+
+	return out, nil
+}
+
+func (a *API) signingJWKSOp(ctx context.Context, _ *struct{}) (*signingJWKSOutput, error) {
+	set, err := a.signingCredSvc.VerificationJWKS(ctx, "receipt")
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to build receipt JWKS")
+	}
+
+	return &signingJWKSOutput{Body: set}, nil
+}

--- a/internal/handler/signing_credential.go
+++ b/internal/handler/signing_credential.go
@@ -7,24 +7,30 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 
+	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
 	"github.com/highflame-ai/zeroid/internal/service"
 )
 
 // ── Workload-attested ephemeral signing credentials ──────────────────────────
 //
-// Attest + revoke are ADMIN routes: the deployer's admin-auth middleware
-// (AuthN's InternalServiceAuth) only lets trusted internal services
-// reach them and validates X-Internal-Service against the shared secret,
-// so by the time these handlers run the caller is a proven trusted
-// service and X-Internal-Service is its identity. The verification JWKS
-// is a PUBLIC route — offline verification by any party is the point;
-// only non-secret public keys are exposed.
+// Attest + revoke are ADMIN routes. ZeroID's admin surface performs no
+// authentication of its own: it is operator-protected at the network
+// layer (separate port, not externally exposed; VPN / service mesh /
+// reverse proxy, or the deployer's optional admin-auth hook) — see
+// TenantContextMiddleware. Authorization within that surface is tenant
+// isolation: every read/write is scoped to the (account_id, project_id)
+// derived from the validated tenant context (GetTenant, fail-closed),
+// exactly like every other ZeroID admin handler. `X-Internal-Service` is
+// a logical workload label (e.g. which signer attested this key) that is
+// only ever trusted within an already tenant-scoped, operator-protected
+// request — never as a standalone cross-tenant principal. The
+// verification JWKS is a PUBLIC route: offline verification by any party
+// is the point, and only non-secret public keys, keyed by a globally
+// unique kid, are exposed.
 
 type attestSigningKeyInput struct {
-	Workload  string `header:"X-Internal-Service" doc:"Attesting workload (validated by admin auth)"`
-	AccountID string `header:"X-Account-ID"`
-	ProjectID string `header:"X-Project-ID"`
-	Body      struct {
+	Workload string `header:"X-Internal-Service" doc:"Attesting workload label (tenant-scoped)"`
+	Body     struct {
 		PublicKey  string `json:"public_key"  doc:"base64url Ed25519 public key (32 bytes)"`
 		Algorithm  string `json:"algorithm"   doc:"EdDSA"`
 		Purpose    string `json:"purpose"     doc:"receipt | authz_audit"`
@@ -86,10 +92,19 @@ func (a *API) registerSigningJWKSRoute(api huma.API) {
 }
 
 func (a *API) attestSigningKeyOp(ctx context.Context, in *attestSigningKeyInput) (*attestSigningKeyOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	if in.Workload == "" {
+		return nil, huma.Error401Unauthorized("caller is not a trusted internal service")
+	}
+
 	res, err := a.signingCredSvc.Attest(ctx, service.AttestRequest{
 		Workload:   in.Workload,
-		AccountID:  in.AccountID,
-		ProjectID:  in.ProjectID,
+		AccountID:  tenant.AccountID,
+		ProjectID:  tenant.ProjectID,
 		PublicKey:  in.Body.PublicKey,
 		Algorithm:  in.Body.Algorithm,
 		Purpose:    in.Body.Purpose,
@@ -107,11 +122,16 @@ func (a *API) attestSigningKeyOp(ctx context.Context, in *attestSigningKeyInput)
 }
 
 func (a *API) revokeSigningKeyOp(ctx context.Context, in *revokeSigningKeyInput) (*revokeSigningKeyOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
 	if in.Workload == "" {
 		return nil, huma.Error401Unauthorized("caller is not a trusted internal service")
 	}
 
-	revoked, err := a.signingCredSvc.RevokeKID(ctx, in.KID, in.Workload, in.Body.Reason)
+	revoked, err := a.signingCredSvc.RevokeKID(ctx, in.KID, in.Workload, tenant.AccountID, tenant.ProjectID, in.Body.Reason)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to revoke signing credential")
 	}

--- a/internal/handler/signing_credential.go
+++ b/internal/handler/signing_credential.go
@@ -33,7 +33,7 @@ type attestSigningKeyInput struct {
 	Body     struct {
 		PublicKey  string `json:"public_key"  doc:"base64url Ed25519 public key (32 bytes)"`
 		Algorithm  string `json:"algorithm"   doc:"EdDSA"`
-		Purpose    string `json:"purpose"     doc:"receipt | authz_audit"`
+		Purpose    string `json:"purpose"     doc:"one of the deployment's configured signing purposes"`
 		TTLSeconds int    `json:"ttl_seconds" doc:"requested operational signing window"`
 	}
 }
@@ -79,14 +79,21 @@ func (a *API) registerSigningCredentialRoutes(api huma.API) {
 	}, a.revokeSigningKeyOp)
 }
 
-// registerSigningJWKSRoute is PUBLIC (no auth) — registered on the public
-// group so AuthN exposes it unauthenticated for offline verification.
+// registerSigningJWKSRoute is PUBLIC (no auth) — the verification JWKS is
+// meant to be fetched unauthenticated for offline verification. The path
+// is deployer-configured (SigningCredsConfig.WellKnownJWKSName); the
+// route is only registered when a JWKS purpose is configured, so a
+// default product-agnostic ZeroID exposes nothing here.
 func (a *API) registerSigningJWKSRoute(api huma.API) {
+	if !a.signingCredSvc.JWKSEnabled() {
+		return
+	}
+
 	huma.Register(api, huma.Operation{
-		OperationID: "receipt-jwks",
+		OperationID: "signing-credential-jwks",
 		Method:      http.MethodGet,
-		Path:        "/.well-known/highflame-receipt-keys",
-		Summary:     "Receipt verification JWKS (non-revoked, audit-retained)",
+		Path:        a.signingCredSvc.WellKnownPath(),
+		Summary:     "Workload-attested signing verification JWKS (non-revoked, audit-retained)",
 		Tags:        []string{"Discovery"},
 	}, a.signingJWKSOp)
 }
@@ -148,9 +155,9 @@ func (a *API) revokeSigningKeyOp(ctx context.Context, in *revokeSigningKeyInput)
 }
 
 func (a *API) signingJWKSOp(ctx context.Context, _ *struct{}) (*signingJWKSOutput, error) {
-	set, err := a.signingCredSvc.VerificationJWKS(ctx, "receipt")
+	set, err := a.signingCredSvc.VerificationJWKS(ctx)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("failed to build receipt JWKS")
+		return nil, huma.Error500InternalServerError("failed to build verification JWKS")
 	}
 
 	return &signingJWKSOutput{Body: set}, nil

--- a/internal/service/signing_credential.go
+++ b/internal/service/signing_credential.go
@@ -183,10 +183,11 @@ func (s *SigningCredentialService) VerificationJWKS(ctx context.Context, purpose
 	return out, nil
 }
 
-// RevokeKID revokes one credential (the attesting workload only). A
-// revoked key fails verification immediately, regardless of retention.
-func (s *SigningCredentialService) RevokeKID(ctx context.Context, kid, workload, reason string) (bool, error) {
-	n, err := s.repo.RevokeKID(ctx, kid, workload, reason, time.Now())
+// RevokeKID revokes one credential within the caller's tenant, scoped to
+// the attesting workload. A revoked key fails verification immediately,
+// regardless of retention.
+func (s *SigningCredentialService) RevokeKID(ctx context.Context, kid, workload, accountID, projectID, reason string) (bool, error) {
+	n, err := s.repo.RevokeKID(ctx, kid, workload, accountID, projectID, reason, time.Now())
 	if err != nil {
 		return false, err
 	}
@@ -194,10 +195,11 @@ func (s *SigningCredentialService) RevokeKID(ctx context.Context, kid, workload,
 	return n > 0, nil
 }
 
-// RevokeWorkload revokes every active key for a workload — the CAE entry
-// point (call on a credential_compromise / trust_level_downgrade signal).
-func (s *SigningCredentialService) RevokeWorkload(ctx context.Context, workload, reason string) (int64, error) {
-	return s.repo.RevokeWorkload(ctx, workload, reason, time.Now())
+// RevokeWorkload revokes every active key for a workload within a tenant
+// — the CAE entry point (call on a credential_compromise /
+// trust_level_downgrade signal).
+func (s *SigningCredentialService) RevokeWorkload(ctx context.Context, workload, accountID, projectID, reason string) (int64, error) {
+	return s.repo.RevokeWorkload(ctx, workload, accountID, projectID, reason, time.Now())
 }
 
 // mintKID returns a collision-safe, sanitized, informative key id.

--- a/internal/service/signing_credential.go
+++ b/internal/service/signing_credential.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
+)
+
+// ErrSigningCredInvalid is returned when an attestation request is
+// malformed (bad key, unsupported alg/purpose).
+var ErrSigningCredInvalid = errors.New("invalid signing-credential attestation request")
+
+const (
+	defaultSigningMaxTTL          = time.Hour
+	defaultSigningRetentionWindow = 400 * 24 * time.Hour
+	kidRandomBytes                = 8
+)
+
+// SigningCredentialService attests workload-supplied Ed25519 public keys,
+// publishes the verification JWKS, and revokes via CAE. The private key
+// never reaches ZeroID — only the public half is ever submitted/stored.
+type SigningCredentialService struct {
+	repo            *postgres.SigningCredentialRepository
+	maxTTL          time.Duration
+	retentionWindow time.Duration
+}
+
+// NewSigningCredentialService builds the service. ttlSeconds /
+// retentionDays come from zeroid.Config (sane defaults applied).
+func NewSigningCredentialService(repo *postgres.SigningCredentialRepository, ttlSeconds, retentionDays int) *SigningCredentialService {
+	maxTTL := time.Duration(ttlSeconds) * time.Second
+	if maxTTL <= 0 {
+		maxTTL = defaultSigningMaxTTL
+	}
+
+	retention := time.Duration(retentionDays) * 24 * time.Hour
+	if retention <= 0 {
+		retention = defaultSigningRetentionWindow
+	}
+
+	return &SigningCredentialService{repo: repo, maxTTL: maxTTL, retentionWindow: retention}
+}
+
+// AttestRequest is a workload's request to register an ephemeral public
+// key. Workload is the authenticated trusted-service identity (resolved
+// by the handler from the caller context, not client-supplied).
+type AttestRequest struct {
+	Workload   string
+	AccountID  string
+	ProjectID  string
+	PublicKey  string // base64 raw-url Ed25519 public key (32 bytes)
+	Algorithm  string // must be EdDSA
+	Purpose    string // receipt | authz_audit
+	TTLSeconds int
+}
+
+// AttestResult is what the workload gets back: the minted kid and the
+// operational expiry. No key material is returned (ZeroID never had the
+// private half; the public half the caller already holds).
+type AttestResult struct {
+	KID      string    `json:"kid"`
+	NotAfter time.Time `json:"not_after"`
+}
+
+var allowedPurposes = map[string]bool{
+	domain.SigningPurposeReceipt:    true,
+	domain.SigningPurposeAuthZAudit: true,
+}
+
+// Attest validates and records an ephemeral public key. NotAfter bounds
+// signing; AuditRetentionUntil (>> NotAfter) bounds verifiability so a
+// rotated/expired key still verifies historical attestations.
+func (s *SigningCredentialService) Attest(ctx context.Context, req AttestRequest) (*AttestResult, error) {
+	if strings.TrimSpace(req.Workload) == "" {
+		return nil, fmt.Errorf("%w: missing workload identity", ErrSigningCredInvalid)
+	}
+
+	if req.Algorithm != domain.SigningAlgorithmEdDSA {
+		return nil, fmt.Errorf("%w: unsupported algorithm %q (only EdDSA)", ErrSigningCredInvalid, req.Algorithm)
+	}
+
+	if !allowedPurposes[req.Purpose] {
+		return nil, fmt.Errorf("%w: purpose %q not permitted", ErrSigningCredInvalid, req.Purpose)
+	}
+
+	pub, err := base64.RawURLEncoding.DecodeString(req.PublicKey)
+	if err != nil || len(pub) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%w: public_key must be base64url 32-byte Ed25519", ErrSigningCredInvalid)
+	}
+
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	if ttl <= 0 || ttl > s.maxTTL {
+		ttl = s.maxTTL
+	}
+
+	kid, err := mintKID(req.Purpose, req.Workload)
+	if err != nil {
+		return nil, fmt.Errorf("minting kid: %w", err)
+	}
+
+	now := time.Now()
+	cred := &domain.SigningCredential{
+		AccountID:           req.AccountID,
+		ProjectID:           req.ProjectID,
+		KID:                 kid,
+		Workload:            req.Workload,
+		Purpose:             req.Purpose,
+		Algorithm:           domain.SigningAlgorithmEdDSA,
+		PublicKey:           req.PublicKey,
+		NotAfter:            now.Add(ttl),
+		AuditRetentionUntil: now.Add(s.retentionWindow),
+	}
+
+	if err := s.repo.Create(ctx, cred); err != nil {
+		return nil, err
+	}
+
+	log.Info().
+		Str("workload", req.Workload).
+		Str("purpose", req.Purpose).
+		Str("kid", kid).
+		Time("not_after", cred.NotAfter).
+		Time("audit_retention_until", cred.AuditRetentionUntil).
+		Msg("signing credential attested")
+
+	return &AttestResult{KID: kid, NotAfter: cred.NotAfter}, nil
+}
+
+// JWK is one RFC 7517 / RFC 8037 OKP Ed25519 public key. Emitted as a
+// plain struct (not jwk.Set) because the public key is already stored
+// base64url — re-importing it through jwx would be lossy churn, and the
+// verifier contract only needs these fields.
+type JWK struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+}
+
+// JWKS is the verification key set served at the well-known path.
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// VerificationJWKS returns every key that may currently VERIFY a receipt
+// for the purpose: non-revoked AND inside the audit-retention window —
+// deliberately including operationally-expired keys so attestations
+// signed before a rotation still verify. Kid-sorted for a stable doc.
+func (s *SigningCredentialService) VerificationJWKS(ctx context.Context, purpose string) (*JWKS, error) {
+	creds, err := s.repo.ListVerifiable(ctx, purpose, time.Now())
+	if err != nil {
+		return nil, err
+	}
+
+	out := &JWKS{Keys: make([]JWK, 0, len(creds))}
+	for _, c := range creds {
+		out.Keys = append(out.Keys, JWK{
+			Kty: "OKP",
+			Crv: "Ed25519",
+			X:   c.PublicKey,
+			Use: "sig",
+			Alg: domain.SigningAlgorithmEdDSA,
+			Kid: c.KID,
+		})
+	}
+
+	sort.Slice(out.Keys, func(i, j int) bool { return out.Keys[i].Kid < out.Keys[j].Kid })
+
+	return out, nil
+}
+
+// RevokeKID revokes one credential (the attesting workload only). A
+// revoked key fails verification immediately, regardless of retention.
+func (s *SigningCredentialService) RevokeKID(ctx context.Context, kid, workload, reason string) (bool, error) {
+	n, err := s.repo.RevokeKID(ctx, kid, workload, reason, time.Now())
+	if err != nil {
+		return false, err
+	}
+
+	return n > 0, nil
+}
+
+// RevokeWorkload revokes every active key for a workload — the CAE entry
+// point (call on a credential_compromise / trust_level_downgrade signal).
+func (s *SigningCredentialService) RevokeWorkload(ctx context.Context, workload, reason string) (int64, error) {
+	return s.repo.RevokeWorkload(ctx, workload, reason, time.Now())
+}
+
+// mintKID returns a collision-safe, sanitized, informative key id.
+// Opaque to verifiers (they only match it); encoding purpose+workload
+// aids audit. Hostile workload/purpose strings are neutralized — the kid
+// is echoed into receipts and the JWKS.
+func mintKID(purpose, workload string) (string, error) {
+	var b [kidRandomBytes]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	clean := func(in string) string {
+		return strings.Map(func(r rune) rune {
+			if r == '-' || r == '_' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+				return r
+			}
+
+			return '-'
+		}, strings.ToLower(in))
+	}
+
+	return fmt.Sprintf("%s-%s-%s", clean(purpose), clean(workload), hex.EncodeToString(b[:])), nil
+}

--- a/internal/service/signing_credential.go
+++ b/internal/service/signing_credential.go
@@ -26,6 +26,10 @@ const (
 	defaultSigningMaxTTL          = time.Hour
 	defaultSigningRetentionWindow = 400 * 24 * time.Hour
 	kidRandomBytes                = 8
+	// defaultSigningJWKSName mirrors zeroid.DefaultSigningJWKSName for the
+	// blank-name fallback (the root config package can't be imported here
+	// without an import cycle; the config layer normally supplies it).
+	defaultSigningJWKSName = "signing-keys"
 )
 
 // SigningCredentialService attests workload-supplied Ed25519 public keys,
@@ -35,11 +39,18 @@ type SigningCredentialService struct {
 	repo            *postgres.SigningCredentialRepository
 	maxTTL          time.Duration
 	retentionWindow time.Duration
+	allowedPurposes map[string]bool
+	jwksPurpose     string
+	wellKnownName   string
 }
 
 // NewSigningCredentialService builds the service. ttlSeconds /
-// retentionDays come from zeroid.Config (sane defaults applied).
-func NewSigningCredentialService(repo *postgres.SigningCredentialRepository, ttlSeconds, retentionDays int) *SigningCredentialService {
+// retentionDays / allowedPurposes / jwksPurpose / wellKnownName all come
+// from zeroid.Config (deployer-supplied). ZeroID is product-agnostic:
+// allowedPurposes is empty unless the deployment opts in, so a default
+// ZeroID accepts no attestations until configured. wellKnownName
+// defaults to DefaultSigningJWKSName when blank.
+func NewSigningCredentialService(repo *postgres.SigningCredentialRepository, ttlSeconds, retentionDays int, allowedPurposes []string, jwksPurpose, wellKnownName string) *SigningCredentialService {
 	maxTTL := time.Duration(ttlSeconds) * time.Second
 	if maxTTL <= 0 {
 		maxTTL = defaultSigningMaxTTL
@@ -50,7 +61,36 @@ func NewSigningCredentialService(repo *postgres.SigningCredentialRepository, ttl
 		retention = defaultSigningRetentionWindow
 	}
 
-	return &SigningCredentialService{repo: repo, maxTTL: maxTTL, retentionWindow: retention}
+	allow := make(map[string]bool, len(allowedPurposes))
+	for _, p := range allowedPurposes {
+		if p != "" {
+			allow[p] = true
+		}
+	}
+
+	if wellKnownName == "" {
+		wellKnownName = defaultSigningJWKSName
+	}
+
+	return &SigningCredentialService{
+		repo:            repo,
+		maxTTL:          maxTTL,
+		retentionWindow: retention,
+		allowedPurposes: allow,
+		jwksPurpose:     jwksPurpose,
+		wellKnownName:   wellKnownName,
+	}
+}
+
+// WellKnownPath is the public route the verification JWKS is served at.
+func (s *SigningCredentialService) WellKnownPath() string {
+	return "/.well-known/" + s.wellKnownName
+}
+
+// JWKSEnabled reports whether a verification JWKS purpose is configured;
+// when false the public JWKS route is not registered (feature dormant).
+func (s *SigningCredentialService) JWKSEnabled() bool {
+	return s.jwksPurpose != ""
 }
 
 // AttestRequest is a workload's request to register an ephemeral public
@@ -62,7 +102,7 @@ type AttestRequest struct {
 	ProjectID  string
 	PublicKey  string // base64 raw-url Ed25519 public key (32 bytes)
 	Algorithm  string // must be EdDSA
-	Purpose    string // receipt | authz_audit
+	Purpose    string // must be in the deployer's AllowedPurposes
 	TTLSeconds int
 }
 
@@ -72,11 +112,6 @@ type AttestRequest struct {
 type AttestResult struct {
 	KID      string    `json:"kid"`
 	NotAfter time.Time `json:"not_after"`
-}
-
-var allowedPurposes = map[string]bool{
-	domain.SigningPurposeReceipt:    true,
-	domain.SigningPurposeAuthZAudit: true,
 }
 
 // Attest validates and records an ephemeral public key. NotAfter bounds
@@ -91,7 +126,7 @@ func (s *SigningCredentialService) Attest(ctx context.Context, req AttestRequest
 		return nil, fmt.Errorf("%w: unsupported algorithm %q (only EdDSA)", ErrSigningCredInvalid, req.Algorithm)
 	}
 
-	if !allowedPurposes[req.Purpose] {
+	if !s.allowedPurposes[req.Purpose] {
 		return nil, fmt.Errorf("%w: purpose %q not permitted", ErrSigningCredInvalid, req.Purpose)
 	}
 
@@ -156,12 +191,13 @@ type JWKS struct {
 	Keys []JWK `json:"keys"`
 }
 
-// VerificationJWKS returns every key that may currently VERIFY a receipt
-// for the purpose: non-revoked AND inside the audit-retention window —
-// deliberately including operationally-expired keys so attestations
-// signed before a rotation still verify. Kid-sorted for a stable doc.
-func (s *SigningCredentialService) VerificationJWKS(ctx context.Context, purpose string) (*JWKS, error) {
-	creds, err := s.repo.ListVerifiable(ctx, purpose, time.Now())
+// VerificationJWKS returns every key that may currently VERIFY an
+// attestation for the configured JWKS purpose: non-revoked AND inside the
+// audit-retention window — deliberately including operationally-expired
+// keys so attestations signed before a rotation still verify. Kid-sorted
+// for a stable doc.
+func (s *SigningCredentialService) VerificationJWKS(ctx context.Context) (*JWKS, error) {
+	creds, err := s.repo.ListVerifiable(ctx, s.jwksPurpose, time.Now())
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +241,7 @@ func (s *SigningCredentialService) RevokeWorkload(ctx context.Context, workload,
 // mintKID returns a collision-safe, sanitized, informative key id.
 // Opaque to verifiers (they only match it); encoding purpose+workload
 // aids audit. Hostile workload/purpose strings are neutralized — the kid
-// is echoed into receipts and the JWKS.
+// is echoed into signed artifacts and the JWKS.
 func mintKID(purpose, workload string) (string, error) {
 	var b [kidRandomBytes]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/internal/service/signing_credential_test.go
+++ b/internal/service/signing_credential_test.go
@@ -1,0 +1,167 @@
+package service
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// The correctness crux of workload-attested signing: a merely-expired
+// (rotated / pod-gone) key must still VERIFY historical attestations
+// within the audit-retention window; only a REVOKED key fails outright.
+// A not_after-only filter cannot express this — these tests pin it.
+
+func TestSigningCredential_VerifiableVsSignable(t *testing.T) {
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name           string
+		notAfter       time.Time
+		retentionUntil time.Time
+		revoked        bool
+		wantSignable   bool
+		wantVerifiable bool
+	}{
+		{
+			name:           "fresh key: signable and verifiable",
+			notAfter:       now.Add(time.Hour),
+			retentionUntil: now.Add(400 * 24 * time.Hour),
+			wantSignable:   true,
+			wantVerifiable: true,
+		},
+		{
+			name:           "expired-but-retained: NOT signable, STILL verifiable",
+			notAfter:       now.Add(-2 * time.Hour), // operational window passed (rotation)
+			retentionUntil: now.Add(300 * 24 * time.Hour),
+			wantSignable:   false,
+			wantVerifiable: true, // the property that matters for historical receipts
+		},
+		{
+			name:           "revoked: neither signable nor verifiable (even within retention)",
+			notAfter:       now.Add(time.Hour),
+			retentionUntil: now.Add(400 * 24 * time.Hour),
+			revoked:        true,
+			wantSignable:   false,
+			wantVerifiable: false,
+		},
+		{
+			name:           "past retention: not verifiable (audit window elapsed)",
+			notAfter:       now.Add(-300 * 24 * time.Hour),
+			retentionUntil: now.Add(-time.Hour),
+			wantSignable:   false,
+			wantVerifiable: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &domain.SigningCredential{
+				NotAfter:            tc.notAfter,
+				AuditRetentionUntil: tc.retentionUntil,
+				Revoked:             tc.revoked,
+			}
+
+			if got := c.SignableNow(now); got != tc.wantSignable {
+				t.Errorf("SignableNow = %v, want %v", got, tc.wantSignable)
+			}
+
+			if got := c.VerifiableNow(now); got != tc.wantVerifiable {
+				t.Errorf("VerifiableNow = %v, want %v", got, tc.wantVerifiable)
+			}
+		})
+	}
+}
+
+func TestMintKID(t *testing.T) {
+	const n = 20000
+
+	seen := make(map[string]struct{}, n)
+
+	for i := 0; i < n; i++ {
+		k, err := mintKID("receipt", "highflame-shield")
+		if err != nil {
+			t.Fatalf("mintKID error: %v", err)
+		}
+
+		if _, dup := seen[k]; dup {
+			t.Fatalf("kid collision after %d iterations: %q", i, k)
+		}
+
+		seen[k] = struct{}{}
+	}
+
+	// Format: <purpose>-<workload>-<16 hex>.
+	k, _ := mintKID("receipt", "highflame-shield")
+	if !strings.HasPrefix(k, "receipt-highflame-shield-") {
+		t.Fatalf("unexpected kid prefix: %q", k)
+	}
+
+	// Hostile workload/purpose must be neutralized — kid is echoed into
+	// receipts and the JWKS.
+	bad, _ := mintKID("RE CEIPT", "Evil/../Workload\n")
+	for _, frag := range []string{"/", "..", "\n", " ", "EVIL", "RE CEIPT"} {
+		if strings.Contains(bad, frag) {
+			t.Fatalf("kid %q contains un-sanitized fragment %q", bad, frag)
+		}
+	}
+
+	for _, r := range bad {
+		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+			t.Fatalf("kid %q has illegal rune %q", bad, r)
+		}
+	}
+}
+
+func TestAttest_RejectsInvalidInput(t *testing.T) {
+	// Validation happens before any repo call, so a nil repo is safe here
+	// and proves these requests never reach persistence.
+	s := NewSigningCredentialService(nil, 3600, 400)
+	ctx := t.Context()
+
+	valid := func() AttestRequest {
+		return AttestRequest{
+			Workload:  "highflame-shield",
+			PublicKey: strings.Repeat("A", 43), // 32 bytes base64url ≈ 43 chars
+			Algorithm: domain.SigningAlgorithmEdDSA,
+			Purpose:   domain.SigningPurposeReceipt,
+		}
+	}
+
+	t.Run("missing workload", func(t *testing.T) {
+		r := valid()
+		r.Workload = ""
+
+		if _, err := s.Attest(ctx, r); err == nil {
+			t.Fatal("expected rejection for missing workload")
+		}
+	})
+
+	t.Run("wrong algorithm", func(t *testing.T) {
+		r := valid()
+		r.Algorithm = "RS256"
+
+		if _, err := s.Attest(ctx, r); err == nil {
+			t.Fatal("expected rejection for non-EdDSA algorithm")
+		}
+	})
+
+	t.Run("disallowed purpose", func(t *testing.T) {
+		r := valid()
+		r.Purpose = "exfiltrate"
+
+		if _, err := s.Attest(ctx, r); err == nil {
+			t.Fatal("expected rejection for disallowed purpose")
+		}
+	})
+
+	t.Run("malformed public key", func(t *testing.T) {
+		r := valid()
+		r.PublicKey = "not-base64url-or-wrong-size"
+
+		if _, err := s.Attest(ctx, r); err == nil {
+			t.Fatal("expected rejection for malformed public key")
+		}
+	})
+}

--- a/internal/service/signing_credential_test.go
+++ b/internal/service/signing_credential_test.go
@@ -117,7 +117,7 @@ func TestMintKID(t *testing.T) {
 func TestAttest_RejectsInvalidInput(t *testing.T) {
 	// Validation happens before any repo call, so a nil repo is safe here
 	// and proves these requests never reach persistence.
-	s := NewSigningCredentialService(nil, 3600, 400)
+	s := NewSigningCredentialService(nil, 3600, 400, []string{"receipt"}, "receipt", "")
 	ctx := t.Context()
 
 	valid := func() AttestRequest {
@@ -125,7 +125,7 @@ func TestAttest_RejectsInvalidInput(t *testing.T) {
 			Workload:  "highflame-shield",
 			PublicKey: strings.Repeat("A", 43), // 32 bytes base64url ≈ 43 chars
 			Algorithm: domain.SigningAlgorithmEdDSA,
-			Purpose:   domain.SigningPurposeReceipt,
+			Purpose:   "receipt", // in the test service's AllowedPurposes
 		}
 	}
 

--- a/internal/service/signing_credential_test.go
+++ b/internal/service/signing_credential_test.go
@@ -108,7 +108,7 @@ func TestMintKID(t *testing.T) {
 	}
 
 	for _, r := range bad {
-		if !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-') {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' {
 			t.Fatalf("kid %q has illegal rune %q", bad, r)
 		}
 	}

--- a/internal/store/postgres/signing_credential.go
+++ b/internal/store/postgres/signing_credential.go
@@ -61,7 +61,7 @@ func (r *SigningCredentialRepository) GetByKID(ctx context.Context, kid, account
 // verify an attestation for a purpose: non-revoked AND inside the
 // audit-retention window (independent of not_after). This is the JWKS
 // source — it intentionally includes operationally-expired keys so
-// already-emitted receipts keep verifying after key rotation.
+// already-emitted attestations keep verifying after key rotation.
 func (r *SigningCredentialRepository) ListVerifiable(ctx context.Context, purpose string, now time.Time) ([]*domain.SigningCredential, error) {
 	var creds []*domain.SigningCredential
 

--- a/internal/store/postgres/signing_credential.go
+++ b/internal/store/postgres/signing_credential.go
@@ -32,16 +32,20 @@ func (r *SigningCredentialRepository) Create(ctx context.Context, c *domain.Sign
 	return nil
 }
 
-// GetByKID resolves a credential by kid for VERIFICATION. It deliberately
-// does NOT filter on not_after — an expired (rotated / pod-gone) key must
-// still resolve so historical attestations verify within the
-// audit-retention window. Revoked/retention semantics are the caller's
-// (domain.SigningCredential.VerifiableNow). Returns (nil, nil) when no
-// such kid exists.
-func (r *SigningCredentialRepository) GetByKID(ctx context.Context, kid string) (*domain.SigningCredential, error) {
+// GetByKID resolves a credential by kid within a tenant for
+// VERIFICATION. It deliberately does NOT filter on not_after — an expired
+// (rotated / pod-gone) key must still resolve so historical attestations
+// verify within the audit-retention window. Revoked/retention semantics
+// are the caller's (domain.SigningCredential.VerifiableNow). Returns
+// (nil, nil) when no such kid exists for the tenant.
+func (r *SigningCredentialRepository) GetByKID(ctx context.Context, kid, accountID, projectID string) (*domain.SigningCredential, error) {
 	c := &domain.SigningCredential{}
 
-	err := r.db.NewSelect().Model(c).Where("kid = ?", kid).Scan(ctx)
+	err := r.db.NewSelect().Model(c).
+		Where("kid = ?", kid).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Scan(ctx)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -74,16 +78,18 @@ func (r *SigningCredentialRepository) ListVerifiable(ctx context.Context, purpos
 	return creds, nil
 }
 
-// RevokeWorkload revokes every non-revoked credential for a workload —
-// the CAE entry point. A revoked key fails verification immediately,
-// regardless of its retention window.
-func (r *SigningCredentialRepository) RevokeWorkload(ctx context.Context, workload, reason string, at time.Time) (int64, error) {
+// RevokeWorkload revokes every non-revoked credential for a workload
+// within a tenant — the CAE entry point. A revoked key fails
+// verification immediately, regardless of its retention window.
+func (r *SigningCredentialRepository) RevokeWorkload(ctx context.Context, workload, accountID, projectID, reason string, at time.Time) (int64, error) {
 	res, err := r.db.NewUpdate().
 		Model((*domain.SigningCredential)(nil)).
 		Set("revoked = ?", true).
 		Set("revoked_reason = ?", reason).
 		Set("revoked_at = ?", at).
 		Where("workload = ?", workload).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
 		Where("revoked = ?", false).
 		Exec(ctx)
 	if err != nil {
@@ -95,9 +101,10 @@ func (r *SigningCredentialRepository) RevokeWorkload(ctx context.Context, worklo
 	return n, nil
 }
 
-// RevokeKID revokes a single credential by kid, scoped to its attesting
-// workload (no cross-workload revocation through this path).
-func (r *SigningCredentialRepository) RevokeKID(ctx context.Context, kid, workload, reason string, at time.Time) (int64, error) {
+// RevokeKID revokes a single credential by kid within a tenant, scoped
+// to its attesting workload (no cross-tenant or cross-workload
+// revocation through this path).
+func (r *SigningCredentialRepository) RevokeKID(ctx context.Context, kid, workload, accountID, projectID, reason string, at time.Time) (int64, error) {
 	res, err := r.db.NewUpdate().
 		Model((*domain.SigningCredential)(nil)).
 		Set("revoked = ?", true).
@@ -105,6 +112,8 @@ func (r *SigningCredentialRepository) RevokeKID(ctx context.Context, kid, worklo
 		Set("revoked_at = ?", at).
 		Where("kid = ?", kid).
 		Where("workload = ?", workload).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
 		Where("revoked = ?", false).
 		Exec(ctx)
 	if err != nil {

--- a/internal/store/postgres/signing_credential.go
+++ b/internal/store/postgres/signing_credential.go
@@ -1,0 +1,135 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/uptrace/bun"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// SigningCredentialRepository handles persistence for workload-attested
+// ephemeral signing keys. Only public key material is stored.
+type SigningCredentialRepository struct {
+	db *bun.DB
+}
+
+// NewSigningCredentialRepository creates a new SigningCredentialRepository.
+func NewSigningCredentialRepository(db *bun.DB) *SigningCredentialRepository {
+	return &SigningCredentialRepository{db: db}
+}
+
+// Create inserts a freshly attested signing credential.
+func (r *SigningCredentialRepository) Create(ctx context.Context, c *domain.SigningCredential) error {
+	if _, err := r.db.NewInsert().Model(c).Exec(ctx); err != nil {
+		return fmt.Errorf("failed to create signing credential: %w", err)
+	}
+
+	return nil
+}
+
+// GetByKID resolves a credential by kid for VERIFICATION. It deliberately
+// does NOT filter on not_after — an expired (rotated / pod-gone) key must
+// still resolve so historical attestations verify within the
+// audit-retention window. Revoked/retention semantics are the caller's
+// (domain.SigningCredential.VerifiableNow). Returns (nil, nil) when no
+// such kid exists.
+func (r *SigningCredentialRepository) GetByKID(ctx context.Context, kid string) (*domain.SigningCredential, error) {
+	c := &domain.SigningCredential{}
+
+	err := r.db.NewSelect().Model(c).Where("kid = ?", kid).Scan(ctx)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get signing credential: %w", err)
+	}
+
+	return c, nil
+}
+
+// ListVerifiable returns every credential whose public key may currently
+// verify an attestation for a purpose: non-revoked AND inside the
+// audit-retention window (independent of not_after). This is the JWKS
+// source — it intentionally includes operationally-expired keys so
+// already-emitted receipts keep verifying after key rotation.
+func (r *SigningCredentialRepository) ListVerifiable(ctx context.Context, purpose string, now time.Time) ([]*domain.SigningCredential, error) {
+	var creds []*domain.SigningCredential
+
+	err := r.db.NewSelect().Model(&creds).
+		Where("purpose = ?", purpose).
+		Where("revoked = ?", false).
+		Where("audit_retention_until > ?", now).
+		Order("kid ASC").
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list verifiable signing credentials: %w", err)
+	}
+
+	return creds, nil
+}
+
+// RevokeWorkload revokes every non-revoked credential for a workload —
+// the CAE entry point. A revoked key fails verification immediately,
+// regardless of its retention window.
+func (r *SigningCredentialRepository) RevokeWorkload(ctx context.Context, workload, reason string, at time.Time) (int64, error) {
+	res, err := r.db.NewUpdate().
+		Model((*domain.SigningCredential)(nil)).
+		Set("revoked = ?", true).
+		Set("revoked_reason = ?", reason).
+		Set("revoked_at = ?", at).
+		Where("workload = ?", workload).
+		Where("revoked = ?", false).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to revoke workload signing credentials: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+
+	return n, nil
+}
+
+// RevokeKID revokes a single credential by kid, scoped to its attesting
+// workload (no cross-workload revocation through this path).
+func (r *SigningCredentialRepository) RevokeKID(ctx context.Context, kid, workload, reason string, at time.Time) (int64, error) {
+	res, err := r.db.NewUpdate().
+		Model((*domain.SigningCredential)(nil)).
+		Set("revoked = ?", true).
+		Set("revoked_reason = ?", reason).
+		Set("revoked_at = ?", at).
+		Where("kid = ?", kid).
+		Where("workload = ?", workload).
+		Where("revoked = ?", false).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to revoke signing credential: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+
+	return n, nil
+}
+
+// PruneExpiredRetention deletes non-revoked credentials whose
+// audit-retention window has fully elapsed (housekeeping). Revoked rows
+// are kept as a tamper-evidence trail.
+func (r *SigningCredentialRepository) PruneExpiredRetention(ctx context.Context, now time.Time) (int64, error) {
+	res, err := r.db.NewDelete().
+		Model((*domain.SigningCredential)(nil)).
+		Where("revoked = ?", false).
+		Where("audit_retention_until <= ?", now).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prune expired signing credentials: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+
+	return n, nil
+}

--- a/migrations/023_signing_credentials.down.sql
+++ b/migrations/023_signing_credentials.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS signing_credentials;

--- a/migrations/023_signing_credentials.up.sql
+++ b/migrations/023_signing_credentials.up.sql
@@ -1,0 +1,46 @@
+-- Workload-attested ephemeral signing credentials.
+--
+-- A workload (e.g. Shield) generates an ephemeral Ed25519 keypair in
+-- memory and attests the PUBLIC half here. ZeroID owns the kid namespace,
+-- publishes the verification JWKS, and revokes via CAE. The private key
+-- is never sent or stored.
+--
+-- Two clocks, deliberately decoupled:
+--   not_after            — operational: how long the key may SIGN.
+--   audit_retention_until — evidence: how long the PUBLIC key remains
+--                           resolvable for verifying historical
+--                           attestations (>> not_after).
+-- A merely-expired (rotated / pod-gone) key still verifies within the
+-- retention window; only a REVOKED key fails. This is the correctness
+-- property a not_after-only filter cannot express.
+
+CREATE TABLE IF NOT EXISTS signing_credentials (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id            VARCHAR(255) NOT NULL DEFAULT '',
+    project_id            VARCHAR(255) NOT NULL DEFAULT '',
+    kid                   VARCHAR(255) NOT NULL,
+    workload              VARCHAR(255) NOT NULL,  -- trusted-service identity, e.g. highflame-shield
+    purpose               VARCHAR(64)  NOT NULL,  -- receipt | authz_audit
+    algorithm             VARCHAR(32)  NOT NULL,  -- EdDSA
+    public_key            TEXT         NOT NULL,  -- base64 raw-url Ed25519 public key (32 bytes)
+    not_after             TIMESTAMPTZ  NOT NULL,  -- operational signing expiry
+    audit_retention_until TIMESTAMPTZ  NOT NULL,  -- public key resolvable for verification until here
+    revoked               BOOLEAN      NOT NULL DEFAULT FALSE,
+    revoked_reason        TEXT         NOT NULL DEFAULT '',
+    revoked_at            TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (kid)
+);
+
+-- Verification lookup: a kid resolves to its key while non-revoked AND
+-- inside the audit-retention window (independent of not_after).
+CREATE INDEX IF NOT EXISTS idx_signing_credentials_verify
+    ON signing_credentials (kid, revoked, audit_retention_until);
+
+-- CAE revocation sweep + operational lookups for a workload.
+CREATE INDEX IF NOT EXISTS idx_signing_credentials_workload
+    ON signing_credentials (workload, purpose, created_at);
+
+-- Retention pruning (delete only past the retention window).
+CREATE INDEX IF NOT EXISTS idx_signing_credentials_retention
+    ON signing_credentials (audit_retention_until) WHERE revoked = FALSE;

--- a/migrations/023_signing_credentials.up.sql
+++ b/migrations/023_signing_credentials.up.sql
@@ -37,9 +37,11 @@ CREATE TABLE IF NOT EXISTS signing_credentials (
 CREATE INDEX IF NOT EXISTS idx_signing_credentials_verify
     ON signing_credentials (kid, revoked, audit_retention_until);
 
--- CAE revocation sweep + operational lookups for a workload.
+-- CAE revocation sweep + operational lookups for a workload, tenant-
+-- scoped: every admin read/revoke is bounded by (account_id, project_id)
+-- derived from the validated tenant context.
 CREATE INDEX IF NOT EXISTS idx_signing_credentials_workload
-    ON signing_credentials (workload, purpose, created_at);
+    ON signing_credentials (account_id, project_id, workload, purpose, created_at);
 
 -- Retention pruning (delete only past the retention window).
 CREATE INDEX IF NOT EXISTS idx_signing_credentials_retention

--- a/migrations/023_signing_credentials.up.sql
+++ b/migrations/023_signing_credentials.up.sql
@@ -1,6 +1,6 @@
 -- Workload-attested ephemeral signing credentials.
 --
--- A workload (e.g. Shield) generates an ephemeral Ed25519 keypair in
+-- A workload generates an ephemeral Ed25519 keypair in
 -- memory and attests the PUBLIC half here. ZeroID owns the kid namespace,
 -- publishes the verification JWKS, and revokes via CAE. The private key
 -- is never sent or stored.
@@ -19,8 +19,8 @@ CREATE TABLE IF NOT EXISTS signing_credentials (
     account_id            VARCHAR(255) NOT NULL DEFAULT '',
     project_id            VARCHAR(255) NOT NULL DEFAULT '',
     kid                   VARCHAR(255) NOT NULL,
-    workload              VARCHAR(255) NOT NULL,  -- trusted-service identity, e.g. highflame-shield
-    purpose               VARCHAR(64)  NOT NULL,  -- receipt | authz_audit
+    workload              VARCHAR(255) NOT NULL,  -- trusted-service identity (deployer-defined)
+    purpose               VARCHAR(64)  NOT NULL,  -- deployer-configured signing purpose
     algorithm             VARCHAR(32)  NOT NULL,  -- EdDSA
     public_key            TEXT         NOT NULL,  -- base64 raw-url Ed25519 public key (32 bytes)
     not_after             TIMESTAMPTZ  NOT NULL,  -- operational signing expiry

--- a/server.go
+++ b/server.go
@@ -151,6 +151,7 @@ func NewServer(cfg Config) (*Server, error) {
 	authCodeRepo := postgres.NewAuthCodeRepository(db)
 	auditRepo := postgres.NewAuditLogRepository(db)
 	backchannelRepo := postgres.NewBackchannelRequestRepository(db)
+	signingCredRepo := postgres.NewSigningCredentialRepository(db)
 
 	// Build the attestation verifier registry. Real verifiers are wired
 	// first (OIDC today). Dev stubs cover image_hash and TPM only — those
@@ -181,6 +182,7 @@ func NewServer(cfg Config) (*Server, error) {
 	credentialPolicySvc := service.NewCredentialPolicyService(credentialPolicyRepo)
 	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL)
 	signalSvc := service.NewSignalService(signalRepo, credentialRepo, identityRepo)
+	signingCredSvc := service.NewSigningCredentialService(signingCredRepo, cfg.SigningCreds.MaxTTLSeconds, cfg.SigningCreds.AuditRetentionDays)
 	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, apiKeyRepo, credentialSvc, signalSvc, cfg.WIMSEDomain)
 	attestationPolicySvc := attestation.NewPolicyService(attestationPolicyRepo, attestationVerifiers)
 	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc, db, cfg.Attestation.AllowUnsafeDevStub)
@@ -218,7 +220,8 @@ func NewServer(cfg Config) (*Server, error) {
 	apiHandler := handler.NewAPI(
 		identitySvc, credentialSvc, credentialPolicySvc,
 		attestationSvc, attestationPolicySvc, proofSvc, oauthSvc, oauthClientSvc,
-		signalSvc, apiKeySvc, agentSvc, auditSvc, backchannelSvc, jwksSvc, db,
+		signalSvc, apiKeySvc, agentSvc, auditSvc, backchannelSvc, jwksSvc,
+		signingCredSvc, db,
 		cfg.Token.Issuer, cfg.Token.BaseURL,
 	)
 

--- a/server.go
+++ b/server.go
@@ -182,7 +182,14 @@ func NewServer(cfg Config) (*Server, error) {
 	credentialPolicySvc := service.NewCredentialPolicyService(credentialPolicyRepo)
 	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL)
 	signalSvc := service.NewSignalService(signalRepo, credentialRepo, identityRepo)
-	signingCredSvc := service.NewSigningCredentialService(signingCredRepo, cfg.SigningCreds.MaxTTLSeconds, cfg.SigningCreds.AuditRetentionDays)
+	signingCredSvc := service.NewSigningCredentialService(
+		signingCredRepo,
+		cfg.SigningCreds.MaxTTLSeconds,
+		cfg.SigningCreds.AuditRetentionDays,
+		cfg.SigningCreds.AllowedPurposes,
+		cfg.SigningCreds.JWKSPurpose,
+		cfg.SigningCreds.WellKnownJWKSName,
+	)
 	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, apiKeyRepo, credentialSvc, signalSvc, cfg.WIMSEDomain)
 	attestationPolicySvc := attestation.NewPolicyService(attestationPolicyRepo, attestationVerifiers)
 	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc, db, cfg.Attestation.AllowUnsafeDevStub)

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -45,6 +45,10 @@ const (
 	testAccountID = "acct-test-001"
 	testProjectID = "proj-test-001"
 	testWIMSE     = "zeroid.dev"
+	// testSigningJWKSName is the branded well-known suffix this test
+	// deployment configures; the verification JWKS is served at
+	// /.well-known/<testSigningJWKSName>.
+	testSigningJWKSName = "test-receipt-keys"
 
 	// authorization_code / refresh_token test constants.
 	testHMACSecret  = "test-hmac-secret-zeroid-32bytes!!"
@@ -175,6 +179,16 @@ func runTests(m *testing.M) int {
 		// false — see GHSA-599q-j34m-33vc.
 		Backchannel: zeroid.BackchannelConfig{
 			AllowPrivateNotificationEndpoints: true,
+		},
+		// Opt this test deployment into workload-attested signing with a
+		// branded well-known name + purpose allowlist — exactly what a
+		// product deployer supplies. ZeroID itself ships product-agnostic.
+		SigningCreds: zeroid.SigningCredsConfig{
+			MaxTTLSeconds:      3600,
+			AuditRetentionDays: 400,
+			AllowedPurposes:    []string{"receipt", "authz_audit"},
+			JWKSPurpose:        "receipt",
+			WellKnownJWKSName:  testSigningJWKSName,
 		},
 		WIMSEDomain: testWIMSE,
 	}

--- a/tests/integration/signing_credential_test.go
+++ b/tests/integration/signing_credential_test.go
@@ -64,7 +64,7 @@ func attestKey(t *testing.T, purpose string, ttlSeconds int) (kid string, priv e
 func jwksKey(t *testing.T, kid string) ed25519.PublicKey {
 	t.Helper()
 
-	resp := get(t, "/.well-known/highflame-receipt-keys", nil)
+	resp := get(t, "/.well-known/"+testSigningJWKSName, nil)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	doc := decode(t, resp)

--- a/tests/integration/signing_credential_test.go
+++ b/tests/integration/signing_credential_test.go
@@ -1,0 +1,222 @@
+package integration_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end coverage of workload-attested ephemeral signing credentials
+// against a real ZeroID + Postgres. These tests deliberately reproduce
+// EXACTLY what downstream consumers do:
+//
+//   - Shield (the signer): generates an ephemeral Ed25519 keypair in
+//     memory, attests the PUBLIC half, signs receipts locally with the
+//     private half.
+//   - Observatory / any auditor (the verifier): fetches the public JWKS
+//     by kid and verifies offline — never trusting ZeroID's verdict.
+//
+// If these pass, AuthZ and Shield can build their signing features on
+// this primitive with confidence the full loop works.
+
+const signingWorkload = "highflame-shield"
+
+// attestKey simulates a workload: generate an ephemeral keypair, attest
+// the public half, return the kid + the private key kept locally.
+func attestKey(t *testing.T, purpose string, ttlSeconds int) (kid string, priv ed25519.PrivateKey) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	headers := map[string]string{
+		"X-Account-ID":       testAccountID,
+		"X-Project-ID":       testProjectID,
+		"X-Internal-Service": signingWorkload, // validated workload identity
+	}
+	body := map[string]any{
+		"public_key":  base64.RawURLEncoding.EncodeToString(pub),
+		"algorithm":   "EdDSA",
+		"purpose":     purpose,
+		"ttl_seconds": ttlSeconds,
+	}
+
+	resp := post(t, adminPath("/signing-credentials"), body, headers)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "attest should succeed")
+
+	m := decode(t, resp)
+	kid, _ = m["kid"].(string)
+	require.NotEmpty(t, kid, "attest must return a kid")
+	require.NotEmpty(t, m["not_after"], "attest must return not_after")
+
+	return kid, priv
+}
+
+// jwksKey fetches the public verification JWKS and returns the raw
+// Ed25519 public key for kid, or nil if absent. This is the exact path
+// Observatory's resolver takes — public route, no auth.
+func jwksKey(t *testing.T, kid string) ed25519.PublicKey {
+	t.Helper()
+
+	resp := get(t, "/.well-known/highflame-receipt-keys", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	doc := decode(t, resp)
+
+	keys, _ := doc["keys"].([]any)
+	for _, k := range keys {
+		jwk, _ := k.(map[string]any)
+		if jwk["kid"] != kid {
+			continue
+		}
+
+		assert.Equal(t, "OKP", jwk["kty"])
+		assert.Equal(t, "Ed25519", jwk["crv"])
+		assert.Equal(t, "EdDSA", jwk["alg"])
+		assert.Equal(t, "sig", jwk["use"])
+
+		x, _ := jwk["x"].(string)
+		raw, err := base64.RawURLEncoding.DecodeString(x)
+		require.NoError(t, err)
+		require.Len(t, raw, ed25519.PublicKeySize)
+
+		return ed25519.PublicKey(raw)
+	}
+
+	return nil
+}
+
+// TestSigningCredential_EndToEnd_AttestSignVerify is THE downstream
+// proof: a consumer holding the private key produces a signature that
+// verifies against the JWKS-published public key resolved by kid.
+func TestSigningCredential_EndToEnd_AttestSignVerify(t *testing.T) {
+	kid, priv := attestKey(t, "receipt", 3600)
+
+	// Shield-side: sign a canonical receipt locally.
+	canonical := []byte(`{"schema":"hf-receipt/1","decision":"deny","kid":"` + kid + `"}`)
+	sig := ed25519.Sign(priv, canonical)
+
+	// Verifier-side: resolve the public key from the JWKS by kid, verify
+	// offline (no trust in ZeroID's word).
+	pub := jwksKey(t, kid)
+	require.NotNil(t, pub, "attested kid must appear in the public JWKS")
+	require.True(t, ed25519.Verify(pub, canonical, sig),
+		"signature from the attested private key must verify against the JWKS public key")
+
+	// Tamper detection: any change to the signed bytes breaks it.
+	require.False(t, ed25519.Verify(pub, []byte(`{"decision":"allow"}`), sig),
+		"tampered canonical must not verify")
+}
+
+// TestSigningCredential_Rotation_Overlap proves that after key rotation
+// BOTH kids resolve in the JWKS, so receipts emitted under the old key
+// keep verifying (no verification gap across a Shield rotation).
+func TestSigningCredential_Rotation_Overlap(t *testing.T) {
+	kidA, privA := attestKey(t, "receipt", 3600)
+	canonicalA := []byte(`{"turn":1,"kid":"` + kidA + `"}`)
+	sigA := ed25519.Sign(privA, canonicalA)
+
+	// Rotate: a fresh ephemeral key is attested (new kid).
+	kidB, privB := attestKey(t, "receipt", 3600)
+	require.NotEqual(t, kidA, kidB, "rotation must mint a distinct kid")
+
+	// Both verify — old receipts under kidA still resolve during overlap.
+	pubA := jwksKey(t, kidA)
+	require.NotNil(t, pubA, "old kid must remain in JWKS during overlap")
+	require.True(t, ed25519.Verify(pubA, canonicalA, sigA))
+
+	canonicalB := []byte(`{"turn":2,"kid":"` + kidB + `"}`)
+	pubB := jwksKey(t, kidB)
+	require.NotNil(t, pubB)
+	require.True(t, ed25519.Verify(pubB, canonicalB, ed25519.Sign(privB, canonicalB)))
+}
+
+// TestSigningCredential_ExpiredButRetained_StillVerifies pins the
+// two-clock invariant end-to-end: once not_after passes the key may no
+// longer SIGN, but its public key stays in the JWKS (audit retention ≫
+// not_after) so a receipt signed before expiry STILL verifies. This is
+// the property a not_after-only filter cannot express — and exactly the
+// "what if Shield rotated / the pod restarted?" case.
+func TestSigningCredential_ExpiredButRetained_StillVerifies(t *testing.T) {
+	kid, priv := attestKey(t, "receipt", 1) // 1-second operational window
+
+	canonical := []byte(`{"signed":"before-expiry","kid":"` + kid + `"}`)
+	sig := ed25519.Sign(priv, canonical)
+
+	time.Sleep(2 * time.Second) // not_after has now passed (key un-signable)
+
+	pub := jwksKey(t, kid)
+	require.NotNil(t, pub,
+		"an operationally-expired but non-revoked key must remain verifiable within the audit-retention window")
+	require.True(t, ed25519.Verify(pub, canonical, sig),
+		"a receipt signed before not_after must still verify after expiry")
+}
+
+// TestSigningCredential_Revoke_RemovesFromJWKS proves revocation is
+// immediate and overrides retention: a revoked kid drops out of the
+// JWKS, so anything signed under it can no longer be verified.
+func TestSigningCredential_Revoke_RemovesFromJWKS(t *testing.T) {
+	kid, priv := attestKey(t, "receipt", 3600)
+
+	canonical := []byte(`{"x":1,"kid":"` + kid + `"}`)
+	sig := ed25519.Sign(priv, canonical)
+
+	require.NotNil(t, jwksKey(t, kid), "kid present before revocation")
+
+	resp := post(t, adminPath("/signing-credentials/"+kid+"/revoke"),
+		map[string]any{"reason": "integration test"},
+		map[string]string{
+			"X-Account-ID":       testAccountID,
+			"X-Project-ID":       testProjectID,
+			"X-Internal-Service": signingWorkload,
+		})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "revoke should succeed")
+
+	pub := jwksKey(t, kid)
+	require.Nil(t, pub,
+		"a revoked kid must NOT appear in the JWKS even within its retention window")
+	_ = sig // a verifier can no longer obtain a key for this kid → cannot verify
+}
+
+// TestSigningCredential_Attest_Rejections asserts the endpoint defends
+// the contract: malformed inputs are rejected before persistence.
+func TestSigningCredential_Attest_Rejections(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	goodKey := base64.RawURLEncoding.EncodeToString(pub)
+
+	hdr := map[string]string{
+		"X-Account-ID":       testAccountID,
+		"X-Project-ID":       testProjectID,
+		"X-Internal-Service": signingWorkload,
+	}
+
+	cases := []struct {
+		name string
+		body map[string]any
+		hdr  map[string]string
+	}{
+		{"wrong algorithm", map[string]any{"public_key": goodKey, "algorithm": "RS256", "purpose": "receipt"}, hdr},
+		{"disallowed purpose", map[string]any{"public_key": goodKey, "algorithm": "EdDSA", "purpose": "exfiltrate"}, hdr},
+		{"malformed key", map[string]any{"public_key": "not-a-key", "algorithm": "EdDSA", "purpose": "receipt"}, hdr},
+		{
+			"missing workload identity",
+			map[string]any{"public_key": goodKey, "algorithm": "EdDSA", "purpose": "receipt"},
+			map[string]string{"X-Account-ID": testAccountID, "X-Project-ID": testProjectID},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := post(t, adminPath("/signing-credentials"), tc.body, tc.hdr)
+			defer func() { _ = resp.Body.Close() }()
+			assert.GreaterOrEqual(t, resp.StatusCode, 400,
+				"invalid attestation must be rejected before persistence")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The generic identity primitive behind Highflame AARM R5 (Shield decision receipts) and the forthcoming AuthZ audit-signing convergence. Re-homed here from an interim authn-local implementation (highflame-authn#74, closed) after an architecture review concluded it's a **generic credential capability** — multiple consumers, layered on ZeroID's own attestation/credential/CAE machinery — not deployment glue.

A workload (e.g. Shield) generates an **ephemeral Ed25519 keypair in memory** and attests only the **public** half. ZeroID owns the kid namespace, publishes the verification JWKS, and revokes. The private key is never transmitted or stored — an AuthN/ZeroID compromise cannot forge receipts; a workload compromise is TTL-bounded and revocable.

## The correctness property (why this couldn't live in the interim authn impl)

Two clocks, **deliberately decoupled**:

| Clock | Bounds | Horizon |
|---|---|---|
| `not_after` | how long the key may **sign** | short (~1h; keys are ephemeral, rotated) |
| `audit_retention_until` | how long the public key stays resolvable for **verifying** historical attestations | long (~400d default) |

A merely-**expired** key (rotated out / pod gone) **still verifies** historical receipts within the retention window; only a **revoked** key fails outright (immediately, independent of retention — the CAE entry point). A `not_after`-only JWKS filter (the interim impl) made every receipt unverifiable the moment its signing key's operational TTL lapsed — wrong for audit evidence. This is the gap that motivated the re-home.

## What's here

- `migrations/023` + `domain.SigningCredential` (`VerifiableNow` / `SignableNow`)
- postgres repo — `GetByKID` (no `not_after` filter — verification path), `ListVerifiable` (non-revoked ∧ in-retention — JWKS source), `RevokeWorkload` (CAE) / `RevokeKID`, `PruneExpiredRetention`
- service — `Attest` (EdDSA + purpose allowlist + 32-byte base64url key validation, TTL clamp, sanitized collision-safe kid), `VerificationJWKS` (OKP/Ed25519, kid-sorted), revoke
- handler — `POST /signing-credentials` + `/{kid}/revoke` on the **admin** group (deployer admin-auth gates trusted services; `X-Internal-Service` is the validated workload identity); `GET /.well-known/highflame-receipt-keys` on the **public** group (offline verification is the point — only public keys exposed)
- `config`: `signing_credentials.{max_ttl_seconds,audit_retention_days}` (ships with sane defaults)

**Wire contract is identical to the closed interim authn impl**, so Highflame's Shield signer + Observatory resolver need no change once AuthN bumps the ZeroID dependency.

## Test plan

- [x] `VerifiableNow`/`SignableNow` truth table — fresh / expired-but-retained / revoked / past-retention
- [x] `mintKID` — 20k-iteration uniqueness + hostile-input sanitization (kid is echoed into receipts + JWKS)
- [x] `Attest` input rejections — missing workload / wrong alg / disallowed purpose / malformed key
- [x] `GOEXPERIMENT=jsonv2 go build ./...` + `go vet` clean
- [ ] testcontainers integration: attest → JWKS includes → revoke → JWKS excludes → past-retention excluded *(tracked follow-up — matches the dependent repos' convention)*
- [ ] auto-revoke wired from the CAE signal pipeline *(`RevokeWorkload` is the hook; tracked follow-up)*

Refs highflame-architecture#57 #90 #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)