### PR TITLE
feat: GET /v1/auth/identities/by-wimse — resolve identity by WIMSE/SPIFFE URI

### DIFF
--- a/docs/dpop-and-dcr.md
+++ b/docs/dpop-and-dcr.md
@@ -157,6 +157,19 @@ OAuth clients are normally provisioned by an admin via a console. That works whe
 
 RFC 7591 defines a standard registration endpoint; RFC 7592 defines the per-client management endpoints that follow it.
 
+### Choosing between agent identity registration and OAuth DCR
+
+ZeroID has two registration paths; the right one depends on what you're registering.
+
+| Use case | Endpoint | Auth shape |
+|---|---|---|
+| **Agent identity** participating in delegation chains (`token_exchange`, multi-hop `jwt-bearer`) | `POST /api/v1/agents/register` with `public_key_pem` | Keypair owned by the agent; public PEM uploaded to the broker at registration. Self-signed JWT assertions verify against the stored key. |
+| **Confidential OAuth client** — vendor MCP server, installer bootstrap, single-hop tool — that does not participate in delegation chains | `POST /oauth2/register` (this doc) with `client_secret_basic` / `client_secret_post`, optionally inline `jwks` for jwt-bearer assertions | Client secret minted at registration; assertion-signing keys (if used) held at the broker. |
+
+The split is deliberate. DCR-registered clients are **explicitly blocked from `token_exchange`** (enforced at the grant-type allow-list — see "What ZeroID enforces" below) because they have no `IdentityID` binding and cannot legitimately act as a delegation actor. Agents that need to participate in chains must register through the agent identity path. See the [agent registration walkthrough in the README](../README.md#1-register-an-agent) for that side of the API.
+
+**Both paths hold public keys at the broker, not behind the agent.** `public_key_pem` (agent path) and inline `jwks` (DCR path) are the recommended shapes. `jwks_uri` (broker fetches keys from a URL the client publishes) is accepted for RFC 7591 spec compliance, but it requires every registered client to operate an internet-reachable HTTPS endpoint solely for key publication — and is not the recommended pattern for self-hosted ZeroID deployments. Broker-held keys remove an entire class of operational concerns (tunneling, NAT, certificate provisioning for client hosts) and limit internet-exposed surface area to ZeroID itself.
+
 ### Wire shape
 
 #### 1. Mint an initial access token (one-time, per registrant)
@@ -223,6 +236,63 @@ curl -X DELETE https://auth.example/oauth2/register/9f43b1c2 \
 ```
 
 GET and PUT responses re-include the public client metadata but **never** re-reveal `client_secret` or `registration_access_token`.
+
+#### 4. Register a client that signs JWT assertions (jwt-bearer grant, inline `jwks`)
+
+For clients that will use the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant — typically a service-account-style integration whose downstream calls are authorized by a signed JWT assertion — register an inline JWKS at registration time so the broker can verify those assertions:
+
+```bash
+# 1. Generate a P-256 keypair locally (one-time per client).
+openssl ecparam -name prime256v1 -genkey -noout -out client-private.pem
+openssl ec -in client-private.pem -pubout -out client-public.pem
+
+# 2. Convert client-public.pem into JWK form (kty/crv/x/y). Any small helper
+#    works — Python's `cryptography` + `python-jose`, Go's `lestrrat-go/jwx`,
+#    or the `mkjwk` CLI. The shape below assumes you've already produced it.
+
+# 3. Register, embedding the JWK inline.
+curl -s -X POST https://auth.example/oauth2/register \
+  -H "Authorization: Bearer $IAT" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "client_name": "Acme Notebook MCP",
+        "grant_types": [
+          "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          "client_credentials"
+        ],
+        "scope": "notebook:read notebook:write",
+        "token_endpoint_auth_method": "client_secret_basic",
+        "jwks": {
+          "keys": [{
+            "kty": "EC",
+            "crv": "P-256",
+            "use": "sig",
+            "alg": "ES256",
+            "kid": "client-key-1",
+            "x":   "<base64url of public x coordinate>",
+            "y":   "<base64url of public y coordinate>"
+          }]
+        },
+        "software_id":      "com.acme.notebook",
+        "software_version": "2.4.0"
+      }'
+```
+
+When this client later presents a jwt-bearer grant:
+
+```bash
+curl -s -X POST https://auth.example/oauth2/token \
+  -u "<client_id>:<client_secret>" \
+  -d 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer' \
+  -d 'assertion=<JWT signed by client-key-1>' \
+  -d 'scope=notebook:read'
+```
+
+…the client authenticates **to the token endpoint** with HTTP Basic (its `client_secret`), and the `assertion` JWT is verified against the JWKS uploaded at registration. The two checks are independent: `token_endpoint_auth_method` governs how the client identifies itself to the endpoint; the `jwks` governs how its assertion signature is verified.
+
+**Why inline `jwks` rather than `jwks_uri`**: RFC 7591 §2 accepts both. Inline `jwks` uploads the keys to the broker once at registration time, the broker stores them, and verification is local. `jwks_uri` requires the broker to fetch keys from a URL the client publishes, which means the client must run an internet-reachable HTTPS endpoint solely for key publication — workable when client and broker live in different security domains, but unnecessary friction for self-hosted ZeroID deployments. For key rotation, use an RFC 7592 `PUT` to swap the inline JWKS (single round-trip, no DNS or TLS dependency).
+
+> **`private_key_jwt` is not currently accepted** as `token_endpoint_auth_method` for DCR-registered clients (see "What ZeroID enforces" below). DCR clients authenticate to the token endpoint with their client secret; the jwt-bearer **grant** is the path where signed assertions and JWKS come into play.
 
 ### What ZeroID enforces
 

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -502,8 +502,15 @@ var ErrInvalidWIMSEURI = errors.New("invalid wimse uri")
 // Rules (SPIFFE §2):
 //   - scheme is "spiffe"
 //   - non-empty host (the trust domain)
-//   - non-empty path
-//   - no query, no fragment, no user-info
+//   - host must not include a port
+//   - non-empty workload path (a bare trust-domain URI is the trust-domain ID,
+//     not a workload ID — reject)
+//   - path must not have a trailing slash or empty segments
+//   - path segments must conform to SPIFFE §2.3 character set (delegated to
+//     ValidateSPIFFEPathSegment so the read-side validator agrees with
+//     BuildWIMSEURI on what's a legal segment)
+//   - no query (including a trailing "?" with empty value), no fragment, no
+//     user-info
 //   - total length within MaxSPIFFEIDBytes
 //
 // Returns a wrapped ErrInvalidWIMSEURI on failure.
@@ -529,16 +536,37 @@ func ValidateWIMSEURI(uri string) error {
 	if u.Host == "" {
 		return fmt.Errorf("%w: missing trust domain (host)", ErrInvalidWIMSEURI)
 	}
+	// SPIFFE §2.2: the trust domain is a DNS name without a port.
+	// url.Host carries the host[:port] form; reject any colon to forbid ports.
+	if strings.Contains(u.Host, ":") {
+		return fmt.Errorf("%w: trust domain must not contain a port", ErrInvalidWIMSEURI)
+	}
 	if u.User != nil {
 		return fmt.Errorf("%w: user-info not allowed", ErrInvalidWIMSEURI)
 	}
-	if u.RawQuery != "" || u.Fragment != "" {
+	// ForceQuery catches a trailing "?" even when RawQuery is empty.
+	if u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
 		return fmt.Errorf("%w: query/fragment not allowed", ErrInvalidWIMSEURI)
 	}
 	// SPIFFE IDs always have a workload path. A bare trust-domain URI like
 	// "spiffe://example.org" is a trust domain identifier, not a workload ID.
 	if u.Path == "" || u.Path == "/" {
 		return fmt.Errorf("%w: missing workload path", ErrInvalidWIMSEURI)
+	}
+	if strings.HasSuffix(u.Path, "/") {
+		return fmt.Errorf("%w: path must not end with a slash", ErrInvalidWIMSEURI)
+	}
+	if strings.Contains(u.Path, "//") {
+		return fmt.Errorf("%w: path must not contain empty segments", ErrInvalidWIMSEURI)
+	}
+	// Validate each path segment against the same character set BuildWIMSEURI
+	// enforces. The read-side validator must agree with the write-side
+	// constructor on what's legal — otherwise a stored URI could fail
+	// validation on lookup.
+	for _, seg := range strings.Split(strings.TrimPrefix(u.Path, "/"), "/") {
+		if err := ValidateSPIFFEPathSegment("path segment", seg); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidWIMSEURI, err)
+		}
 	}
 	return nil
 }

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/uptrace/bun"
@@ -482,6 +484,61 @@ func ValidateSPIFFEPathSegment(field, value string) error {
 		default:
 			return fmt.Errorf("%s contains character %q not allowed in a SPIFFE path segment (allowed: a-z A-Z 0-9 . - _)", field, r)
 		}
+	}
+	return nil
+}
+
+// ErrInvalidWIMSEURI is returned by ValidateWIMSEURI when the caller-supplied
+// URI cannot be a SPIFFE ID. Callers branch on this with errors.Is to map to
+// a 400 at the HTTP boundary.
+var ErrInvalidWIMSEURI = errors.New("invalid wimse uri")
+
+// ValidateWIMSEURI checks the shape of a caller-supplied WIMSE/SPIFFE URI
+// without binding it to a specific trust domain. Used by lookup endpoints
+// (e.g. GET /identities/by-wimse) that need to reject obviously malformed
+// input before hitting the store, but cannot reject by trust-domain because
+// the caller's tenant determines which trust domain is in play.
+//
+// Rules (SPIFFE §2):
+//   - scheme is "spiffe"
+//   - non-empty host (the trust domain)
+//   - non-empty path
+//   - no query, no fragment, no user-info
+//   - total length within MaxSPIFFEIDBytes
+//
+// Returns a wrapped ErrInvalidWIMSEURI on failure.
+func ValidateWIMSEURI(uri string) error {
+	if uri == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidWIMSEURI)
+	}
+	if len(uri) > MaxSPIFFEIDBytes {
+		return fmt.Errorf("%w: exceeds %d bytes", ErrInvalidWIMSEURI, MaxSPIFFEIDBytes)
+	}
+	// Reject obvious scheme mismatches before url.Parse so the error reason
+	// is more useful than "missing scheme".
+	if !strings.HasPrefix(uri, "spiffe://") {
+		return fmt.Errorf("%w: scheme must be spiffe://", ErrInvalidWIMSEURI)
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidWIMSEURI, err)
+	}
+	if u.Scheme != "spiffe" {
+		return fmt.Errorf("%w: scheme must be spiffe (got %q)", ErrInvalidWIMSEURI, u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%w: missing trust domain (host)", ErrInvalidWIMSEURI)
+	}
+	if u.User != nil {
+		return fmt.Errorf("%w: user-info not allowed", ErrInvalidWIMSEURI)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("%w: query/fragment not allowed", ErrInvalidWIMSEURI)
+	}
+	// SPIFFE IDs always have a workload path. A bare trust-domain URI like
+	// "spiffe://example.org" is a trust domain identifier, not a workload ID.
+	if u.Path == "" || u.Path == "/" {
+		return fmt.Errorf("%w: missing workload path", ErrInvalidWIMSEURI)
 	}
 	return nil
 }

--- a/domain/identity_test.go
+++ b/domain/identity_test.go
@@ -6,6 +6,47 @@ import (
 	"testing"
 )
 
+// TestValidateWIMSEURI pins the shape contract used by /identities/by-wimse:
+// only well-formed spiffe:// URIs with a trust domain and a workload path
+// pass. Anything else returns a wrapped ErrInvalidWIMSEURI so handlers can
+// errors.Is and map to 400.
+func TestValidateWIMSEURI(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		if err := ValidateWIMSEURI("spiffe://highflame.dev/acct/proj/agent/my-agent"); err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("rejection cases", func(t *testing.T) {
+		cases := []struct {
+			name string
+			uri  string
+		}{
+			{"empty", ""},
+			{"missing scheme", "highflame.dev/acct/proj/agent/x"},
+			{"wrong scheme", "https://highflame.dev/acct/proj/agent/x"},
+			{"missing host", "spiffe:///acct/proj/agent/x"},
+			{"bare trust domain", "spiffe://highflame.dev"},
+			{"trust domain with empty path", "spiffe://highflame.dev/"},
+			{"with query", "spiffe://highflame.dev/acct/proj/agent/x?foo=bar"},
+			{"with fragment", "spiffe://highflame.dev/acct/proj/agent/x#frag"},
+			{"with user-info", "spiffe://user:pass@highflame.dev/acct/proj/agent/x"},
+			{"too long", "spiffe://highflame.dev/" + strings.Repeat("a", MaxSPIFFEIDBytes)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := ValidateWIMSEURI(tc.uri)
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tc.uri)
+				}
+				if !errors.Is(err, ErrInvalidWIMSEURI) {
+					t.Fatalf("error not wrapped with ErrInvalidWIMSEURI: %v", err)
+				}
+			})
+		}
+	})
+}
+
 // TestBuildWIMSEURI_LengthCap pins the SPIFFE §2.4 invariant: any URI that
 // would exceed MaxSPIFFEIDBytes is rejected at construction time, returning
 // ErrSPIFFEIDTooLong so callers can errors.Is. Three cases — happy path, the

--- a/domain/identity_test.go
+++ b/domain/identity_test.go
@@ -29,8 +29,14 @@ func TestValidateWIMSEURI(t *testing.T) {
 			{"bare trust domain", "spiffe://highflame.dev"},
 			{"trust domain with empty path", "spiffe://highflame.dev/"},
 			{"with query", "spiffe://highflame.dev/acct/proj/agent/x?foo=bar"},
+			{"with trailing question mark", "spiffe://highflame.dev/acct/proj/agent/x?"},
 			{"with fragment", "spiffe://highflame.dev/acct/proj/agent/x#frag"},
 			{"with user-info", "spiffe://user:pass@highflame.dev/acct/proj/agent/x"},
+			{"trust domain with port", "spiffe://highflame.dev:443/acct/proj/agent/x"},
+			{"path with trailing slash", "spiffe://highflame.dev/acct/proj/agent/x/"},
+			{"path with empty segment", "spiffe://highflame.dev/acct//agent/x"},
+			{"path segment with space", "spiffe://highflame.dev/acct/proj/agent/my agent"},
+			{"path segment with special char", "spiffe://highflame.dev/acct/proj/agent/my$agent"},
 			{"too long", "spiffe://highflame.dev/" + strings.Repeat("a", MaxSPIFFEIDBytes)},
 		}
 		for _, tc := range cases {

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -54,6 +54,15 @@ type IdentityIDInput struct {
 	ID string `path:"id" doc:"Identity UUID"`
 }
 
+// GetIdentityByWIMSEInput is the query for GET /identities/by-wimse.
+// The URI is supplied as a query param (rather than a path segment) because
+// SPIFFE URIs contain slashes that would conflict with route segmentation
+// and the trust-domain host that wouldn't survive path encoding without
+// loss-of-fidelity surprises.
+type GetIdentityByWIMSEInput struct {
+	URI string `query:"uri" required:"true" doc:"WIMSE/SPIFFE URI to resolve (e.g. spiffe://highflame.io/acme/prod/agent/claude-bot)"`
+}
+
 type ListIdentitiesInput struct {
 	IdentityType []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
 	Label        string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
@@ -127,6 +136,19 @@ func (a *API) registerIdentityRoutes(api huma.API) {
 		Tags:          []string{"Identities"},
 		DefaultStatus: http.StatusCreated,
 	}, a.createIdentityOp)
+
+	// Registered before /identities/{id} so the literal `by-wimse` segment
+	// is matched before falling into the {id} wildcard. chi handles this
+	// fine in either order, but keeping the literal first makes the
+	// precedence obvious from the registration order.
+	huma.Register(api, huma.Operation{
+		OperationID: "get-identity-by-wimse",
+		Method:      http.MethodGet,
+		Path:        "/identities/by-wimse",
+		Summary:     "Resolve an identity by its WIMSE/SPIFFE URI",
+		Description: "Lookup endpoint used by downstream gateways to verify a JWT's sub claim still resolves to an active identity row in the caller's tenant before forwarding the request.",
+		Tags:        []string{"Identities"},
+	}, a.getIdentityByWIMSEOp)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "get-identity",
@@ -247,6 +269,46 @@ func (a *API) getIdentityOp(ctx context.Context, input *IdentityIDInput) (*Ident
 	identity, err := a.identitySvc.GetIdentity(ctx, input.ID, tenant.AccountID, tenant.ProjectID)
 	if err != nil {
 		return nil, huma.Error404NotFound("identity not found")
+	}
+
+	return &IdentityOutput{Body: identity}, nil
+}
+
+// getIdentityByWIMSEOp resolves an identity by its WIMSE/SPIFFE URI within
+// the caller's tenant. Used by downstream gateways (firehog) to gate
+// forwarding on identity status — a signature-valid, unexpired JWT for a
+// deactivated identity must still be rejected, and only the identity row
+// carries that signal.
+//
+// On 400 / 404 the body follows huma's RFC 9457 ProblemDetails shape with
+// the failure code in `detail` ("invalid_wimse_uri" / "identity_not_found")
+// and the offending URI echoed back in `errors[0].value` so callers can log
+// it without round-tripping the query string.
+func (a *API) getIdentityByWIMSEOp(ctx context.Context, input *GetIdentityByWIMSEInput) (*IdentityOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	if vErr := domain.ValidateWIMSEURI(input.URI); vErr != nil {
+		return nil, huma.Error400BadRequest("invalid_wimse_uri", &huma.ErrorDetail{
+			Message:  vErr.Error(),
+			Location: "query.uri",
+			Value:    input.URI,
+		})
+	}
+
+	identity, err := a.identitySvc.GetIdentityByWIMSEURI(ctx, input.URI, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		if errors.Is(err, service.ErrIdentityNotFound) {
+			return nil, huma.Error404NotFound("identity_not_found", &huma.ErrorDetail{
+				Message:  "no identity matches the supplied WIMSE URI in this tenant",
+				Location: "query.uri",
+				Value:    input.URI,
+			})
+		}
+		log.Error().Err(err).Str("wimse_uri", input.URI).Msg("failed to resolve identity by wimse uri")
+		return nil, huma.Error500InternalServerError("failed to resolve identity")
 	}
 
 	return &IdentityOutput{Body: identity}, nil

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
+	"database/sql"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -24,6 +25,12 @@ var ErrIdentityAlreadyExists = errors.New("identity already exists")
 // ErrInvalidIdentityField marks caller-fixable input errors on registration
 // (currently the SPIFFE path-segment check). Maps to 400 at the HTTP boundary.
 var ErrInvalidIdentityField = errors.New("invalid identity field")
+
+// ErrIdentityNotFound is returned by lookup methods when no identity matches
+// the supplied selector within the caller's tenant. Wraps sql.ErrNoRows from
+// the store layer so handlers can errors.Is and map to 404 without coupling
+// to the database driver.
+var ErrIdentityNotFound = errors.New("identity not found")
 
 // IdentityService handles identity lifecycle operations.
 type IdentityService struct {
@@ -252,6 +259,26 @@ func (s *IdentityService) GetIdentity(ctx context.Context, id, accountID, projec
 // GetIdentityByExternalID retrieves an identity by its external_id within a tenant.
 func (s *IdentityService) GetIdentityByExternalID(ctx context.Context, externalID, accountID, projectID string) (*domain.Identity, error) {
 	return s.repo.GetByExternalID(ctx, externalID, accountID, projectID)
+}
+
+// GetIdentityByWIMSEURI resolves an identity by its WIMSE/SPIFFE URI within a
+// tenant. Used by the /identities/by-wimse lookup endpoint that downstream
+// gateways (firehog) hit to confirm a JWT's sub claim still resolves to an
+// active identity row before forwarding the request.
+//
+// Tenant isolation is enforced at the store layer: the same URI in a
+// different tenant returns ErrIdentityNotFound, not the other tenant's row.
+// A sql.ErrNoRows from the store is normalised to ErrIdentityNotFound so the
+// handler stays decoupled from the database driver.
+func (s *IdentityService) GetIdentityByWIMSEURI(ctx context.Context, wimseURI, accountID, projectID string) (*domain.Identity, error) {
+	identity, err := s.repo.GetByWIMSEURI(ctx, wimseURI, accountID, projectID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrIdentityNotFound
+		}
+		return nil, err
+	}
+	return identity, nil
 }
 
 // ListIdentities returns identities for a tenant, optionally filtered by identity_type(s) and label.

--- a/tests/integration/identity_by_wimse_test.go
+++ b/tests/integration/identity_by_wimse_test.go
@@ -1,0 +1,123 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// byWIMSEPath builds GET /api/v1/identities/by-wimse?uri=<wimseURI> with the
+// URI query-encoded. Test callers MUST go through this rather than string-
+// concatenation so the `/` characters inside the SPIFFE path don't accidentally
+// land as extra path segments.
+func byWIMSEPath(wimseURI string) string {
+	q := url.Values{}
+	q.Set("uri", wimseURI)
+	return adminPath("/identities/by-wimse") + "?" + q.Encode()
+}
+
+// TestGetIdentityByWIMSE_Found verifies the happy path: a freshly registered
+// identity is resolvable by its WIMSE URI and the response payload matches the
+// identity returned at registration time.
+func TestGetIdentityByWIMSE_Found(t *testing.T) {
+	externalID := uid("by-wimse-found")
+	identity := registerIdentity(t, externalID, []string{"billing:read"})
+
+	resp := get(t, byWIMSEPath(identity.WIMSEURI), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 for known WIMSE URI")
+
+	body := decode(t, resp)
+	assert.Equal(t, identity.ID, body["id"])
+	assert.Equal(t, identity.WIMSEURI, body["wimse_uri"])
+	assert.Equal(t, externalID, body["external_id"])
+	assert.Equal(t, testAccountID, body["account_id"])
+	assert.Equal(t, testProjectID, body["project_id"])
+	// status must round-trip — this is the field firehog gates on.
+	assert.Equal(t, "active", body["status"])
+}
+
+// TestGetIdentityByWIMSE_TenantScoping verifies cross-tenant isolation:
+// an identity created in tenant A is NOT visible to a caller presenting
+// tenant B's headers, even with the exact WIMSE URI. Returns 404, not 403
+// (existence disclosure) and not 200.
+func TestGetIdentityByWIMSE_TenantScoping(t *testing.T) {
+	// Tenant A is the default test tenant (testAccountID / testProjectID).
+	externalID := uid("by-wimse-iso")
+	identity := registerIdentity(t, externalID, []string{"billing:read"})
+
+	// Tenant B: a fresh isolated tenant.
+	tenantB := tenantHeaders("acct-by-wimse-b-"+uid(""), "proj-by-wimse-b-"+uid(""))
+
+	resp := get(t, byWIMSEPath(identity.WIMSEURI), tenantB)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"cross-tenant lookup must return 404, not 200 (leak) or 403 (existence disclosure)")
+	_ = resp.Body.Close()
+}
+
+// TestGetIdentityByWIMSE_NotFound verifies that a well-formed URI with no
+// matching identity returns 404 with the structured error contract.
+func TestGetIdentityByWIMSE_NotFound(t *testing.T) {
+	wimse := "spiffe://" + testWIMSE + "/" + testAccountID + "/" + testProjectID + "/agent/does-not-exist-" + uid("")
+	resp := get(t, byWIMSEPath(wimse), adminHeaders())
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	body := decode(t, resp)
+	// huma RFC 9457 problem-details: detail carries the failure code.
+	assert.Equal(t, "identity_not_found", body["detail"])
+	// errors[0].value echoes the offending URI for callers that log it.
+	if errs, ok := body["errors"].([]any); ok && len(errs) > 0 {
+		first := errs[0].(map[string]any)
+		assert.Equal(t, wimse, first["value"])
+		assert.Equal(t, "query.uri", first["location"])
+	} else {
+		t.Fatalf("expected errors[0] payload, got %v", body)
+	}
+}
+
+// TestGetIdentityByWIMSE_InvalidURI exercises the shape validator: anything
+// that isn't a valid spiffe:// URI returns 400 with the invalid_wimse_uri
+// error code, before the store is touched.
+func TestGetIdentityByWIMSE_InvalidURI(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  string
+	}{
+		{"not_a_uri", "not-a-uri"},
+		{"missing_scheme", testWIMSE + "/" + testAccountID + "/" + testProjectID + "/agent/x"},
+		{"wrong_scheme", "https://" + testWIMSE + "/" + testAccountID + "/" + testProjectID + "/agent/x"},
+		{"missing_path", "spiffe://" + testWIMSE},
+		{"trailing_slash_only", "spiffe://" + testWIMSE + "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := get(t, byWIMSEPath(tc.uri), adminHeaders())
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+				"expected 400 for %q, got %d", tc.uri, resp.StatusCode)
+			body := decode(t, resp)
+			assert.Equal(t, "invalid_wimse_uri", body["detail"])
+			if errs, ok := body["errors"].([]any); ok && len(errs) > 0 {
+				first := errs[0].(map[string]any)
+				assert.Equal(t, tc.uri, first["value"])
+				assert.Equal(t, "query.uri", first["location"])
+			} else {
+				t.Fatalf("expected errors[0] payload, got %v", body)
+			}
+		})
+	}
+}
+
+// TestGetIdentityByWIMSE_AuthRequired verifies that omitting the tenant
+// headers (X-Account-ID / X-Project-ID) returns 401, mirroring every other
+// tenant-scoped admin endpoint. This is the same "missing tenant context"
+// gate used by GET /identities/{id} and friends.
+func TestGetIdentityByWIMSE_AuthRequired(t *testing.T) {
+	wimse := "spiffe://" + testWIMSE + "/" + testAccountID + "/" + testProjectID + "/agent/any"
+	// No headers — tenant context will be absent.
+	resp := get(t, byWIMSEPath(wimse), nil)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"missing tenant headers must yield 401, got %d", resp.StatusCode)
+	_ = resp.Body.Close()
+}


### PR DESCRIPTION
## Summary
- New endpoint: `GET /v1/auth/identities/by-wimse?uri=...` resolves a workload identity by its WIMSE/SPIFFE URI within the caller's tenant
- Service: wraps the existing `IdentityRepository.GetByWIMSEURI` store method
- Tenant-scoped — same auth + tenant-resolution pattern as every other `/identities/*` route

GW calls this on first contact with an ES256 NHI token to confirm the identity row is still active before forwarding the request. Catches deactivated identities even when the JWT signature is still valid.

Shape validation lives at `domain.ValidateWIMSEURI` (scheme=spiffe, host present, workload path present, no query/fragment/user-info, length <= MaxSPIFFEIDBytes). Pairs with the existing `ValidateSPIFFEPathSegment` + 2048-byte length cap.

Wire-shape contract (RFC 9457 problem-details for errors):
- 200: standard `domain.Identity` JSON payload
- 400: `detail: "invalid_wimse_uri"`, `errors[0].value` echoes the offending uri
- 404: `detail: "identity_not_found"`, same shape
- 401: missing tenant context (mirrors every other tenant-scoped admin route)

## Test plan
- [x] go vet / go build clean
- [x] go test ./... clean (full suite)
- [x] Tests added: found / tenant-scoped / not-found / invalid-URI / auth-required
- [x] Unit test on `ValidateWIMSEURI` for happy path + 10 rejection cases