### PR TITLE
fix: wrap ExternalPrincipalExchange application_id-not-found as *OAuthError

### DIFF
--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -620,7 +620,12 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 	if req.ApplicationID != "" {
 		resolved, err := s.identitySvc.GetIdentity(ctx, req.ApplicationID, req.AccountID, req.ProjectID)
 		if err != nil {
-			return nil, fmt.Errorf("invalid_request: application_id %s not found or access denied", req.ApplicationID)
+			// Previously wrapped via plain fmt.Errorf which extractOAuthError
+			// doesn't match against *OAuthError — the token endpoint emitted
+			// server_error (500) instead of the intended invalid_request (400).
+			// Use oauthBadRequestCause so the OAuth wire shape is correct AND
+			// the wrapped err remains accessible via errors.Unwrap for logs.
+			return nil, oauthBadRequestCause("invalid_request", fmt.Sprintf("application_id %s not found or access denied", req.ApplicationID), err)
 		}
 		if !resolved.Status.IsUsable() {
 			return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/sha256"
 	"crypto/x509"
+	"database/sql"
 	"encoding/hex"
 	"encoding/pem"
 	"errors"
@@ -621,12 +622,30 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 	if req.ApplicationID != "" {
 		resolved, err := s.identitySvc.GetIdentity(ctx, req.ApplicationID, req.AccountID, req.ProjectID)
 		if err != nil {
-			// Previously wrapped via plain fmt.Errorf which extractOAuthError
-			// doesn't match against *OAuthError — the token endpoint emitted
-			// server_error (500) instead of the intended invalid_request (400).
-			// Use oauthBadRequestCause so the OAuth wire shape is correct AND
-			// the wrapped err remains accessible via errors.Unwrap for logs.
-			return nil, oauthBadRequestCause("invalid_request", fmt.Sprintf("application_id %s not found or access denied", req.ApplicationID), err)
+			// Distinguish "row not found / wrong tenant" (client error,
+			// 400 invalid_request) from transient infrastructure failures
+			// (server error, 500 — retriable by the client). The bun
+			// repository wraps sql.ErrNoRows for "no row matches id +
+			// account_id + project_id" — that covers both genuine-missing
+			// and IDOR-protected cross-tenant lookups. Anything else is
+			// an infra problem (DB unreachable, query timeout, etc.) the
+			// client can't act on; 500 with the cause preserved for logs
+			// lets the client retry instead of getting a misleading 400.
+			//
+			// Previously this branch used plain fmt.Errorf, which
+			// extractOAuthError didn't match as *OAuthError — every
+			// failure ended up as a 500 server_error regardless of cause.
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, oauthBadRequestCause(
+					oautherror.InvalidRequest,
+					fmt.Sprintf("application_id %s not found or access denied", req.ApplicationID),
+					err,
+				)
+			}
+			return nil, oauthServerError(
+				fmt.Sprintf("failed to look up application_id %s", req.ApplicationID),
+				err,
+			)
 		}
 		if !resolved.Status.IsUsable() {
 			return nil, oauthBadRequest(oautherror.InvalidGrant, "identity is suspended or deactivated")


### PR DESCRIPTION
## Summary

`ExternalPrincipalExchange` (the external-principal path of the `token_exchange` grant, when `actor_token` is empty) had two bugs at `internal/service/oauth.go:621-630`:

1. **Wire-shape bug** (the one originally fixed): a plain `fmt.Errorf("invalid_request: ...")` falls through `extractOAuthError`'s `errors.As(*OAuthError)` check and emits 500 `server_error` instead of the intended 400 `invalid_request`.
2. **Error-classification bug** (caught during PR-169's own review by Copilot): all `GetIdentity` failures were lumped into the same 400 message, including transient infrastructure errors (DB unreachable, query timeout, etc.) that should be 500-retriable.

## Final shape (after Copilot review fixes — commit `483816e`)

```go
resolved, err := s.identitySvc.GetIdentity(ctx, req.ApplicationID, req.AccountID, req.ProjectID)
if err != nil {
    // Distinguish "row not found / wrong tenant" (client error, 400
    // invalid_request) from transient infrastructure failures (server
    // error, 500 — retriable by the client). The bun repository wraps
    // sql.ErrNoRows for "no row matches id + account_id + project_id" —
    // that covers both genuine-missing and IDOR-protected cross-tenant
    // lookups. Anything else is an infra problem the client can't act on.
    if errors.Is(err, sql.ErrNoRows) {
        return nil, oauthBadRequestCause(
            oautherror.InvalidRequest,
            fmt.Sprintf("application_id %s not found or access denied", req.ApplicationID),
            err,
        )
    }
    return nil, oauthServerError(
        fmt.Sprintf("failed to look up application_id %s", req.ApplicationID),
        err,
    )
}
```

Net wire-behavior change vs the original buggy code:
- **HTTP status on "not found"**: 500 → 400 (the intended status)
- **HTTP status on transient DB error**: 500 → 500 (unchanged, but now with a meaningful description AND retriable signal)
- **Error code on body for "not found"**: `{"error":"server_error"}` → `{"error":"invalid_request"}`
- **Error code on body for transient DB error**: `{"error":"server_error"}` → `{"error":"server_error"}` (unchanged but now via the right helper)
- **Internal logs**: gain access to the underlying `GetIdentity` error via `errors.Unwrap` (previously discarded)
- **Uses `oautherror.InvalidRequest`** (PR-167's RFC-anchored constant), not a bare string

## Commit history

| Commit | Purpose |
|---|---|
| `3e417f5` | Original fix — wrap with `oauthBadRequestCause`. Used bare `"invalid_request"` string because PR-167 wasn't merged into main yet. |
| `571368f` | Merge from main, bringing in PR-167's `oautherror` package. |
| `483816e` | Address Copilot findings: swap bare string to `oautherror.InvalidRequest`, distinguish `sql.ErrNoRows` from transient errors. |

## Origin and scope

The original wire-shape bug was from commit `d5bedb44` (March 2026 — Yash Datta). Caught by Copilot during [PR-167's review](https://github.com/highflame-ai/zeroid/pull/167); split out of that PR to keep its scope clean (constants sweep, not error-wrapping fixes).

A grep for `fmt\.Errorf\("invalid_` across `internal/` returned this as the **only site** with this anti-pattern. Confirmed the same shape doesn't appear via `errors.New` either.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Full integration suite passes (`go test ./tests/integration/...` — ~36s, no regressions)
- [ ] **No new test added** — `ExternalPrincipalExchange` has no integration coverage today; the path requires a `TrustedServiceValidator` that isn't wired in any test setup. Adding the full harness for a 1-line bug fix is disproportionate; whoever next touches this code path should add coverage.

## What this PR is NOT

- Not a refactor — single function call site + comment changes
- Not a wire-API change beyond fixing the bug