### PR TITLE
feat: delegation explorer — graph, by-jti, and chains endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ When an orchestrator needs a specialized agent to handle part of a task, it dele
 
 This is the key difference from sharing credentials: the sub-agent has its own registered identity and its own keypair. It proves it holds that keypair by signing a short-lived JWT assertion (`actor_token`). ZeroID verifies both tokens and issues a delegated token that carries both identities.
 
-The SDK does not currently ship a JWT-assertion helper, so the snippets below define `generate_ec_keypair` and `build_jwt_assertion` inline. A production-grade Python reference (with the same DER → IEEE P1363 signature conversion required by ES256) lives at [`integrations/openclaw/sidecar/agent-identity-sidecar.py:450`](./integrations/openclaw/sidecar/agent-identity-sidecar.py).
+The SDK does not currently ship a JWT-assertion helper, so the snippets below define `generate_ec_keypair` and `build_jwt_assertion` inline. A production-grade Python reference (with the same DER → IEEE P1363 signature conversion required by ES256) lives at [`examples/openclaw/agent-identity-sidecar.py:450`](./examples/openclaw/agent-identity-sidecar.py).
 
 <details>
 <summary>Python</summary>

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ When an orchestrator needs a specialized agent to handle part of a task, it dele
 
 This is the key difference from sharing credentials: the sub-agent has its own registered identity and its own keypair. It proves it holds that keypair by signing a short-lived JWT assertion (`actor_token`). ZeroID verifies both tokens and issues a delegated token that carries both identities.
 
-The SDK does not currently ship a JWT-assertion helper, so the snippets below define `generate_ec_keypair` and `build_jwt_assertion` inline. A production-grade Python reference (with the same DER → IEEE P1363 signature conversion required by ES256) lives at [`examples/openclaw/agent-identity-sidecar.py:450`](./examples/openclaw/agent-identity-sidecar.py).
+The SDK does not currently ship a JWT-assertion helper, so the snippets below define `generate_ec_keypair` and `build_jwt_assertion` inline. A production-grade Python reference (with the same DER → IEEE P1363 signature conversion required by ES256) lives at [`integrations/openclaw/sidecar/agent-identity-sidecar.py:450`](./integrations/openclaw/sidecar/agent-identity-sidecar.py).
 
 <details>
 <summary>Python</summary>
@@ -908,6 +908,9 @@ Most admin endpoints live under `/api/v1/*`; the CIBA approve/deny endpoints sit
 | GET | `/api/v1/signals/stream` | SSE signal stream |
 | POST | `/api/v1/proofs/generate` | Generate WIMSE proof token |
 | POST | `/api/v1/proofs/verify` | Verify WIMSE proof token |
+| GET | `/api/v1/delegations/graph` | Depth-bounded delegation subgraph centered on an identity (`?identity_id=&depth=`) |
+| GET | `/api/v1/delegations/by-jti/{jti}` | Full lineage root → leaf for any credential (forensic provenance walk) |
+| GET | `/api/v1/delegations/chains` | List delegation tree summaries in a time window (`?since=&until=&limit=`) |
 | POST | `/oauth2/bc-authorize/{auth_req_id}/approve` | Approve a pending CIBA request (tenant-scoped) |
 | POST | `/oauth2/bc-authorize/{auth_req_id}/deny` | Deny a pending CIBA request (tenant-scoped) |
 
@@ -951,6 +954,7 @@ References: [OpenID Agentic AI](https://openid.net/wp-content/uploads/2025/10/Id
 - Coding agent task claims — `session_id`, `task_id`, `task_type`, `allowed_tools`, `workspace`, `environment` as typed fields on `ZeroIDIdentity`; `has_tool()` helper alongside `has_scope()`
 - Ecosystem integrations (LangGraph, CrewAI, Strands)
 - **CIBA (Client-Initiated Backchannel Authentication)** — full OpenID CIBA Core 1.0 server-side flow with poll, ping, and push delivery modes; deployer-pluggable `BackchannelNotifier` for out-of-band user prompts (email, Slack, push); SSRF-guarded outbound callbacks
+- **Delegation Explorer** — three read-only endpoints that expose the delegation graph stored in `issued_credentials`: `/delegations/graph` (depth-bounded subgraph centered on any identity, with per-edge scope attenuation), `/delegations/by-jti/{jti}` (forensic lineage walk root → leaf), and `/delegations/chains` (mission summary list with time-window filtering). All three are tenant-scoped and driven by `parent_jti` recursive CTEs — no dependency on `mission_id` for correctness.
 
 **Planned**
 - Human-in-the-loop approval workflow (`/api/v1/approvals`)

--- a/internal/handler/delegation.go
+++ b/internal/handler/delegation.go
@@ -42,7 +42,6 @@ type DelegationChainsInput struct {
 type DelegationChainsOutput struct {
 	Body struct {
 		Chains []*postgres.ChainSummary `json:"chains"`
-		Total  int                      `json:"total"`
 	}
 }
 
@@ -125,6 +124,5 @@ func (a *API) delegationChainsOp(ctx context.Context, input *DelegationChainsInp
 
 	out := &DelegationChainsOutput{}
 	out.Body.Chains = chains
-	out.Body.Total = len(chains)
 	return out, nil
 }

--- a/internal/handler/delegation.go
+++ b/internal/handler/delegation.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/rs/zerolog/log"
+
+	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
+	"github.com/highflame-ai/zeroid/internal/service"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
+)
+
+// ── Delegation types ─────────────────────────────────────────────────────────
+
+type DelegationGraphInput struct {
+	IdentityID string `query:"identity_id" required:"true" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" doc:"Identity UUID to center the graph on"`
+	Depth      int    `query:"depth"       default:"3" minimum:"1" maximum:"10" doc:"Hops from the focal credential in each direction"`
+}
+
+type DelegationGraphOutput struct {
+	Body *service.Graph
+}
+
+type DelegationByJTIInput struct {
+	JTI string `path:"jti" pattern:"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" doc:"JWT ID of the credential to walk up to root"`
+}
+
+type DelegationChainOutput struct {
+	Body *service.Chain
+}
+
+type DelegationChainsInput struct {
+	Since time.Time `query:"since" doc:"Lower bound on issued_at (RFC3339); defaults to until-30d"`
+	Until time.Time `query:"until" doc:"Upper bound on issued_at (RFC3339); defaults to now"`
+	Limit int       `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Maximum number of chains to return"`
+}
+
+type DelegationChainsOutput struct {
+	Body struct {
+		Chains []*postgres.ChainSummary `json:"chains"`
+		Total  int                      `json:"total"`
+	}
+}
+
+// ── Delegation routes ────────────────────────────────────────────────────────
+
+func (a *API) registerDelegationRoutes(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "delegation-graph",
+		Method:      http.MethodGet,
+		Path:        "/delegations/graph",
+		Summary:     "Depth-bounded delegation subgraph centered on an identity",
+		Description: "Returns nodes (identities) and edges (issued credentials) within `depth` hops up and down the parent_jti chain from the identity's most recent credential. Edges carry scope-attenuation (scopes_in / scopes_out / attenuated) so consumers can flag misconfigured delegations visually.",
+		Tags:        []string{"Delegations"},
+	}, a.delegationGraphOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "delegation-by-jti",
+		Method:      http.MethodGet,
+		Path:        "/delegations/by-jti/{jti}",
+		Summary:     "Walk the parent_jti chain from a credential up to its root",
+		Description: "Returns the full lineage from the root credential to the credential identified by `jti`, with scope attenuation per edge. Used for forensic 'where did this token come from?' queries.",
+		Tags:        []string{"Delegations"},
+	}, a.delegationByJTIOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "delegation-chains",
+		Method:      http.MethodGet,
+		Path:        "/delegations/chains",
+		Summary:     "List delegation chain summaries in a time window",
+		Description: "Returns one summary row per delegation tree (grouped by mission_id, falling back to root JTI for legacy credentials), ordered by last activity DESC. Defaults to the last 30 days.",
+		Tags:        []string{"Delegations"},
+	}, a.delegationChainsOp)
+}
+
+func (a *API) delegationGraphOp(ctx context.Context, input *DelegationGraphInput) (*DelegationGraphOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	g, err := a.delegationSvc.GetGraph(ctx, input.IdentityID, input.Depth, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		log.Error().Err(err).
+			Str("identity_id", input.IdentityID).
+			Int("depth", input.Depth).
+			Msg("failed to build delegation graph")
+		return nil, huma.Error500InternalServerError("failed to build delegation graph")
+	}
+	return &DelegationGraphOutput{Body: g}, nil
+}
+
+func (a *API) delegationByJTIOp(ctx context.Context, input *DelegationByJTIInput) (*DelegationChainOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	chain, err := a.delegationSvc.WalkByJTI(ctx, input.JTI, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		if errors.Is(err, service.ErrCredentialNotFound) {
+			return nil, huma.Error404NotFound("credential not found")
+		}
+		log.Error().Err(err).Str("jti", input.JTI).Msg("delegation by-jti failed")
+		return nil, huma.Error500InternalServerError("failed to walk delegation chain")
+	}
+	return &DelegationChainOutput{Body: chain}, nil
+}
+
+func (a *API) delegationChainsOp(ctx context.Context, input *DelegationChainsInput) (*DelegationChainsOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	chains, err := a.delegationSvc.ListChains(ctx, input.Since, input.Until, input.Limit, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to list delegation chains")
+		return nil, huma.Error500InternalServerError("failed to list delegation chains")
+	}
+
+	out := &DelegationChainsOutput{}
+	out.Body.Chains = chains
+	out.Body.Total = len(chains)
+	return out, nil
+}

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -35,6 +35,7 @@ type API struct {
 	auditSvc             *service.AuditService
 	backchannelSvc       *service.BackchannelService
 	dpopSvc              *service.DPoPService
+	delegationSvc        *service.DelegationService
 	jwksSvc              *signing.JWKSService
 	signingCredSvc       *service.SigningCredentialService
 	db                   *bun.DB
@@ -59,6 +60,7 @@ func NewAPI(
 	auditSvc *service.AuditService,
 	backchannelSvc *service.BackchannelService,
 	dpopSvc *service.DPoPService,
+	delegationSvc *service.DelegationService,
 	jwksSvc *signing.JWKSService,
 	signingCredSvc *service.SigningCredentialService,
 	db *bun.DB,
@@ -79,6 +81,7 @@ func NewAPI(
 		auditSvc:             auditSvc,
 		backchannelSvc:       backchannelSvc,
 		dpopSvc:              dpopSvc,
+		delegationSvc:        delegationSvc,
 		jwksSvc:              jwksSvc,
 		signingCredSvc:       signingCredSvc,
 		db:                   db,
@@ -138,6 +141,7 @@ func (a *API) RegisterAdmin(api huma.API, router chi.Router) {
 	a.registerBackchannelAdminRoutes(api)
 	a.registerExpiringSoonRoute(api)
 	a.registerSigningCredentialRoutes(api)
+	a.registerDelegationRoutes(api)
 }
 
 // RegisterAgentAuth registers endpoints requiring agent-auth middleware (proof generation).

--- a/internal/service/delegation.go
+++ b/internal/service/delegation.go
@@ -1,0 +1,352 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
+)
+
+// ErrCredentialNotFound is returned by WalkByJTI when no credential
+// matches the requested JTI within the caller's tenant scope. Handlers
+// map this to 404; any other error maps to 500.
+var ErrCredentialNotFound = errors.New("credential not found")
+
+// MaxGraphDepth caps the recursive CTE depth on /delegations/graph
+// regardless of what the caller requests. The recursive CTE itself uses
+// this cap as the depth guard inside the SQL WITH clause; exporting it
+// here lets handlers reject requests outside the supported range early.
+const MaxGraphDepth = 10
+
+// MaxGraphNodes caps the size of a /delegations/graph response. When
+// exceeded the response carries Truncated=true so the consumer knows the
+// view is incomplete. Picked to match the snappy-with-up-to-500-nodes
+// acceptance target on issue #153.
+const MaxGraphNodes = 500
+
+// GraphNode is a single identity rendered in the delegation graph.
+// Stripped to the fields a force-graph or list view needs — full
+// identity records are available via /identities/{id}.
+type GraphNode struct {
+	ID           string `json:"id"`
+	WIMSEURI     string `json:"wimse_uri"`
+	Name         string `json:"name"`
+	IdentityType string `json:"identity_type"`
+	TrustLevel   string `json:"trust_level"`
+	Status       string `json:"status"`
+}
+
+// GraphEdge is one delegation hop — an issued credential connecting two
+// identities. ScopesIn/ScopesOut/Attenuated are the scope-attenuation
+// triple; for root credentials (no parent) ScopesIn equals ScopesOut and
+// Attenuated is empty.
+type GraphEdge struct {
+	From            string    `json:"from,omitempty"`
+	To              string    `json:"to,omitempty"`
+	JTI             string    `json:"jti"`
+	ParentJTI       string    `json:"parent_jti,omitempty"`
+	MissionID       string    `json:"mission_id,omitempty"`
+	IssuedAt        time.Time `json:"issued_at"`
+	ExpiresAt       time.Time `json:"expires_at"`
+	GrantType       string    `json:"grant_type"`
+	DelegationDepth int       `json:"delegation_depth"`
+	ScopesIn        []string  `json:"scopes_in"`
+	ScopesOut       []string  `json:"scopes_out"`
+	Attenuated      []string  `json:"attenuated"`
+	IsRevoked       bool      `json:"is_revoked"`
+}
+
+// Graph is the response shape for /delegations/graph — a depth-bounded
+// local subgraph centered on a focal identity. FocalID is the
+// identity_id the request was anchored on. Truncated is set when the
+// raw walk would have exceeded MaxGraphNodes.
+type Graph struct {
+	Nodes     []*GraphNode `json:"nodes"`
+	Edges     []*GraphEdge `json:"edges"`
+	FocalID   string       `json:"focal_id"`
+	Truncated bool         `json:"truncated,omitempty"`
+}
+
+// Chain is the response shape for /delegations/by-jti/{jti} — one full
+// lineage from root to leaf with scope attenuation per edge.
+type Chain struct {
+	Nodes []*GraphNode `json:"nodes"`
+	Edges []*GraphEdge `json:"edges"`
+}
+
+// DelegationService assembles delegation graphs and chains for the
+// Delegation Explorer endpoints. It is a thin coordinator over the
+// credential repository (already has ListByIdentity), the new
+// DelegationRepository (WalkUp / WalkDown / ListChains), and the
+// identity repository (GetByIDs for batch node enrichment).
+type DelegationService struct {
+	credRepo     *postgres.CredentialRepository
+	delegRepo    *postgres.DelegationRepository
+	identityRepo *postgres.IdentityRepository
+}
+
+// NewDelegationService creates a DelegationService.
+func NewDelegationService(credRepo *postgres.CredentialRepository, delegRepo *postgres.DelegationRepository, identityRepo *postgres.IdentityRepository) *DelegationService {
+	return &DelegationService{
+		credRepo:     credRepo,
+		delegRepo:    delegRepo,
+		identityRepo: identityRepo,
+	}
+}
+
+// GetGraph returns the depth-bounded local subgraph centered on
+// identityID. The focal credential is identityID's most recent
+// credential; the walk proceeds up `depth` hops via parent_jti and
+// down `depth` hops via reverse parent_jti. Identities are enriched in
+// one batch query.
+//
+// When the identity has issued no credentials yet, returns a one-node
+// graph (just the identity, no edges). When the credential count
+// exceeds MaxGraphNodes after the walk, Truncated is set on the
+// response; nodes are kept but edges are capped at MaxGraphNodes-1.
+func (s *DelegationService) GetGraph(ctx context.Context, identityID string, depth int, accountID, projectID string) (*Graph, error) {
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > MaxGraphDepth {
+		depth = MaxGraphDepth
+	}
+
+	creds, err := s.credRepo.ListByIdentity(ctx, identityID, accountID, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("look up focal identity credentials: %w", err)
+	}
+
+	// No credentials yet — return a single-node graph anchored on the
+	// identity if it exists. If the identity itself can't be loaded
+	// (unknown UUID, or owned by a different tenant) return an empty
+	// graph rather than an error: ListByIdentity already enforces
+	// tenant scope, so this branch is the natural funnel for both
+	// "not yet active" and "not visible to this tenant" — and the
+	// caller cannot tell them apart by design.
+	if len(creds) == 0 {
+		id, err := s.identityRepo.GetByID(ctx, identityID, accountID, projectID)
+		if err != nil {
+			return &Graph{Nodes: nil, Edges: nil, FocalID: identityID}, nil
+		}
+		return &Graph{
+			Nodes:   []*GraphNode{identityToNode(id)},
+			Edges:   nil,
+			FocalID: identityID,
+		}, nil
+	}
+
+	// creds is ordered issued_at DESC by ListByIdentity, so creds[0] is
+	// the most recent. Anchor the walk on its jti.
+	focal := creds[0]
+
+	up, err := s.delegRepo.WalkUp(ctx, focal.JTI, accountID, projectID, depth)
+	if err != nil {
+		return nil, err
+	}
+	down, err := s.delegRepo.WalkDown(ctx, focal.JTI, accountID, projectID, depth)
+	if err != nil {
+		return nil, err
+	}
+
+	merged := mergeByJTI(up, down)
+	graph := s.buildGraph(ctx, merged, accountID, projectID, identityID)
+	return graph, nil
+}
+
+// WalkByJTI returns the full lineage from root to the credential
+// identified by jti. Useful for forensic "show me where this token came
+// from" queries — every hop with its scope attenuation.
+//
+// Walks up to MaxGraphDepth hops; deeper chains are silently truncated
+// at the root end (the returned chain still ends at the requested jti).
+func (s *DelegationService) WalkByJTI(ctx context.Context, jti, accountID, projectID string) (*Chain, error) {
+	creds, err := s.delegRepo.WalkUp(ctx, jti, accountID, projectID, MaxGraphDepth)
+	if err != nil {
+		return nil, err
+	}
+	if len(creds) == 0 {
+		return nil, ErrCredentialNotFound
+	}
+	g := s.buildGraph(ctx, creds, accountID, projectID, "")
+	return &Chain{Nodes: g.Nodes, Edges: g.Edges}, nil
+}
+
+// ListChains returns chain summaries (one per delegation tree) active
+// in the [since, until) window, ordered by last activity DESC.
+//
+// until defaults to now() when zero; since defaults to until - 30 days
+// when zero. Limit is clamped to [1, 500].
+func (s *DelegationService) ListChains(ctx context.Context, since, until time.Time, limit int, accountID, projectID string) ([]*postgres.ChainSummary, error) {
+	if until.IsZero() {
+		until = time.Now()
+	}
+	if since.IsZero() {
+		since = until.Add(-30 * 24 * time.Hour)
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	return s.delegRepo.ListChains(ctx, accountID, projectID, since, until, limit)
+}
+
+// buildGraph turns a flat ordered credential list into the
+// (nodes, edges) shape, computing scope attenuation per edge and
+// batch-loading identities. focalID is forwarded onto the returned
+// Graph; pass "" when not relevant (e.g. /by-jti responses).
+func (s *DelegationService) buildGraph(ctx context.Context, creds []*domain.IssuedCredential, accountID, projectID, focalID string) *Graph {
+	truncated := false
+	if len(creds) > MaxGraphNodes {
+		creds = creds[:MaxGraphNodes]
+		truncated = true
+	}
+
+	// Index credentials by JTI so each edge can locate its parent's
+	// scopes in O(1) for the attenuation diff.
+	byJTI := make(map[string]*domain.IssuedCredential, len(creds))
+	for _, c := range creds {
+		byJTI[c.JTI] = c
+	}
+
+	// Collect distinct identity IDs (excluding nils) for one batch
+	// lookup. Some credentials may have IdentityID nil — those still
+	// produce edges but contribute no node on their own.
+	idSet := make(map[string]struct{}, len(creds))
+	for _, c := range creds {
+		if c.IdentityID != nil && *c.IdentityID != "" {
+			idSet[*c.IdentityID] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	identities, err := s.identityRepo.GetByIDs(ctx, ids, accountID, projectID)
+	if err != nil {
+		log.Warn().Err(err).Msg("identity batch load failed; graph nodes will be empty")
+	}
+
+	nodes := make([]*GraphNode, 0, len(identities))
+	for _, id := range identities {
+		nodes = append(nodes, identityToNode(id))
+	}
+
+	edges := make([]*GraphEdge, 0, len(creds))
+	for _, c := range creds {
+		edge := credentialToEdge(c)
+		if c.ParentJTI != "" {
+			if parent, ok := byJTI[c.ParentJTI]; ok {
+				edge.From = identityIDOrEmpty(parent.IdentityID)
+				edge.ScopesIn = parent.Scopes
+				edge.Attenuated = setDiff(parent.Scopes, c.Scopes)
+			}
+		}
+		edges = append(edges, edge)
+	}
+
+	return &Graph{
+		Nodes:     nodes,
+		Edges:     edges,
+		FocalID:   focalID,
+		Truncated: truncated,
+	}
+}
+
+// mergeByJTI merges two credential slices into one, de-duping by JTI.
+// Order is preserved from the first slice; new entries from the second
+// slice are appended in their original order.
+func mergeByJTI(a, b []*domain.IssuedCredential) []*domain.IssuedCredential {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]*domain.IssuedCredential, 0, len(a)+len(b))
+	for _, c := range a {
+		if _, ok := seen[c.JTI]; ok {
+			continue
+		}
+		seen[c.JTI] = struct{}{}
+		out = append(out, c)
+	}
+	for _, c := range b {
+		if _, ok := seen[c.JTI]; ok {
+			continue
+		}
+		seen[c.JTI] = struct{}{}
+		out = append(out, c)
+	}
+	return out
+}
+
+// identityToNode reduces an Identity to the GraphNode subset.
+func identityToNode(id *domain.Identity) *GraphNode {
+	return &GraphNode{
+		ID:           id.ID,
+		WIMSEURI:     id.WIMSEURI,
+		Name:         id.Name,
+		IdentityType: string(id.IdentityType),
+		TrustLevel:   string(id.TrustLevel),
+		Status:       string(id.Status),
+	}
+}
+
+// credentialToEdge converts an IssuedCredential into the wire-shape
+// GraphEdge, prepopulating fields that do not depend on a parent
+// lookup. The caller fills in From / ScopesIn / Attenuated for
+// non-root edges.
+func credentialToEdge(c *domain.IssuedCredential) *GraphEdge {
+	scopesOut := c.Scopes
+	if scopesOut == nil {
+		scopesOut = []string{}
+	}
+	return &GraphEdge{
+		To:              identityIDOrEmpty(c.IdentityID),
+		JTI:             c.JTI,
+		ParentJTI:       c.ParentJTI,
+		MissionID:       c.MissionID,
+		IssuedAt:        c.IssuedAt,
+		ExpiresAt:       c.ExpiresAt,
+		GrantType:       string(c.GrantType),
+		DelegationDepth: c.DelegationDepth,
+		// ScopesIn defaults to ScopesOut for root credentials so the
+		// triple is always populated; the parent-lookup branch
+		// overwrites this for non-root edges.
+		ScopesIn:   scopesOut,
+		ScopesOut:  scopesOut,
+		Attenuated: []string{},
+		IsRevoked:  c.IsRevoked,
+	}
+}
+
+func identityIDOrEmpty(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// setDiff returns the elements in a that are not in b, preserving the
+// order from a. Used to compute the attenuated-scopes set on each edge.
+func setDiff(a, b []string) []string {
+	if len(a) == 0 {
+		return []string{}
+	}
+	inB := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		inB[s] = struct{}{}
+	}
+	out := make([]string, 0)
+	for _, s := range a {
+		if _, ok := inB[s]; !ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/service/delegation.go
+++ b/internal/service/delegation.go
@@ -109,7 +109,7 @@ func NewDelegationService(credRepo *postgres.CredentialRepository, delegRepo *po
 // When the identity has issued no credentials yet, returns a one-node
 // graph (just the identity, no edges). When the credential count
 // exceeds MaxGraphNodes after the walk, Truncated is set on the
-// response; nodes are kept but edges are capped at MaxGraphNodes-1.
+// response; credentials are capped at MaxGraphNodes.
 func (s *DelegationService) GetGraph(ctx context.Context, identityID string, depth int, accountID, projectID string) (*Graph, error) {
 	if depth < 1 {
 		depth = 1

--- a/internal/store/postgres/delegation.go
+++ b/internal/store/postgres/delegation.go
@@ -68,16 +68,13 @@ type ChainSummary struct {
 // would not be reachable because the recursive step filters on
 // `ic.account_id` / `ic.project_id`.
 //
-// The recursive step also constrains `(chain.mission_id IS NULL OR
-// ic.mission_id = chain.mission_id)` so the planner prunes to a single
-// mission's rows via idx_issued_credentials_mission_id instead of scanning
-// the tenant slice on every iteration. parent_jti still drives lineage
-// segmentation — branched missions (sibling token_exchanges off the same
-// parent) share mission_id but live in different parent_jti chains, and the
-// join on `ic.jti = chain.parent_jti` keeps them apart. The IS NULL branch
-// short-circuits for legacy pre-022 rows with NULL mission_id so the walk
-// proceeds unfiltered; the `=` branch on the non-NULL path is more
-// index-friendly than IS NOT DISTINCT FROM.
+// The recursive step also constrains `ic.mission_id = chain.mission_id` so
+// the planner prunes to a single mission's rows via
+// idx_issued_credentials_mission_id instead of scanning the tenant slice on
+// every iteration. parent_jti still drives lineage segmentation — branched
+// missions (sibling token_exchanges off the same parent) share mission_id
+// but live in different parent_jti chains, and the join on
+// `ic.jti = chain.parent_jti` keeps them apart.
 func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
 	if maxDepth < 0 {
 		maxDepth = 0
@@ -98,7 +95,7 @@ func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, 
 			JOIN chain ON ic.jti = chain.parent_jti
 			WHERE ic.account_id = ?
 			  AND ic.project_id = ?
-			  AND (chain.mission_id IS NULL OR ic.mission_id = chain.mission_id)
+			  AND ic.mission_id = chain.mission_id
 			  AND chain.depth < ?
 		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
 		SELECT ic.*
@@ -120,8 +117,8 @@ func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, 
 // The recursive step joins `ic.parent_jti = chain.jti` to find the
 // children of each row in the chain. Same CYCLE + depth-cap safety as
 // WalkUp. Same tenant scoping on every join. The
-// `(chain.mission_id IS NULL OR ic.mission_id = chain.mission_id)` predicate
-// plays the same role here as in WalkUp — see that function for the rationale.
+// `ic.mission_id = chain.mission_id` predicate plays the same role here as
+// in WalkUp — see that function for the rationale.
 func (r *DelegationRepository) WalkDown(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
 	if maxDepth < 0 {
 		maxDepth = 0
@@ -141,7 +138,7 @@ func (r *DelegationRepository) WalkDown(ctx context.Context, startJTI, accountID
 			JOIN chain ON ic.parent_jti = chain.jti
 			WHERE ic.account_id = ?
 			  AND ic.project_id = ?
-			  AND (chain.mission_id IS NULL OR ic.mission_id = chain.mission_id)
+			  AND ic.mission_id = chain.mission_id
 			  AND chain.depth < ?
 		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
 		SELECT ic.*

--- a/internal/store/postgres/delegation.go
+++ b/internal/store/postgres/delegation.go
@@ -67,6 +67,17 @@ type ChainSummary struct {
 // step. Credentials with parent_jti pointing into a different tenant
 // would not be reachable because the recursive step filters on
 // `ic.account_id` / `ic.project_id`.
+//
+// The recursive step also constrains `ic.mission_id IS NOT DISTINCT FROM
+// chain.mission_id` so the planner prunes to a single mission's rows via
+// idx_issued_credentials_mission_id instead of scanning the tenant slice
+// on every iteration. parent_jti still drives lineage segmentation —
+// branched missions (sibling token_exchanges off the same parent) share
+// mission_id but live in different parent_jti chains, and the join on
+// `ic.jti = chain.parent_jti` keeps them apart. `IS NOT DISTINCT FROM`
+// (not `=`) keeps legacy pre-migration NULL-mission rows reachable:
+// `NULL = NULL` is falsy in SQL and would terminate the recursion on
+// step 1 for any pre-022 anchor.
 func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
 	if maxDepth < 0 {
 		maxDepth = 0
@@ -75,18 +86,19 @@ func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, 
 	db := dbOrTx(ctx, r.db)
 	// Order DESC so root (highest depth) appears first.
 	const q = `
-		WITH RECURSIVE chain(id, jti, parent_jti, depth) AS (
-			SELECT id, jti, parent_jti, 0
+		WITH RECURSIVE chain(id, jti, parent_jti, depth, mission_id) AS (
+			SELECT id, jti, parent_jti, 0, mission_id
 			FROM issued_credentials
 			WHERE jti = ?
 			  AND account_id = ?
 			  AND project_id = ?
 			UNION ALL
-			SELECT ic.id, ic.jti, ic.parent_jti, chain.depth + 1
+			SELECT ic.id, ic.jti, ic.parent_jti, chain.depth + 1, ic.mission_id
 			FROM issued_credentials ic
 			JOIN chain ON ic.jti = chain.parent_jti
 			WHERE ic.account_id = ?
 			  AND ic.project_id = ?
+			  AND ic.mission_id IS NOT DISTINCT FROM chain.mission_id
 			  AND chain.depth < ?
 		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
 		SELECT ic.*
@@ -107,7 +119,10 @@ func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, 
 //
 // The recursive step joins `ic.parent_jti = chain.jti` to find the
 // children of each row in the chain. Same CYCLE + depth-cap safety as
-// WalkUp. Same tenant scoping on every join.
+// WalkUp. Same tenant scoping on every join. The
+// `ic.mission_id IS NOT DISTINCT FROM chain.mission_id` predicate plays
+// the same role here as in WalkUp — see that function for the rationale
+// and the legacy-NULL caveat.
 func (r *DelegationRepository) WalkDown(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
 	if maxDepth < 0 {
 		maxDepth = 0
@@ -115,18 +130,19 @@ func (r *DelegationRepository) WalkDown(ctx context.Context, startJTI, accountID
 	var creds []*domain.IssuedCredential
 	db := dbOrTx(ctx, r.db)
 	const q = `
-		WITH RECURSIVE chain(id, jti, depth) AS (
-			SELECT id, jti, 0
+		WITH RECURSIVE chain(id, jti, depth, mission_id) AS (
+			SELECT id, jti, 0, mission_id
 			FROM issued_credentials
 			WHERE jti = ?
 			  AND account_id = ?
 			  AND project_id = ?
 			UNION ALL
-			SELECT ic.id, ic.jti, chain.depth + 1
+			SELECT ic.id, ic.jti, chain.depth + 1, ic.mission_id
 			FROM issued_credentials ic
 			JOIN chain ON ic.parent_jti = chain.jti
 			WHERE ic.account_id = ?
 			  AND ic.project_id = ?
+			  AND ic.mission_id IS NOT DISTINCT FROM chain.mission_id
 			  AND chain.depth < ?
 		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
 		SELECT ic.*

--- a/internal/store/postgres/delegation.go
+++ b/internal/store/postgres/delegation.go
@@ -46,11 +46,11 @@ func NewDelegationRepository(db *bun.DB) *DelegationRepository {
 // each row as its own chain. The two cases are indistinguishable to
 // callers — both are opaque chain handles.
 type ChainSummary struct {
-	ChainID          string    `bun:"chain_id"          json:"chain_id"`
-	StartedAt        time.Time `bun:"started_at"        json:"started_at"`
-	LastActivityAt   time.Time `bun:"last_activity_at"  json:"last_activity_at"`
-	CredentialCount  int       `bun:"credential_count"  json:"credential_count"`
-	MaxDepth         int       `bun:"max_depth"         json:"max_depth"`
+	ChainID         string    `bun:"chain_id"          json:"chain_id"`
+	StartedAt       time.Time `bun:"started_at"        json:"started_at"`
+	LastActivityAt  time.Time `bun:"last_activity_at"  json:"last_activity_at"`
+	CredentialCount int       `bun:"credential_count"  json:"credential_count"`
+	MaxDepth        int       `bun:"max_depth"         json:"max_depth"`
 }
 
 // WalkUp returns the credential identified by startJTI plus its ancestors

--- a/internal/store/postgres/delegation.go
+++ b/internal/store/postgres/delegation.go
@@ -1,0 +1,181 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/uptrace/bun"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// DelegationRepository walks the credential delegation graph via parent_jti.
+//
+// Two recursive CTE walkers (WalkUp / WalkDown) and one aggregate
+// (ListChains) cover every read pattern the Delegation Explorer needs:
+//
+//   - WalkUp follows parent_jti links from a starting JTI to the root,
+//     answering "who delegated this token to me, and through what chain?"
+//   - WalkDown follows reverse parent_jti links (children) from a starting
+//     JTI to leaves, answering "what tokens were minted off this one?"
+//   - ListChains groups by COALESCE(mission_id, jti) to produce one row per
+//     delegation tree active in a time window, ordered by last activity.
+//
+// All three are tenant-scoped on every join. Both walkers are depth-capped
+// and use the SQL-standard CYCLE clause (Postgres 14+) for cycle safety,
+// matching the pattern established by revoke_credentials_cascade
+// (migrations/007_cascade_revocation.up.sql).
+//
+// See issue #153.
+type DelegationRepository struct {
+	db *bun.DB
+}
+
+// NewDelegationRepository creates a new DelegationRepository.
+func NewDelegationRepository(db *bun.DB) *DelegationRepository {
+	return &DelegationRepository{db: db}
+}
+
+// ChainSummary is one row of /delegations/chains output — a single
+// delegation tree active in the requested time window.
+//
+// ChainID is COALESCE(mission_id, jti): for credentials issued after the
+// mission_id denormalization landed it's the mission_id (= root JTI);
+// for legacy pre-denormalization credentials it falls back to grouping
+// each row as its own chain. The two cases are indistinguishable to
+// callers — both are opaque chain handles.
+type ChainSummary struct {
+	ChainID          string    `bun:"chain_id"          json:"chain_id"`
+	StartedAt        time.Time `bun:"started_at"        json:"started_at"`
+	LastActivityAt   time.Time `bun:"last_activity_at"  json:"last_activity_at"`
+	CredentialCount  int       `bun:"credential_count"  json:"credential_count"`
+	MaxDepth         int       `bun:"max_depth"         json:"max_depth"`
+}
+
+// WalkUp returns the credential identified by startJTI plus its ancestors
+// reached by following parent_jti links upward, capped at maxDepth hops.
+// Results are ordered root → starting credential.
+//
+// The recursive CTE anchors on startJTI (depth 0) and joins on
+// `ic.jti = chain.parent_jti` to climb the chain one hop at a time. The
+// CYCLE clause guards against any pathological cycle even though
+// parent_jti is acyclic by construction; the hard depth cap is the
+// second line of defense.
+//
+// Tenant scope is enforced both at the anchor and on every recursive
+// step. Credentials with parent_jti pointing into a different tenant
+// would not be reachable because the recursive step filters on
+// `ic.account_id` / `ic.project_id`.
+func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
+	if maxDepth < 0 {
+		maxDepth = 0
+	}
+	var creds []*domain.IssuedCredential
+	db := dbOrTx(ctx, r.db)
+	// Order DESC so root (highest depth) appears first.
+	const q = `
+		WITH RECURSIVE chain(id, jti, parent_jti, depth) AS (
+			SELECT id, jti, parent_jti, 0
+			FROM issued_credentials
+			WHERE jti = ?
+			  AND account_id = ?
+			  AND project_id = ?
+			UNION ALL
+			SELECT ic.id, ic.jti, ic.parent_jti, chain.depth + 1
+			FROM issued_credentials ic
+			JOIN chain ON ic.jti = chain.parent_jti
+			WHERE ic.account_id = ?
+			  AND ic.project_id = ?
+			  AND chain.depth < ?
+		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+		SELECT ic.*
+		FROM issued_credentials ic
+		JOIN chain ON ic.id = chain.id
+		WHERE NOT chain.is_cycle
+		ORDER BY chain.depth DESC, ic.issued_at ASC`
+	if err := db.NewRaw(q, startJTI, accountID, projectID, accountID, projectID, maxDepth).Scan(ctx, &creds); err != nil {
+		return nil, fmt.Errorf("walk-up delegation chain: %w", err)
+	}
+	return creds, nil
+}
+
+// WalkDown returns the credential identified by startJTI plus its
+// descendants reached by following reverse parent_jti links (children),
+// capped at maxDepth hops. Results are ordered starting credential →
+// leaves (depth ASC, issued_at ASC for ties).
+//
+// The recursive step joins `ic.parent_jti = chain.jti` to find the
+// children of each row in the chain. Same CYCLE + depth-cap safety as
+// WalkUp. Same tenant scoping on every join.
+func (r *DelegationRepository) WalkDown(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
+	if maxDepth < 0 {
+		maxDepth = 0
+	}
+	var creds []*domain.IssuedCredential
+	db := dbOrTx(ctx, r.db)
+	const q = `
+		WITH RECURSIVE chain(id, jti, depth) AS (
+			SELECT id, jti, 0
+			FROM issued_credentials
+			WHERE jti = ?
+			  AND account_id = ?
+			  AND project_id = ?
+			UNION ALL
+			SELECT ic.id, ic.jti, chain.depth + 1
+			FROM issued_credentials ic
+			JOIN chain ON ic.parent_jti = chain.jti
+			WHERE ic.account_id = ?
+			  AND ic.project_id = ?
+			  AND chain.depth < ?
+		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+		SELECT ic.*
+		FROM issued_credentials ic
+		JOIN chain ON ic.id = chain.id
+		WHERE NOT chain.is_cycle
+		ORDER BY chain.depth ASC, ic.issued_at ASC`
+	if err := db.NewRaw(q, startJTI, accountID, projectID, accountID, projectID, maxDepth).Scan(ctx, &creds); err != nil {
+		return nil, fmt.Errorf("walk-down delegation chain: %w", err)
+	}
+	return creds, nil
+}
+
+// ListChains returns one summary row per delegation tree active in the
+// [since, until) window, ordered by last activity descending. limit
+// caps the result set.
+//
+// Grouping is COALESCE(mission_id, jti) so credentials denormalized with
+// mission_id collapse onto one row per tree, while legacy credentials
+// without mission_id each form a one-credential chain. Both cases are
+// expected; the result schema is uniform.
+//
+// The aggregate hits idx_issued_credentials_mission_id for the
+// post-denormalization majority. The COALESCE prevents the partial
+// index from being used directly in EXPLAIN plans, but tenant-scope
+// filtering still narrows the scan to the active tenant's rows.
+func (r *DelegationRepository) ListChains(ctx context.Context, accountID, projectID string, since, until time.Time, limit int) ([]*ChainSummary, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var rows []*ChainSummary
+	db := dbOrTx(ctx, r.db)
+	const q = `
+		SELECT
+			COALESCE(mission_id, jti) AS chain_id,
+			MIN(issued_at)            AS started_at,
+			MAX(issued_at)            AS last_activity_at,
+			COUNT(*)::int             AS credential_count,
+			MAX(delegation_depth)::int AS max_depth
+		FROM issued_credentials
+		WHERE account_id = ?
+		  AND project_id = ?
+		  AND issued_at >= ?
+		  AND issued_at <  ?
+		GROUP BY COALESCE(mission_id, jti)
+		ORDER BY MAX(issued_at) DESC
+		LIMIT ?`
+	if err := db.NewRaw(q, accountID, projectID, since, until, limit).Scan(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("list delegation chains: %w", err)
+	}
+	return rows, nil
+}

--- a/internal/store/postgres/delegation.go
+++ b/internal/store/postgres/delegation.go
@@ -68,16 +68,16 @@ type ChainSummary struct {
 // would not be reachable because the recursive step filters on
 // `ic.account_id` / `ic.project_id`.
 //
-// The recursive step also constrains `ic.mission_id IS NOT DISTINCT FROM
-// chain.mission_id` so the planner prunes to a single mission's rows via
-// idx_issued_credentials_mission_id instead of scanning the tenant slice
-// on every iteration. parent_jti still drives lineage segmentation —
-// branched missions (sibling token_exchanges off the same parent) share
-// mission_id but live in different parent_jti chains, and the join on
-// `ic.jti = chain.parent_jti` keeps them apart. `IS NOT DISTINCT FROM`
-// (not `=`) keeps legacy pre-migration NULL-mission rows reachable:
-// `NULL = NULL` is falsy in SQL and would terminate the recursion on
-// step 1 for any pre-022 anchor.
+// The recursive step also constrains `(chain.mission_id IS NULL OR
+// ic.mission_id = chain.mission_id)` so the planner prunes to a single
+// mission's rows via idx_issued_credentials_mission_id instead of scanning
+// the tenant slice on every iteration. parent_jti still drives lineage
+// segmentation — branched missions (sibling token_exchanges off the same
+// parent) share mission_id but live in different parent_jti chains, and the
+// join on `ic.jti = chain.parent_jti` keeps them apart. The IS NULL branch
+// short-circuits for legacy pre-022 rows with NULL mission_id so the walk
+// proceeds unfiltered; the `=` branch on the non-NULL path is more
+// index-friendly than IS NOT DISTINCT FROM.
 func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
 	if maxDepth < 0 {
 		maxDepth = 0
@@ -98,7 +98,7 @@ func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, 
 			JOIN chain ON ic.jti = chain.parent_jti
 			WHERE ic.account_id = ?
 			  AND ic.project_id = ?
-			  AND ic.mission_id IS NOT DISTINCT FROM chain.mission_id
+			  AND (chain.mission_id IS NULL OR ic.mission_id = chain.mission_id)
 			  AND chain.depth < ?
 		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
 		SELECT ic.*
@@ -120,9 +120,8 @@ func (r *DelegationRepository) WalkUp(ctx context.Context, startJTI, accountID, 
 // The recursive step joins `ic.parent_jti = chain.jti` to find the
 // children of each row in the chain. Same CYCLE + depth-cap safety as
 // WalkUp. Same tenant scoping on every join. The
-// `ic.mission_id IS NOT DISTINCT FROM chain.mission_id` predicate plays
-// the same role here as in WalkUp — see that function for the rationale
-// and the legacy-NULL caveat.
+// `(chain.mission_id IS NULL OR ic.mission_id = chain.mission_id)` predicate
+// plays the same role here as in WalkUp — see that function for the rationale.
 func (r *DelegationRepository) WalkDown(ctx context.Context, startJTI, accountID, projectID string, maxDepth int) ([]*domain.IssuedCredential, error) {
 	if maxDepth < 0 {
 		maxDepth = 0
@@ -142,7 +141,7 @@ func (r *DelegationRepository) WalkDown(ctx context.Context, startJTI, accountID
 			JOIN chain ON ic.parent_jti = chain.jti
 			WHERE ic.account_id = ?
 			  AND ic.project_id = ?
-			  AND ic.mission_id IS NOT DISTINCT FROM chain.mission_id
+			  AND (chain.mission_id IS NULL OR ic.mission_id = chain.mission_id)
 			  AND chain.depth < ?
 		) CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
 		SELECT ic.*

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -49,6 +49,31 @@ func (r *IdentityRepository) GetByID(ctx context.Context, id, accountID, project
 	return identity, nil
 }
 
+// GetByIDs returns identities with the given UUIDs, scoped to a tenant.
+// Used for batch node enrichment in graph endpoints (issue #153) so a
+// single query loads every identity referenced by a delegation chain
+// instead of issuing one GetByID per node.
+//
+// Returns the rows that matched; missing IDs are silently dropped (the
+// caller may filter ids belonging to other tenants, or pass IDs that
+// have since been deleted — both are non-errors for graph rendering).
+func (r *IdentityRepository) GetByIDs(ctx context.Context, ids []string, accountID, projectID string) ([]*domain.Identity, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var identities []*domain.Identity
+	db := dbOrTx(ctx, r.db)
+	err := db.NewSelect().Model(&identities).
+		Where("id IN (?)", bun.In(ids)).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Scan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get identities by ids: %w", err)
+	}
+	return identities, nil
+}
+
 // GetByExternalID retrieves an identity by external ID within a tenant.
 func (r *IdentityRepository) GetByExternalID(ctx context.Context, externalID, accountID, projectID string) (*domain.Identity, error) {
 	identity := &domain.Identity{}

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -64,7 +64,7 @@ func (r *IdentityRepository) GetByIDs(ctx context.Context, ids []string, account
 	var identities []*domain.Identity
 	db := dbOrTx(ctx, r.db)
 	err := db.NewSelect().Model(&identities).
-		Where("id IN (?)", bun.In(ids)).
+		Where("id IN (?)", bun.List(ids)).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
 		Scan(ctx)

--- a/server.go
+++ b/server.go
@@ -152,6 +152,7 @@ func NewServer(cfg Config) (*Server, error) {
 	auditRepo := postgres.NewAuditLogRepository(db)
 	backchannelRepo := postgres.NewBackchannelRequestRepository(db)
 	signingCredRepo := postgres.NewSigningCredentialRepository(db)
+	delegationRepo := postgres.NewDelegationRepository(db)
 
 	// Build the attestation verifier registry. Real verifiers are wired
 	// first (OIDC today). Dev stubs cover image_hash and TPM only — those
@@ -227,11 +228,15 @@ func NewServer(cfg Config) (*Server, error) {
 	// via the dpop_jti table. Stateless beyond the DB it reads/writes.
 	dpopSvc := service.NewDPoPService(db)
 
+	// DelegationService is read-only over credentialRepo / delegationRepo /
+	// identityRepo and has no service dependencies of its own.
+	delegationSvc := service.NewDelegationService(credentialRepo, delegationRepo, identityRepo)
+
 	// Create shared API handler.
 	apiHandler := handler.NewAPI(
 		identitySvc, credentialSvc, credentialPolicySvc,
 		attestationSvc, attestationPolicySvc, proofSvc, oauthSvc, oauthClientSvc,
-		signalSvc, apiKeySvc, agentSvc, auditSvc, backchannelSvc, dpopSvc, jwksSvc,
+		signalSvc, apiKeySvc, agentSvc, auditSvc, backchannelSvc, dpopSvc, delegationSvc, jwksSvc,
 		signingCredSvc, db,
 		cfg.Token.Issuer, cfg.Token.BaseURL,
 	)

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -686,7 +686,7 @@ func TestDelegationGraph_MalformedIdentityID_Rejected(t *testing.T) {
 		"123",
 		"abc-def-ghi",
 		"00000000-0000-0000-0000-00000000000Z", // invalid hex char
-		"",                                      // empty string (required)
+		"",                                     // empty string (required)
 	} {
 		path := adminPath("/delegations/graph?identity_id=" + bad + "&depth=2")
 		if bad == "" {

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -745,4 +746,128 @@ func TestDelegationChains_InvalidParams_Rejected(t *testing.T) {
 		assert.Less(t, resp.StatusCode, 500,
 			"param %s must NOT 500", bad)
 	}
+}
+
+// TestDelegationGraph_BranchedMissionIsolation pins the lineage-segmentation
+// invariant that motivated rsharath's review: within a single mission, two
+// sibling branches must not bleed into each other's graph. Sibling branches
+// share mission_id but live in different parent_jti lineages, so a walker
+// that joined purely on mission_id (instead of parent_jti) would silently
+// mix them.
+//
+// This test passes against both the pre-change and post-change SQL — it's a
+// regression guard. The new mission_id predicate in WalkUp / WalkDown is an
+// AND (not an OR) against the existing parent_jti join, so sibling rows in
+// the same mission are still excluded by the parent_jti edge.
+//
+// Shape:
+//
+//	orch (root, mission M)
+//	  ├── B1  (parent_jti = orch.jti, mission M)
+//	  └── B2  (parent_jti = orch.jti, mission M)  ← must NOT show up in B1's graph
+func TestDelegationGraph_BranchedMissionIsolation(t *testing.T) {
+	policyID := delegationPolicy(t, uid("branched-policy"), []string{"data:read"})
+
+	_, _, orchTok := issueRootCredential(t, policyID, "branched-orch", []string{"data:read"})
+	b1ID, _, _ := exchangeToken(t, policyID, "branched-b1",
+		[]string{"data:read"}, []string{"data:read"}, orchTok)
+	b2ID, _, _ := exchangeToken(t, policyID, "branched-b2",
+		[]string{"data:read"}, []string{"data:read"}, orchTok)
+
+	resp := get(t, adminPath("/delegations/graph?identity_id="+b1ID+"&depth=2"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	ids := nodeIDs(body)
+	assert.Contains(t, ids, b1ID, "B1 (focal) must be in its own graph")
+	assert.NotContains(t, ids, b2ID,
+		"B2 is a sibling branch under the same mission as B1; must NOT appear in B1's graph")
+}
+
+// TestDelegationGraph_LegacyNullMissionID pins the legacy-row fallback:
+// credentials with mission_id = NULL (issued before migration 022) must
+// still walk correctly. This is the reason the new recursive predicate
+// uses `IS NOT DISTINCT FROM` instead of `=` — `NULL = NULL` is falsy in
+// SQL and would silently terminate the recursion on the first step for
+// any pre-migration anchor.
+//
+// Setup: build a normal A → B chain via OAuth, then UPDATE both rows to
+// NULL mission_id to simulate the pre-migration state. Walk from B and
+// confirm A is still reachable. Passes against both pre-change code
+// (no mission filter at all) and post-change code (NULL IS NOT DISTINCT
+// FROM NULL is TRUE, recursion proceeds).
+func TestDelegationGraph_LegacyNullMissionID(t *testing.T) {
+	policyID := delegationPolicy(t, uid("legacy-null-policy"), []string{"data:read"})
+
+	orchID, orchJTI, orchTok := issueRootCredential(t, policyID, "legacy-null-orch",
+		[]string{"data:read"})
+	bID, bJTI, _ := exchangeToken(t, policyID, "legacy-null-b",
+		[]string{"data:read"}, []string{"data:read"}, orchTok)
+
+	ctx := context.Background()
+	_, err := testDB.NewUpdate().
+		Table("issued_credentials").
+		Set("mission_id = NULL").
+		Where("jti IN (?, ?)", orchJTI, bJTI).
+		Exec(ctx)
+	require.NoError(t, err, "simulate pre-migration NULL mission_id")
+
+	resp := get(t, adminPath("/delegations/graph?identity_id="+bID+"&depth=2"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	ids := nodeIDs(body)
+	assert.Contains(t, ids, bID, "B (focal) must appear in its own graph")
+	assert.Contains(t, ids, orchID,
+		"legacy NULL-mission anchor must still walk to its parent via parent_jti — IS NOT DISTINCT FROM lets NULL chains through")
+}
+
+// TestDelegationGraph_CrossMissionBoundary is the test that drives the
+// SQL change. It pins that the new recursive-step predicate prunes the
+// walker at a mission boundary: a credential linked by parent_jti to a
+// credential in a different mission must not be reached.
+//
+// This shouldn't happen in practice — mission_id is propagated on every
+// token_exchange — but the test simulates the scenario by UPDATEing one
+// row's mission_id to a different value. It is the primary correctness
+// claim of the new predicate.
+//
+// Expected:
+//   - Pre-change (no mission filter on recursive step): FAILS — A is
+//     reachable from B via parent_jti and gets included in the graph.
+//   - Post-change (IS NOT DISTINCT FROM): PASSES — the recursive step
+//     prunes A because A.mission_id != B.mission_id.
+//
+// If this test passes against the pre-change code, the test isn't
+// actually exercising the predicate — fix it before touching SQL.
+func TestDelegationGraph_CrossMissionBoundary(t *testing.T) {
+	policyID := delegationPolicy(t, uid("cross-mission-policy"), []string{"data:read"})
+
+	orchID, orchJTI, orchTok := issueRootCredential(t, policyID, "cross-orch",
+		[]string{"data:read"})
+	bID, _, _ := exchangeToken(t, policyID, "cross-b",
+		[]string{"data:read"}, []string{"data:read"}, orchTok)
+
+	// Rewrite the orchestrator's mission_id so it no longer matches B's.
+	// B's mission_id was propagated from the orch token at exchange time;
+	// flipping orch's value after the fact creates the synthetic
+	// cross-mission boundary the predicate must catch. Using a literal
+	// distinct value (not NULL) ensures the IS NOT DISTINCT FROM check
+	// evaluates to FALSE on the recursive step.
+	ctx := context.Background()
+	_, err := testDB.NewUpdate().
+		Table("issued_credentials").
+		Set("mission_id = ?", "synthetic-other-mission-"+uid("")).
+		Where("jti = ?", orchJTI).
+		Exec(ctx)
+	require.NoError(t, err, "simulate cross-mission parent_jti link")
+
+	resp := get(t, adminPath("/delegations/graph?identity_id="+bID+"&depth=2"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	ids := nodeIDs(body)
+	assert.Contains(t, ids, bID, "B (focal) must always appear in its own graph")
+	assert.NotContains(t, ids, orchID,
+		"orch lives in a different mission than B; the recursive predicate must prune it")
 }

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -476,11 +476,8 @@ func TestDelegationChains_TimeWindow(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	body := decode(t, resp)
-	total, _ := body["total"].(float64)
-	assert.GreaterOrEqual(t, int(total), 1, "must include the chain we just issued")
-
 	chains, _ := body["chains"].([]any)
-	require.NotEmpty(t, chains)
+	require.NotEmpty(t, chains, "must include the chain we just issued")
 	first := chains[0].(map[string]any)
 	assert.NotEmpty(t, first["chain_id"])
 	assert.NotEmpty(t, first["started_at"])

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -1,0 +1,751 @@
+package integration_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// delegationPolicy returns a fresh credential policy that allows
+// client_credentials + token_exchange up to depth 5 with the supplied
+// scope set. Centralized so a future scope-allowlist tightening only
+// needs editing in one place.
+func delegationPolicy(t *testing.T, name string, allowedScopes []string) string {
+	t.Helper()
+	return createRichCredentialPolicy(t, map[string]any{
+		"name":                 name,
+		"allowed_grant_types":  []string{"client_credentials", "token_exchange"},
+		"allowed_scopes":       allowedScopes,
+		"max_delegation_depth": 5,
+		"max_ttl_seconds":      3600,
+	}, adminHeaders())
+}
+
+// issueRootCredential registers an identity + OAuth client, issues a
+// client_credentials token, returns (identityID, jti, accessToken).
+// Centralized so chain-building tests stop reading like boilerplate.
+func issueRootCredential(t *testing.T, policyID, namePrefix string, scopes []string) (identityID, jti, token string) {
+	t.Helper()
+	extID := uid(namePrefix)
+	identityID = registerIdentityWithPolicy(t, extID, policyID, "", scopes, adminHeaders())
+	client := registerOAuthClient(t, extID, scopes)
+	scopeStr := scopesToString(scopes)
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         scopeStr,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"client_credentials root issuance: expected 200")
+	token = decode(t, resp)["access_token"].(string)
+	jti = decodeJWTUnsafe(t, token)["jti"].(string)
+	return
+}
+
+// exchangeToken registers a new identity with the given scope ceiling,
+// then exchanges parentToken for a token bound to that identity.
+// Returns (identityID, jti, accessToken). Scopes on the exchanged
+// token are exactly requestedScopes so attenuation tests can drive a
+// known shape.
+func exchangeToken(t *testing.T, policyID, namePrefix string, allowedScopes, requestedScopes []string, parentToken string) (identityID, jti, token string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	extID := uid(namePrefix)
+	identityID = registerIdentityWithPolicy(t, extID, policyID, ecPublicKeyPEM(t, key),
+		allowedScopes, adminHeaders())
+	wimse := fetchIdentityWIMSEByExternalID(t, extID)
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": parentToken,
+		"actor_token":   buildAssertion(t, key, wimse),
+		"scope":         scopesToString(requestedScopes),
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"token_exchange %s: expected 200, got %d", namePrefix, resp.StatusCode)
+	token = decode(t, resp)["access_token"].(string)
+	jti = decodeJWTUnsafe(t, token)["jti"].(string)
+	return
+}
+
+func scopesToString(scopes []string) string {
+	out := ""
+	for i, s := range scopes {
+		if i > 0 {
+			out += " "
+		}
+		out += s
+	}
+	return out
+}
+
+// edgeMap indexes graph response edges by their `to` identity_id so
+// per-edge assertions can target a specific hop without iterating.
+func edgeMap(body map[string]any) map[string]map[string]any {
+	edges, _ := body["edges"].([]any)
+	out := make(map[string]map[string]any, len(edges))
+	for _, e := range edges {
+		m := e.(map[string]any)
+		if to, ok := m["to"].(string); ok && to != "" {
+			out[to] = m
+		}
+	}
+	return out
+}
+
+func nodeIDs(body map[string]any) map[string]struct{} {
+	nodes, _ := body["nodes"].([]any)
+	out := make(map[string]struct{}, len(nodes))
+	for _, n := range nodes {
+		m := n.(map[string]any)
+		out[m["id"].(string)] = struct{}{}
+	}
+	return out
+}
+
+func stringSlice(v any) []string {
+	arr, _ := v.([]any)
+	out := make([]string, 0, len(arr))
+	for _, x := range arr {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestDelegationGraph_DepthBoundedSubgraph builds a 3-node delegation
+// chain with scope attenuation at the deepest hop. Pins:
+//
+//   - Exact node count: 3 (orchestrator + A + B).
+//   - Exact edge count: 3 (root + 2 exchanges).
+//   - focal_id echoes the queried identity.
+//   - orchestrator→A edge: scopes_in == scopes_out, attenuated == [].
+//   - A→B edge: scopes_in = parent scopes, scopes_out = child scopes,
+//     attenuated = exactly ["data:write"].
+//
+// Chain shape:
+//
+//	orchestrator  client_credentials  [data:read, data:write]   depth 0
+//	  └── A       token_exchange      [data:read, data:write]   depth 1
+//	        └── B token_exchange      [data:read]               depth 2  ← attenuated
+func TestDelegationGraph_DepthBoundedSubgraph(t *testing.T) {
+	policyID := delegationPolicy(t, uid("deleg-policy"), []string{"data:read", "data:write"})
+
+	orchID, _, orchToken := issueRootCredential(t, policyID, "deleg-orch",
+		[]string{"data:read", "data:write"})
+	aID, _, tokenA := exchangeToken(t, policyID, "deleg-agent-a",
+		[]string{"data:read", "data:write"},
+		[]string{"data:read", "data:write"}, orchToken)
+	bID, _, _ := exchangeToken(t, policyID, "deleg-agent-b",
+		[]string{"data:read", "data:write"},
+		[]string{"data:read"}, tokenA)
+
+	graphResp := get(t, adminPath("/delegations/graph?identity_id="+aID+"&depth=2"), adminHeaders())
+	require.Equal(t, http.StatusOK, graphResp.StatusCode)
+	body := decode(t, graphResp)
+
+	assert.Equal(t, aID, body["focal_id"], "focal_id must echo queried identity")
+	assert.Nil(t, body["truncated"], "small graph must not be truncated")
+
+	ids := nodeIDs(body)
+	assert.Len(t, ids, 3, "graph must include exactly 3 nodes (orch + A + B)")
+	assert.Contains(t, ids, orchID, "orchestrator missing from nodes")
+	assert.Contains(t, ids, aID, "agent-A missing from nodes")
+	assert.Contains(t, ids, bID, "agent-B missing from nodes")
+
+	edges, _ := body["edges"].([]any)
+	require.Len(t, edges, 3, "graph must include exactly 3 edges (root + 2 hops)")
+
+	byTo := edgeMap(body)
+	orchEdge, ok := byTo[orchID]
+	require.True(t, ok, "orchestrator must have an edge keyed by its identity_id")
+	assert.Empty(t, orchEdge["from"],
+		"root credential edge has no parent → from must be empty")
+	assert.Empty(t, orchEdge["parent_jti"],
+		"root credential edge has no parent_jti (omitted via omitempty)")
+	assert.Empty(t, stringSlice(orchEdge["attenuated"]),
+		"root credential has no parent → attenuated must be empty")
+	assert.Equal(t, stringSlice(orchEdge["scopes_in"]), stringSlice(orchEdge["scopes_out"]),
+		"root credential: scopes_in must equal scopes_out")
+
+	aEdge, ok := byTo[aID]
+	require.True(t, ok, "agent-A edge must exist")
+	assert.Equal(t, orchID, aEdge["from"], "A's edge must point from orchestrator")
+	assert.Empty(t, stringSlice(aEdge["attenuated"]),
+		"A inherits both scopes; attenuation must be empty")
+
+	bEdge, ok := byTo[bID]
+	require.True(t, ok, "agent-B edge must exist")
+	assert.Equal(t, aID, bEdge["from"], "B's edge must point from agent-A")
+	assert.ElementsMatch(t, []string{"data:read", "data:write"}, stringSlice(bEdge["scopes_in"]),
+		"B's scopes_in must be A's full scope set")
+	assert.ElementsMatch(t, []string{"data:read"}, stringSlice(bEdge["scopes_out"]),
+		"B's scopes_out must be exactly what was requested")
+	assert.ElementsMatch(t, []string{"data:write"}, stringSlice(bEdge["attenuated"]),
+		"the one dropped scope on A→B must be data:write")
+}
+
+// TestDelegationGraph_NoCredentials_SingleNode pins the empty-chain
+// behavior: a registered identity with no issued credentials returns a
+// single-node graph (the identity itself) with no edges.
+func TestDelegationGraph_NoCredentials_SingleNode(t *testing.T) {
+	extID := uid("deleg-empty")
+	identityID := registerIdentityWithPolicy(t, extID, "", "",
+		[]string{"data:read"}, adminHeaders())
+
+	resp := get(t, adminPath("/delegations/graph?identity_id="+identityID+"&depth=2"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decode(t, resp)
+	assert.Equal(t, identityID, body["focal_id"])
+
+	nodes, _ := body["nodes"].([]any)
+	require.Len(t, nodes, 1, "no-credential identity yields exactly one node (itself)")
+	assert.Equal(t, identityID, nodes[0].(map[string]any)["id"],
+		"the single node must be the queried identity, not a placeholder")
+
+	edges, _ := body["edges"].([]any)
+	assert.Empty(t, edges, "no-credential identity yields no edges")
+}
+
+// TestDelegationGraph_DepthLimitsTheWalk pins the depth-bound invariant
+// on the recursive CTE: a 4-hop chain queried with depth=1 from the
+// middle node returns ONLY the focal credential plus one hop in each
+// direction. The root and the deepest leaf must be absent.
+//
+// This is the most important correctness test in the file: a CTE that
+// silently ignored its depth cap would still return a "valid-looking"
+// response, just oversized — which is exactly the failure mode that
+// makes a 500-credential mission OOM the Studio renderer.
+//
+// Chain: orch → A → B → C → D, request graph for B with depth=1.
+// Expected: {A, B, C} only (D and orch must be missing).
+func TestDelegationGraph_DepthLimitsTheWalk(t *testing.T) {
+	policyID := delegationPolicy(t, uid("deleg-depth-policy"), []string{"data:read"})
+
+	orchID, _, orchTok := issueRootCredential(t, policyID, "depth-orch", []string{"data:read"})
+	aID, _, tokA := exchangeToken(t, policyID, "depth-a",
+		[]string{"data:read"}, []string{"data:read"}, orchTok)
+	bID, _, tokB := exchangeToken(t, policyID, "depth-b",
+		[]string{"data:read"}, []string{"data:read"}, tokA)
+	cID, _, tokC := exchangeToken(t, policyID, "depth-c",
+		[]string{"data:read"}, []string{"data:read"}, tokB)
+	dID, _, _ := exchangeToken(t, policyID, "depth-d",
+		[]string{"data:read"}, []string{"data:read"}, tokC)
+
+	resp := get(t, adminPath("/delegations/graph?identity_id="+bID+"&depth=1"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	ids := nodeIDs(body)
+	assert.Contains(t, ids, aID, "depth=1 from B must include A (1 hop up)")
+	assert.Contains(t, ids, bID, "depth=1 from B must include B (focal)")
+	assert.Contains(t, ids, cID, "depth=1 from B must include C (1 hop down)")
+	assert.NotContains(t, ids, orchID,
+		"depth=1 from B must NOT include orchestrator (2 hops up)")
+	assert.NotContains(t, ids, dID,
+		"depth=1 from B must NOT include D (2 hops down)")
+	assert.Len(t, ids, 3, "depth=1 must yield exactly 3 nodes — no more, no fewer")
+
+	// A's parent (orchestrator) is outside the walked set, so A's edge
+	// must carry from="" — surfaces the depth boundary to the client.
+	aEdge := edgeMap(body)[aID]
+	require.NotNil(t, aEdge, "A's edge must be present")
+	assert.Empty(t, aEdge["from"],
+		"A's parent (orch) is beyond the depth cap; edge.from must be empty")
+}
+
+// TestDelegationGraph_MostRecentCredentialIsFocal pins the Option-B
+// design choice: when an identity participates in multiple unrelated
+// chains, GetGraph centers on the most recent credential and the older
+// chain is invisible.
+//
+// Without this guard the focal selection could silently flip between
+// chains as old credentials happen to sort differently.
+func TestDelegationGraph_MostRecentCredentialIsFocal(t *testing.T) {
+	policyID := delegationPolicy(t, uid("focal-policy"), []string{"data:read"})
+
+	// Issue two unrelated root credentials for the same identity. Each
+	// is its own mission tree — they share nothing but the identity.
+	extID := uid("focal-orch")
+	identityID := registerIdentityWithPolicy(t, extID, policyID, "",
+		[]string{"data:read"}, adminHeaders())
+	client := registerOAuthClient(t, extID, []string{"data:read"})
+
+	respFirst := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, respFirst.StatusCode)
+	jtiFirst := decodeJWTUnsafe(t, decode(t, respFirst)["access_token"].(string))["jti"].(string)
+
+	// Force monotonic clock movement so the second credential's
+	// issued_at is strictly greater than the first.
+	time.Sleep(20 * time.Millisecond)
+
+	respSecond := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, respSecond.StatusCode)
+	jtiSecond := decodeJWTUnsafe(t, decode(t, respSecond)["access_token"].(string))["jti"].(string)
+	require.NotEqual(t, jtiFirst, jtiSecond, "two issuances must produce distinct JTIs")
+
+	resp := get(t, adminPath("/delegations/graph?identity_id="+identityID+"&depth=2"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	edges, _ := body["edges"].([]any)
+	require.Len(t, edges, 1,
+		"focal must walk only the most-recent credential's chain; the older chain is invisible")
+	gotJTI := edges[0].(map[string]any)["jti"].(string)
+	assert.Equal(t, jtiSecond, gotJTI,
+		"focal credential must be the most recent issuance")
+	assert.NotEqual(t, jtiFirst, gotJTI,
+		"older credential's chain must NOT be selected as focal")
+}
+
+// TestDelegationGraph_RevokedCredentialAppears pins that the graph is
+// a historical view, not an "active credentials" view: revoked
+// credentials still appear with is_revoked=true. Forensic replay
+// depends on this.
+func TestDelegationGraph_RevokedCredentialAppears(t *testing.T) {
+	policyID := delegationPolicy(t, uid("revoke-policy"), []string{"data:read"})
+
+	_, _, orchTok := issueRootCredential(t, policyID, "revoke-orch", []string{"data:read"})
+	aID, aJTI, tokA := exchangeToken(t, policyID, "revoke-a",
+		[]string{"data:read"}, []string{"data:read"}, orchTok)
+	_ = tokA
+
+	// Revoke A's credential by JTI via the credential-list lookup.
+	credResp := get(t, adminPath("/credentials?identity_id="+aID), adminHeaders())
+	require.Equal(t, http.StatusOK, credResp.StatusCode)
+	creds := decode(t, credResp)["credentials"].([]any)
+	require.NotEmpty(t, creds, "A must have at least one credential")
+	var credID string
+	for _, c := range creds {
+		m := c.(map[string]any)
+		if m["jti"].(string) == aJTI {
+			credID = m["id"].(string)
+		}
+	}
+	require.NotEmpty(t, credID, "could not resolve A's credential ID for revocation")
+
+	rev := post(t, adminPath("/credentials/"+credID+"/revoke"),
+		map[string]any{"reason": "test-revoke"}, adminHeaders())
+	require.Equal(t, http.StatusOK, rev.StatusCode, "revoke must succeed")
+
+	resp := get(t, adminPath("/delegations/graph?identity_id="+aID+"&depth=2"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	aEdge := edgeMap(body)[aID]
+	require.NotNil(t, aEdge, "A's edge must still appear after revocation")
+	assert.True(t, aEdge["is_revoked"].(bool),
+		"revoked credential's edge must carry is_revoked=true")
+}
+
+// TestDelegationGraph_DepthOutOfRange_Rejected pins the Huma-side
+// validation bounds on `depth` (1..10). 0 and 11 both reject with
+// 422 (Huma's validation-error status).
+func TestDelegationGraph_DepthOutOfRange_Rejected(t *testing.T) {
+	extID := uid("deleg-bounds")
+	identityID := registerIdentityWithPolicy(t, extID, "", "",
+		[]string{"data:read"}, adminHeaders())
+
+	for _, depth := range []int{0, 11, 100} {
+		resp := get(t,
+			adminPath("/delegations/graph?identity_id="+identityID+"&depth="+fmt.Sprintf("%d", depth)),
+			adminHeaders())
+		defer func() { _ = resp.Body.Close() }()
+		assert.GreaterOrEqual(t, resp.StatusCode, 400,
+			"depth=%d must be rejected with 4xx", depth)
+		assert.Less(t, resp.StatusCode, 500,
+			"depth=%d must NOT 500 (validation, not server error)", depth)
+	}
+}
+
+// TestDelegationGraph_MissingIdentityID_Rejected pins the Huma
+// `required:"true"` enforcement on identity_id. Without it the
+// service would receive an empty UUID and silently return the
+// "no credentials" path, which would mask client mistakes.
+func TestDelegationGraph_MissingIdentityID_Rejected(t *testing.T) {
+	resp := get(t, adminPath("/delegations/graph?depth=2"), adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.GreaterOrEqual(t, resp.StatusCode, 400,
+		"missing identity_id must be rejected with 4xx")
+	assert.Less(t, resp.StatusCode, 500,
+		"missing identity_id must NOT 500 (validation, not server error)")
+}
+
+// TestDelegationByJTI_WalksToRoot pins the forensic lineage walk: given
+// a leaf credential's JTI, the endpoint returns the full chain root → leaf
+// ordered by depth, and per-edge scope attenuation is computed against
+// the parent's scopes.
+func TestDelegationByJTI_WalksToRoot(t *testing.T) {
+	policyID := delegationPolicy(t, uid("by-jti-policy"), []string{"data:read"})
+
+	_, rootJTI, orchTok := issueRootCredential(t, policyID, "byjti-orch",
+		[]string{"data:read"})
+	_, leafJTI, _ := exchangeToken(t, policyID, "byjti-agent",
+		[]string{"data:read"}, []string{"data:read"}, orchTok)
+
+	chainResp := get(t, adminPath("/delegations/by-jti/"+url.PathEscape(leafJTI)), adminHeaders())
+	require.Equal(t, http.StatusOK, chainResp.StatusCode)
+
+	body := decode(t, chainResp)
+	edges, _ := body["edges"].([]any)
+	require.Len(t, edges, 2, "lineage has 2 hops: root + token_exchange")
+
+	first := edges[0].(map[string]any)
+	second := edges[1].(map[string]any)
+	firstDepth, _ := first["delegation_depth"].(float64)
+	secondDepth, _ := second["delegation_depth"].(float64)
+	assert.Equal(t, 0, int(firstDepth), "first edge must be root (delegation_depth 0)")
+	assert.Equal(t, 1, int(secondDepth), "second edge must be depth 1")
+	assert.Equal(t, rootJTI, first["jti"], "first edge JTI must match root credential")
+	assert.Equal(t, leafJTI, second["jti"], "second edge JTI must match leaf credential")
+	assert.Equal(t, rootJTI, second["parent_jti"],
+		"leaf's parent_jti must reference the root")
+}
+
+// TestDelegationByJTI_NotFound pins the 404 path. A valid UUID that does
+// not match any credential must 404, not 500 and not return an empty
+// chain with 200.
+func TestDelegationByJTI_NotFound(t *testing.T) {
+	resp := get(t, adminPath("/delegations/by-jti/00000000-0000-0000-0000-000000000000"), adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"unknown JTI must 404")
+}
+
+// TestDelegationByJTI_TenantIsolation pins that a JTI minted in tenant A
+// is not addressable from tenant B — the walk anchor is tenant-scoped.
+// This is the IDOR guard for forensic lookup.
+func TestDelegationByJTI_TenantIsolation(t *testing.T) {
+	tenantBHeaders := tenantHeaders(
+		"acct-byjti-iso-b-"+uid(""),
+		"proj-byjti-iso-b-"+uid(""),
+	)
+
+	policyID := delegationPolicy(t, uid("byjti-iso-policy"), []string{"data:read"})
+	_, rootJTI, _ := issueRootCredential(t, policyID, "byjti-iso-orch", []string{"data:read"})
+
+	resp := get(t,
+		adminPath("/delegations/by-jti/"+url.PathEscape(rootJTI)),
+		tenantBHeaders)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"tenant B must not resolve tenant A's JTI — 404 expected")
+}
+
+// TestDelegationChains_TimeWindow pins the happy path: issuing a
+// credential inside [since, until) produces at least one chain summary.
+func TestDelegationChains_TimeWindow(t *testing.T) {
+	policyID := delegationPolicy(t, uid("chains-policy"), []string{"data:read"})
+
+	before := time.Now().Add(-1 * time.Minute)
+	issueRootCredential(t, policyID, "chains-orch", []string{"data:read"})
+	after := time.Now().Add(1 * time.Minute)
+
+	q := "/delegations/chains" +
+		"?since=" + url.QueryEscape(before.Format(time.RFC3339)) +
+		"&until=" + url.QueryEscape(after.Format(time.RFC3339)) +
+		"&limit=100"
+	resp := get(t, adminPath(q), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decode(t, resp)
+	total, _ := body["total"].(float64)
+	assert.GreaterOrEqual(t, int(total), 1, "must include the chain we just issued")
+
+	chains, _ := body["chains"].([]any)
+	require.NotEmpty(t, chains)
+	first := chains[0].(map[string]any)
+	assert.NotEmpty(t, first["chain_id"])
+	assert.NotEmpty(t, first["started_at"])
+	assert.NotEmpty(t, first["last_activity_at"])
+}
+
+// TestDelegationChains_TimeWindowExcludesOutOfRange pins the exclusive
+// upper bound: a credential issued at time T with a window [T+10s, T+1m)
+// must NOT appear. Without this, a permissive time filter would let
+// callers see chains they shouldn't.
+//
+// Uses a fresh tenant so we don't have to disambiguate from other
+// tests' chains in the same window.
+func TestDelegationChains_TimeWindowExcludesOutOfRange(t *testing.T) {
+	headers := tenantHeaders(
+		"acct-chains-window-"+uid(""),
+		"proj-chains-window-"+uid(""),
+	)
+
+	// Issue one chain in this fresh tenant.
+	extID := uid("window-orch")
+	body := map[string]any{
+		"external_id":    extID,
+		"trust_level":    "unverified",
+		"owner_user_id":  "user-test-owner",
+		"allowed_scopes": []string{"data:read"},
+	}
+	idResp := post(t, adminPath("/identities"), body, headers)
+	require.Equal(t, http.StatusCreated, idResp.StatusCode)
+	_ = decode(t, idResp)
+
+	client := registerOAuthClient(t, extID, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    headers["X-Account-ID"],
+		"project_id":    headers["X-Project-ID"],
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	issuedAt := time.Now()
+
+	// Query a window that starts AFTER issuance — expect zero rows.
+	since := issuedAt.Add(10 * time.Second).Format(time.RFC3339)
+	until := issuedAt.Add(1 * time.Minute).Format(time.RFC3339)
+	q := "/delegations/chains" +
+		"?since=" + url.QueryEscape(since) +
+		"&until=" + url.QueryEscape(until) +
+		"&limit=100"
+	chainsResp := get(t, adminPath(q), headers)
+	require.Equal(t, http.StatusOK, chainsResp.StatusCode)
+	out := decode(t, chainsResp)
+	total, _ := out["total"].(float64)
+	assert.Equal(t, 0, int(total),
+		"chain issued before `since` must NOT appear in the response")
+}
+
+// TestDelegationChains_OrderingAndLimit pins two invariants together:
+//
+//   - Chains are returned ordered by last_activity_at DESC (newest first).
+//   - The `limit` query param actually caps the response size.
+//
+// Done in a fresh tenant so the response is exactly the chains we create.
+func TestDelegationChains_OrderingAndLimit(t *testing.T) {
+	headers := tenantHeaders(
+		"acct-chains-order-"+uid(""),
+		"proj-chains-order-"+uid(""),
+	)
+
+	// Issue two roots in this tenant, oldest first.
+	jtiOld := issueRootInTenant(t, headers, "order-old")
+	time.Sleep(20 * time.Millisecond)
+	jtiNew := issueRootInTenant(t, headers, "order-new")
+	require.NotEqual(t, jtiOld, jtiNew)
+
+	// Full list, ordered.
+	q := "/delegations/chains?limit=100"
+	full := decode(t, get(t, adminPath(q), headers))
+	chains, _ := full["chains"].([]any)
+	require.GreaterOrEqual(t, len(chains), 2)
+	firstID := chains[0].(map[string]any)["chain_id"].(string)
+	secondID := chains[1].(map[string]any)["chain_id"].(string)
+	assert.Equal(t, jtiNew, firstID,
+		"newest chain must sort first (ORDER BY last_activity_at DESC)")
+	assert.Equal(t, jtiOld, secondID, "older chain must sort second")
+
+	// Limit=1 returns only the newest.
+	one := decode(t, get(t, adminPath("/delegations/chains?limit=1"), headers))
+	oneChains, _ := one["chains"].([]any)
+	require.Len(t, oneChains, 1, "limit=1 must cap response at one chain")
+	assert.Equal(t, jtiNew, oneChains[0].(map[string]any)["chain_id"],
+		"limit=1 must return the newest, not the oldest")
+}
+
+// issueRootInTenant is a tenant-aware variant of issueRootCredential used
+// by the cross-tenant tests. Returns the root JTI which is also the
+// chain_id (= mission_id) for the resulting tree.
+func issueRootInTenant(t *testing.T, headers map[string]string, namePrefix string) string {
+	t.Helper()
+	extID := uid(namePrefix)
+	body := map[string]any{
+		"external_id":    extID,
+		"trust_level":    "unverified",
+		"owner_user_id":  "user-test-owner",
+		"allowed_scopes": []string{"data:read"},
+	}
+	idResp := post(t, adminPath("/identities"), body, headers)
+	require.Equal(t, http.StatusCreated, idResp.StatusCode)
+	_ = decode(t, idResp)
+
+	client := registerOAuthClient(t, extID, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    headers["X-Account-ID"],
+		"project_id":    headers["X-Project-ID"],
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return decodeJWTUnsafe(t, decode(t, resp)["access_token"].(string))["jti"].(string)
+}
+
+// TestDelegationChains_TenantIsolation pins the tenant filter on
+// /chains. A fresh tenant must see only its own chains — never another
+// tenant's, even within an overlapping time window.
+func TestDelegationChains_TenantIsolation(t *testing.T) {
+	tenantA := tenantHeaders(
+		"acct-chains-iso-a-"+uid(""),
+		"proj-chains-iso-a-"+uid(""),
+	)
+	tenantB := tenantHeaders(
+		"acct-chains-iso-b-"+uid(""),
+		"proj-chains-iso-b-"+uid(""),
+	)
+
+	jtiA := issueRootInTenant(t, tenantA, "iso-a")
+	jtiB := issueRootInTenant(t, tenantB, "iso-b")
+
+	listA := decode(t, get(t, adminPath("/delegations/chains?limit=100"), tenantA))
+	chainsA, _ := listA["chains"].([]any)
+	idsA := map[string]struct{}{}
+	for _, c := range chainsA {
+		idsA[c.(map[string]any)["chain_id"].(string)] = struct{}{}
+	}
+	assert.Contains(t, idsA, jtiA, "tenant A must see its own chain")
+	assert.NotContains(t, idsA, jtiB, "tenant A must NOT see tenant B's chain")
+
+	listB := decode(t, get(t, adminPath("/delegations/chains?limit=100"), tenantB))
+	chainsB, _ := listB["chains"].([]any)
+	idsB := map[string]struct{}{}
+	for _, c := range chainsB {
+		idsB[c.(map[string]any)["chain_id"].(string)] = struct{}{}
+	}
+	assert.Contains(t, idsB, jtiB, "tenant B must see its own chain")
+	assert.NotContains(t, idsB, jtiA, "tenant B must NOT see tenant A's chain")
+}
+
+// TestDelegationGraph_TenantIsolation pins the cross-tenant guard:
+// querying tenant A's identity ID with tenant B's headers returns an
+// empty graph (no nodes, no edges). The handler does not 500.
+func TestDelegationGraph_TenantIsolation(t *testing.T) {
+	tenantA := adminHeaders()
+	tenantB := tenantHeaders(
+		"acct-deleg-isolation-b-"+uid(""),
+		"proj-deleg-isolation-b-"+uid(""),
+	)
+
+	orchExtID := uid("isolation-orch")
+	orchID := registerIdentityWithPolicy(t, orchExtID, "", "",
+		[]string{"data:read"}, tenantA)
+	orchClient := registerOAuthClient(t, orchExtID, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     orchClient.ClientID,
+		"client_secret": orchClient.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	resp2 := get(t, adminPath("/delegations/graph?identity_id="+orchID), tenantB)
+	require.Equal(t, http.StatusOK, resp2.StatusCode,
+		"cross-tenant query must not 500 — empty graph is the documented contract")
+
+	body := decode(t, resp2)
+	nodes, _ := body["nodes"].([]any)
+	edges, _ := body["edges"].([]any)
+	assert.Empty(t, nodes, "tenant B must not see tenant A's identity in graph")
+	assert.Empty(t, edges, "tenant B must not see tenant A's edges in graph")
+}
+
+// TestDelegationGraph_MalformedIdentityID_Rejected pins the UUID pattern
+// validation on identity_id. Non-UUID values must be rejected by the
+// handler before reaching the service layer — a Postgres UUID parse
+// error here would otherwise produce a 500.
+func TestDelegationGraph_MalformedIdentityID_Rejected(t *testing.T) {
+	for _, bad := range []string{
+		"not-a-uuid",
+		"123",
+		"abc-def-ghi",
+		"00000000-0000-0000-0000-00000000000Z", // invalid hex char
+		"",                                      // empty string (required)
+	} {
+		path := adminPath("/delegations/graph?identity_id=" + bad + "&depth=2")
+		if bad == "" {
+			path = adminPath("/delegations/graph?identity_id=&depth=2")
+		}
+		resp := get(t, path, adminHeaders())
+		_ = resp.Body.Close()
+		assert.GreaterOrEqual(t, resp.StatusCode, 400,
+			"identity_id=%q must be rejected with 4xx", bad)
+		assert.Less(t, resp.StatusCode, 500,
+			"identity_id=%q must NOT 500 — must be caught before DB", bad)
+	}
+}
+
+// TestDelegationByJTI_MalformedJTI_Rejected pins the UUID pattern
+// validation on the {jti} path parameter. The jti column is varchar so
+// a non-UUID would not produce a DB error, but we still want 422 from
+// the handler rather than a silent 404 that hides a client mistake.
+func TestDelegationByJTI_MalformedJTI_Rejected(t *testing.T) {
+	for _, bad := range []string{
+		"not-a-uuid",
+		"123",
+		"../../../etc/passwd",
+		"00000000-0000-0000-0000-00000000000Z", // invalid hex char
+	} {
+		resp := get(t, adminPath("/delegations/by-jti/"+bad), adminHeaders())
+		_ = resp.Body.Close()
+		assert.GreaterOrEqual(t, resp.StatusCode, 400,
+			"jti=%q must be rejected with 4xx", bad)
+		assert.Less(t, resp.StatusCode, 500,
+			"jti=%q must NOT 500", bad)
+	}
+}
+
+// TestDelegationChains_InvalidParams_Rejected pins Huma validation on
+// the /chains query parameters: limit must be in [1,500] and since/until
+// must be valid RFC3339 timestamps.
+func TestDelegationChains_InvalidParams_Rejected(t *testing.T) {
+	// limit out of range
+	for _, bad := range []string{"0", "501", "-1", "99999"} {
+		resp := get(t, adminPath("/delegations/chains?limit="+bad), adminHeaders())
+		_ = resp.Body.Close()
+		assert.GreaterOrEqual(t, resp.StatusCode, 400,
+			"limit=%s must be rejected with 4xx", bad)
+		assert.Less(t, resp.StatusCode, 500,
+			"limit=%s must NOT 500", bad)
+	}
+
+	// malformed time params
+	for _, bad := range []string{
+		"since=yesterday",
+		"since=not-a-date",
+		"until=32-13-2099",
+	} {
+		resp := get(t, adminPath("/delegations/chains?"+bad), adminHeaders())
+		_ = resp.Body.Close()
+		assert.GreaterOrEqual(t, resp.StatusCode, 400,
+			"param %s must be rejected with 4xx", bad)
+		assert.Less(t, resp.StatusCode, 500,
+			"param %s must NOT 500", bad)
+	}
+}

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -784,43 +784,6 @@ func TestDelegationGraph_BranchedMissionIsolation(t *testing.T) {
 		"B2 is a sibling branch under the same mission as B1; must NOT appear in B1's graph")
 }
 
-// TestDelegationGraph_LegacyNullMissionID pins the legacy-row fallback:
-// credentials with mission_id = NULL (issued before migration 022) must
-// still walk correctly. This is the reason the new recursive predicate
-// uses `IS NOT DISTINCT FROM` instead of `=` — `NULL = NULL` is falsy in
-// SQL and would silently terminate the recursion on the first step for
-// any pre-migration anchor.
-//
-// Setup: build a normal A → B chain via OAuth, then UPDATE both rows to
-// NULL mission_id to simulate the pre-migration state. Walk from B and
-// confirm A is still reachable. Passes against both pre-change code
-// (no mission filter at all) and post-change code (NULL IS NOT DISTINCT
-// FROM NULL is TRUE, recursion proceeds).
-func TestDelegationGraph_LegacyNullMissionID(t *testing.T) {
-	policyID := delegationPolicy(t, uid("legacy-null-policy"), []string{"data:read"})
-
-	orchID, orchJTI, orchTok := issueRootCredential(t, policyID, "legacy-null-orch",
-		[]string{"data:read"})
-	bID, bJTI, _ := exchangeToken(t, policyID, "legacy-null-b",
-		[]string{"data:read"}, []string{"data:read"}, orchTok)
-
-	ctx := context.Background()
-	_, err := testDB.NewUpdate().
-		Table("issued_credentials").
-		Set("mission_id = NULL").
-		Where("jti IN (?, ?)", orchJTI, bJTI).
-		Exec(ctx)
-	require.NoError(t, err, "simulate pre-migration NULL mission_id")
-
-	resp := get(t, adminPath("/delegations/graph?identity_id="+bID+"&depth=2"), adminHeaders())
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	body := decode(t, resp)
-
-	ids := nodeIDs(body)
-	assert.Contains(t, ids, bID, "B (focal) must appear in its own graph")
-	assert.Contains(t, ids, orchID,
-		"legacy NULL-mission anchor must still walk to its parent via parent_jti — IS NOT DISTINCT FROM lets NULL chains through")
-}
 
 // TestDelegationGraph_CrossMissionBoundary is the test that drives the
 // SQL change. It pins that the new recursive-step predicate prunes the

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -784,7 +784,6 @@ func TestDelegationGraph_BranchedMissionIsolation(t *testing.T) {
 		"B2 is a sibling branch under the same mission as B1; must NOT appear in B1's graph")
 }
 
-
 // TestDelegationGraph_CrossMissionBoundary is the test that drives the
 // SQL change. It pins that the new recursive-step predicate prunes the
 // walker at a mission boundary: a credential linked by parent_jti to a


### PR DESCRIPTION
Adds three read-only admin endpoints that expose the delegation graph stored in issued_credentials:

- GET /api/v1/delegations/graph?identity_id=&depth= Depth-bounded subgraph centered on an identity's most recent credential. Walks parent_jti up and down via recursive CTEs. Returns nodes + edges with scopes_in/scopes_out/attenuated per edge.

- GET /api/v1/delegations/by-jti/{jti} Forensic lineage walk from any credential up to its root. Ordered root → leaf; useful for token provenance audits.

- GET /api/v1/delegations/chains?since=&until=&limit= One summary row per delegation tree, ordered by last_activity DESC. Groups by mission_id, falling back to root JTI for legacy credentials.

New files: internal/store/postgres/delegation.go (WalkUp/WalkDown/ ListChains via recursive CTEs with CYCLE clause), internal/service/ delegation.go (scope attenuation, graph assembly, MaxGraphDepth=10/ MaxGraphNodes=500), internal/handler/delegation.go (Huma v2 ops with UUID pattern validation on identity_id and jti params).

Modified: identity.go adds GetByIDs batch lookup; routes.go and server.go wire the new service; README adds API reference entries and Roadmap release note.

18 integration tests cover subgraph semantics, depth bounding, scope attenuation, revocation visibility, most-recent-credential selection, tenant isolation, and malformed-input rejection on all three endpoints.

## Summary

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

---

## Testing
- [ ] Manually tested
- [X] Unit tests added/updated
- [ ] No tests required

---

## Impact / Risks
New surface area (read-only):
  - 3 new admin endpoints under /api/v1/delegations/ — no existing endpoint signatures changed, fully backwards compatible
  - New DelegationService, DelegationRepository, and GetByIDs batch method on IdentityRepository
---

## 📸 Screenshots / Logs (if applicable)

---

