### PR TITLE
feat: add /oauth2/authorize endpoint + PrincipalResolver hook

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/service"
 )
 
 // ClaimsEnricher is called during JWT issuance to add custom claims.
@@ -38,6 +39,37 @@ type GrantRequest struct {
 	Role           string
 	PrivilegeScope []string
 }
+
+// Principal is the resolved caller at /oauth2/authorize — the tenant +
+// user binding that gets baked into the issued authorization code JWT.
+// Re-exported from internal/service so deployer code stays at the
+// top-level zeroid public surface; both names refer to the same type.
+//
+// See internal/service/principal.go for the canonical doc comment.
+type Principal = service.Principal
+
+// AuthorizeRequest is the typed, read-only snapshot of the parsed
+// /oauth2/authorize request handed to every PrincipalResolver. Resolvers
+// see this — never net/http types — so the extensibility hook stays
+// consistent with zeroid's other typed-struct boundaries.
+//
+// See internal/service/principal.go for the canonical doc comment.
+type AuthorizeRequest = service.AuthorizeRequest
+
+// PrincipalResolver authenticates the caller at /oauth2/authorize.
+// Registered via Server.RegisterPrincipalResolver and tried in
+// registration order; the first resolver to return a non-nil Principal
+// wins. Return ErrPrincipalNotApplicable to defer to the next resolver;
+// any other error fails the request with 401 invalid_client.
+//
+// See internal/service/principal.go for the canonical doc comment.
+type PrincipalResolver = service.PrincipalResolver
+
+// ErrPrincipalNotApplicable is the sentinel returned by a
+// PrincipalResolver that does not apply to the current request. zeroid
+// moves to the next registered resolver; when every resolver returns
+// this sentinel, the request fails with 401 invalid_client.
+var ErrPrincipalNotApplicable = service.ErrPrincipalNotApplicable
 
 // AdminAuthMiddleware is an optional middleware applied to the admin API router.
 // When set, every request to the admin port passes through this middleware before

--- a/hooks.go
+++ b/hooks.go
@@ -71,6 +71,17 @@ type PrincipalResolver = service.PrincipalResolver
 // this sentinel, the request fails with 401 invalid_client.
 var ErrPrincipalNotApplicable = service.ErrPrincipalNotApplicable
 
+// ErrNoResolversRegistered is the sentinel surfaced by zeroid when
+// /oauth2/authorize is reached but no PrincipalResolver has been
+// registered via Server.RegisterPrincipalResolver. The handler maps
+// this to 503 Service Unavailable so the deployer sees a clear
+// "you forgot to wire this up" signal rather than an ambiguous 401.
+//
+// Deployers don't typically observe this sentinel directly — it's
+// emitted by zeroid's chain walker and consumed by the handler. The
+// re-export exists so deployer tests can match on it via errors.Is.
+var ErrNoResolversRegistered = service.ErrNoResolversRegistered
+
 // AdminAuthMiddleware is an optional middleware applied to the admin API router.
 // When set, every request to the admin port passes through this middleware before
 // reaching any handler. Use this to add authentication (Bearer JWT, mTLS, API key,

--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -1,0 +1,276 @@
+package handler
+
+// /oauth2/authorize — the upstream half of the OAuth 2.0 + PKCE
+// authorization_code grant. Mounted as a plain chi route (not Huma)
+// because:
+//
+//  1. The principal-credential field set is resolver-dependent —
+//     api_key today, session cookie / mTLS tomorrow — and doesn't fit
+//     a static OpenAPI input schema. Huma's value (declarative input
+//     parsing + auto-generated OpenAPI) is poor fit here.
+//  2. The endpoint's contract is "redirect 302 with code+state in the
+//     URL query," not "JSON-in JSON-out." Huma's TokenOutput-style
+//     status+body shape isn't a clean way to model that.
+//
+// The downstream half (decode + consume) lives in
+// internal/service/oauth.go::authorizationCode and is served by
+// /oauth2/token.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+	"github.com/highflame-ai/zeroid/internal/service"
+)
+
+// registerAuthorizeRoute mounts POST /oauth2/authorize on the public
+// chi router. GET is intentionally not supported in v1: RFC 6749
+// §4.1.1 permits GET for browser redirects, but the v1 use case (CLI
+// clients posting api_key + code_challenge) is POST-only. GET would
+// surface principal credentials in URL query strings + access logs.
+func (a *API) registerAuthorizeRoute(router chi.Router) {
+	router.Post("/oauth2/authorize", a.authorizeHandler)
+}
+
+// authorizeHandler is the chi handler for POST /oauth2/authorize.
+//
+// Pipeline:
+//
+//  1. Parse application/x-www-form-urlencoded body
+//  2. Build a typed AuthorizeRequest snapshot from the parsed form +
+//     headers + cookies (read-only — resolvers never see *http.Request)
+//  3. Required-field gate + response_type=code check (cheap, before
+//     any DB hits)
+//  4. Walk the registered PrincipalResolver chain. First non-nil
+//     Principal wins. No matches → 401 invalid_client.
+//  5. Intersect (caller-requested scope ∩ resolver-narrowed scope) —
+//     the service layer intersects again with the client's registered
+//     scope, so the issued code carries the narrowest authority.
+//  6. Hand off to OAuthService.IssueAuthCode for client validation,
+//     redirect_uri allow-list, S256 enforcement, and JWT minting.
+//  7. Build the redirect URL with code + state and emit 302.
+//
+// Errors fall into two camps. Syntactic errors (missing fields, bad
+// response_type) and credential failures (no resolver matched, all
+// resolvers rejected) return RFC 6749 §5.2 JSON error bodies — we
+// cannot redirect to a URL we haven't validated. Errors AFTER
+// successful client lookup could in principle be redirected back per
+// RFC 6749 §4.1.2.1, but v1 keeps them as JSON too; CLI clients
+// (today's only consumer) parse JSON errors fine, and redirect-with-
+// error needs careful URL validation we'd rather not introduce
+// piecemeal.
+func (a *API) authorizeHandler(w http.ResponseWriter, r *http.Request) {
+	// ── Step 1: parse form body ──────────────────────────────────────
+	if err := r.ParseForm(); err != nil {
+		writeAuthorizeError(w, http.StatusBadRequest, oautherror.InvalidRequest,
+			"could not parse application/x-www-form-urlencoded body")
+		return
+	}
+
+	// ── Step 2: build the AuthorizeRequest snapshot ──────────────────
+	// Form/Header/Cookie are typed accessors over the underlying
+	// request — resolvers read through them without ever holding a
+	// reference to *http.Request. PostForm.Get is naturally read-only.
+	postForm := r.PostForm
+	header := r.Header
+	req := &service.AuthorizeRequest{
+		ClientID:            postForm.Get("client_id"),
+		RedirectURI:         postForm.Get("redirect_uri"),
+		ResponseType:        postForm.Get("response_type"),
+		CodeChallenge:       postForm.Get("code_challenge"),
+		CodeChallengeMethod: postForm.Get("code_challenge_method"),
+		State:               postForm.Get("state"),
+		Scope:               postForm.Get("scope"),
+		Form:                postForm.Get,
+		Header: func(name string) string {
+			return header.Get(name)
+		},
+		Cookie: func(name string) string {
+			c, err := r.Cookie(name)
+			if err != nil {
+				return ""
+			}
+			return c.Value
+		},
+	}
+
+	// ── Step 3: required-field gate ──────────────────────────────────
+	// Caller errors before any DB hits — fail fast with a clear
+	// message. The service layer enforces the same gates again at
+	// IssueAuthCode (defense in depth for programmatic callers that
+	// bypass the handler), but we surface a per-field error here so
+	// CLI clients get actionable feedback.
+	if req.ClientID == "" {
+		writeAuthorizeError(w, http.StatusBadRequest, oautherror.InvalidRequest, "client_id is required")
+		return
+	}
+	if req.RedirectURI == "" {
+		writeAuthorizeError(w, http.StatusBadRequest, oautherror.InvalidRequest, "redirect_uri is required")
+		return
+	}
+	if req.CodeChallenge == "" {
+		writeAuthorizeError(w, http.StatusBadRequest, oautherror.InvalidRequest, "code_challenge is required")
+		return
+	}
+	if req.CodeChallengeMethod == "" {
+		writeAuthorizeError(w, http.StatusBadRequest, oautherror.InvalidRequest, "code_challenge_method is required")
+		return
+	}
+	if req.ResponseType != "" && req.ResponseType != "code" {
+		// response_type is optional in our shape (we only support
+		// "code" anyway), but if the caller passes something else
+		// they have the wrong shape in their head — surface it
+		// instead of silently accepting.
+		writeAuthorizeError(w, http.StatusBadRequest, oautherror.InvalidRequest,
+			"response_type must be 'code' (only authorization_code grant is supported at /oauth2/authorize)")
+		return
+	}
+
+	// ── Step 4: principal resolution ─────────────────────────────────
+	// resolvePrincipal is nil only when the deployer never registered
+	// any resolver — surface a clear 503 so they see the
+	// "you forgot to wire this up" signal instead of an ambiguous 401.
+	if a.resolvePrincipal == nil {
+		log.Warn().Str("client_id", req.ClientID).Msg("/oauth2/authorize called but no PrincipalResolver is registered")
+		writeAuthorizeError(w, http.StatusServiceUnavailable, oautherror.ServerError,
+			"/oauth2/authorize is not configured on this deployment: no PrincipalResolver registered")
+		return
+	}
+
+	principal, resolverName, err := a.resolvePrincipal(r.Context(), req)
+	if err != nil {
+		// A specific resolver found its credential in the request but
+		// rejected it (wrong api_key, expired cookie, etc.). Log the
+		// resolver name + error for operators; return a generic
+		// invalid_client to the caller so we don't leak which
+		// resolver path matched.
+		log.Warn().
+			Err(err).
+			Str("resolver", resolverName).
+			Str("client_id", req.ClientID).
+			Msg("principal resolver rejected request")
+		writeAuthorizeError(w, http.StatusUnauthorized, oautherror.InvalidClient,
+			"credential rejected")
+		return
+	}
+	if principal == nil {
+		// Every registered resolver returned ErrPrincipalNotApplicable —
+		// the caller didn't supply a credential any resolver
+		// recognized. 401 with a hint that points at the deployer-
+		// chosen credential names is the most useful response.
+		writeAuthorizeError(w, http.StatusUnauthorized, oautherror.InvalidClient,
+			"no applicable credential — request did not match any registered principal resolver")
+		return
+	}
+
+	// ── Step 5: caller-requested ∩ resolver-narrowed scope ───────────
+	// The service layer (IssueAuthCode) does the final intersection
+	// against the client's registered scope set. Here we just combine
+	// what the caller asked for with what the resolver pre-narrowed.
+	scopes := principal.Scopes
+	if req.Scope != "" {
+		requested := strings.Fields(req.Scope)
+		if len(scopes) > 0 {
+			scopes = intersectStrings(requested, scopes)
+		} else {
+			scopes = requested
+		}
+	}
+
+	// ── Step 6: mint via service ─────────────────────────────────────
+	code, err := a.oauthSvc.IssueAuthCode(r.Context(), service.IssueAuthCodeRequest{
+		ClientID:            req.ClientID,
+		RedirectURI:         req.RedirectURI,
+		CodeChallenge:       req.CodeChallenge,
+		CodeChallengeMethod: req.CodeChallengeMethod,
+		AccountID:           principal.AccountID,
+		ProjectID:           principal.ProjectID,
+		UserID:              principal.UserID,
+		OrgID:               principal.OrgID,
+		Scopes:              scopes,
+	})
+	if err != nil {
+		log.Warn().
+			Err(err).
+			Str("resolver", resolverName).
+			Str("client_id", req.ClientID).
+			Str("account_id", principal.AccountID).
+			Msg("IssueAuthCode rejected request")
+		errCode, desc, status := extractOAuthError(err)
+		writeAuthorizeError(w, status, errCode, desc)
+		return
+	}
+
+	// ── Step 7: 302 to redirect_uri with ?code=…&state=… ─────────────
+	// redirect_uri has been validated by IssueAuthCode against the
+	// client's registered list — we can trust it now. Parse + add
+	// query params.
+	u, parseErr := url.Parse(req.RedirectURI)
+	if parseErr != nil {
+		// IssueAuthCode validated this URL is in the client's
+		// registered list; if it now fails to parse, the client's
+		// registration is corrupt. 500 not 400.
+		log.Error().Err(parseErr).Str("redirect_uri", req.RedirectURI).Msg("registered redirect_uri failed url.Parse")
+		writeAuthorizeError(w, http.StatusInternalServerError, oautherror.ServerError,
+			"failed to build redirect")
+		return
+	}
+	q := u.Query()
+	q.Set("code", code)
+	if req.State != "" {
+		q.Set("state", req.State)
+	}
+	u.RawQuery = q.Encode()
+
+	log.Info().
+		Str("resolver", resolverName).
+		Str("client_id", req.ClientID).
+		Str("account_id", principal.AccountID).
+		Str("project_id", principal.ProjectID).
+		Str("user_id", principal.UserID).
+		Msg("authorization code issued")
+
+	w.Header().Set("Location", u.String())
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusFound)
+}
+
+// writeAuthorizeError emits an RFC 6749 §5.2 JSON error body. Used for
+// all error paths at /oauth2/authorize in v1 (no redirect-with-error).
+// Cache-Control: no-store per RFC 6749 §5.1 to prevent intermediary
+// caches from holding error responses tied to credential state.
+func writeAuthorizeError(w http.ResponseWriter, status int, code, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+}
+
+// intersectStrings returns the set intersection of a and b, preserving
+// the order of a. Used to combine caller-requested scopes with the
+// resolver's pre-narrowed scope surface before handing off to
+// IssueAuthCode (which intersects again with the client's registered
+// scopes). Linear time + linear memory; the scope lists are small
+// enough that a hash-set lookup is the right shape.
+func intersectStrings(a, b []string) []string {
+	set := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		set[s] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	for _, s := range a {
+		if _, ok := set[s]; ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -18,6 +18,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
@@ -133,18 +134,22 @@ func (a *API) authorizeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── Step 4: principal resolution ─────────────────────────────────
-	// resolvePrincipal is nil only when the deployer never registered
-	// any resolver — surface a clear 503 so they see the
-	// "you forgot to wire this up" signal instead of an ambiguous 401.
-	if a.resolvePrincipal == nil {
-		log.Warn().Str("client_id", req.ClientID).Msg("/oauth2/authorize called but no PrincipalResolver is registered")
-		writeAuthorizeError(w, http.StatusServiceUnavailable, oautherror.ServerError,
-			"/oauth2/authorize is not configured on this deployment: no PrincipalResolver registered")
-		return
-	}
-
+	// The resolvePrincipal callback is wired unconditionally by
+	// Server.NewServer (it's a method bound to the server's resolver
+	// registry — never nil). The registry itself may be empty, which
+	// is the "deployer forgot to wire it up" case — surfaced via the
+	// ErrNoResolversRegistered sentinel below as a 503.
 	principal, resolverName, err := a.resolvePrincipal(r.Context(), req)
 	if err != nil {
+		if errors.Is(err, service.ErrNoResolversRegistered) {
+			// Configuration error, not a runtime credential error —
+			// 503 so embedders see a clear setup signal. Distinct
+			// from 401 ("you wired it up but no credential matched").
+			log.Warn().Str("client_id", req.ClientID).Msg("/oauth2/authorize called but no PrincipalResolver is registered")
+			writeAuthorizeError(w, http.StatusServiceUnavailable, oautherror.ServerError,
+				"/oauth2/authorize is not configured on this deployment: no PrincipalResolver registered")
+			return
+		}
 		// A specific resolver found its credential in the request but
 		// rejected it (wrong api_key, expired cookie, etc.). Log the
 		// resolver name + error for operators; return a generic

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -5,6 +5,7 @@
 package handler
 
 import (
+	"context"
 	"io"
 	"time"
 
@@ -42,7 +43,25 @@ type API struct {
 	db                   *bun.DB
 	issuer               string
 	startTime            time.Time
+
+	// resolvePrincipal walks the PrincipalResolver chain registered on
+	// the top-level Server. Wired by Server.NewServer via
+	// SetPrincipalResolverFunc; nil when no resolvers are registered
+	// (the /oauth2/authorize handler then returns 503 so deployers
+	// see a clear "not configured" signal).
+	resolvePrincipal PrincipalResolverFunc
 }
+
+// PrincipalResolverFunc is the chain-walker function the /oauth2/authorize
+// handler calls to resolve the caller's tenant + user context. Returns
+// the resolved principal, the name of the resolver that produced it
+// (for log attribution), and any error.
+//
+// The function lives here (handler package) rather than in service or
+// the top-level zeroid package so handler can hold it as a field without
+// pulling in the resolver-registry mutex. Server constructs an instance
+// bound to its own registry and hands it to API at construction time.
+type PrincipalResolverFunc func(ctx context.Context, req *service.AuthorizeRequest) (*service.Principal, string, error)
 
 // NewAPI creates a new API with all service dependencies.
 func NewAPI(
@@ -128,6 +147,16 @@ func (a *API) RegisterPublic(api huma.API, router chi.Router) {
 	a.registerOAuthRoutes(api)
 	a.registerDynamicRegistrationRoutes(api)
 	a.registerAuthVerifyRoute(router)
+	a.registerAuthorizeRoute(router)
+}
+
+// SetPrincipalResolverFunc wires the PrincipalResolver chain walker
+// from the top-level Server into this API. Called by Server.NewServer
+// once after API construction; not part of the public deployer API
+// (deployers call Server.RegisterPrincipalResolver instead, which
+// updates the registry that this function reads from).
+func (a *API) SetPrincipalResolverFunc(fn PrincipalResolverFunc) {
+	a.resolvePrincipal = fn
 }
 
 // RegisterAdmin registers admin/management endpoints:

--- a/internal/service/authcode.go
+++ b/internal/service/authcode.go
@@ -109,3 +109,107 @@ func verifyCodeChallenge(codeVerifier, codeChallenge string) bool {
 func normalizeLoopback(uri string) string {
 	return strings.Replace(uri, "://127.0.0.1:", "://localhost:", 1)
 }
+
+// AuthCodeTTL is the lifetime of an issued authorization code. RFC 6749
+// §4.1.2 recommends a maximum of 10 minutes; the conventional value across
+// mainstream OAuth providers is 5 minutes. Short TTL is the primary defense
+// against code interception — once the code is in the browser URL bar it's
+// already exposed to logs, referer headers, and extensions, so we want it
+// useless quickly.
+const AuthCodeTTL = 5 * time.Minute
+
+// AuthCodeSubject is the JWT subject string decodeAuthCodeJWT requires. Hard-
+// coded to bind the JWT shape to the auth-code grant — a token without this
+// subject (e.g. a regular access token someone tries to replay as an auth
+// code) is rejected before any tenant context is read.
+const AuthCodeSubject = "auth-code"
+
+// mintAuthCodeJWT is the symmetric counterpart to decodeAuthCodeJWT — it
+// produces an HS256 JWT containing the AuthCodeClaims shape that the decoder
+// reads. Pure function: no service receiver, no I/O, fully deterministic
+// given inputs (except for the time-derived jti). Callers (currently
+// OAuthService.IssueAuthCode) are responsible for validating the surrounding
+// OAuth context (client registration, redirect-uri allow-list, S256-only
+// challenge) before invoking the mint.
+//
+// The jti is derived from sha256(client_id|user_id|now-nano) — deterministic
+// enough for debug-traceability across logs, unique enough that two near-
+// simultaneous codes for the same client+user don't collide. zeroid's
+// Consume uses jti as the single-use key, so uniqueness is the only
+// correctness requirement.
+func mintAuthCodeJWT(claims *AuthCodeClaims, hmacSecret, issuer string, now time.Time) (string, error) {
+	if hmacSecret == "" {
+		return "", fmt.Errorf("authcode mint: hmac secret is empty")
+	}
+	if issuer == "" {
+		return "", fmt.Errorf("authcode mint: issuer is empty")
+	}
+	if claims == nil {
+		return "", fmt.Errorf("authcode mint: claims are nil")
+	}
+	if claims.ClientID == "" || claims.CodeChallenge == "" || claims.RedirectURI == "" {
+		return "", fmt.Errorf("authcode mint: client_id, code_challenge, redirect_uri are all required")
+	}
+	if claims.AccountID == "" {
+		return "", fmt.Errorf("authcode mint: account_id is required")
+	}
+
+	jti := claims.JTI
+	if jti == "" {
+		seed := fmt.Sprintf("%s|%s|%d", claims.ClientID, claims.UserID, now.UnixNano())
+		h := sha256.Sum256([]byte(seed))
+		// 32 hex chars — collision-resistant and short enough to fit in
+		// log lines without wrapping.
+		jti = hex.EncodeToString(h[:16])
+	}
+
+	exp := claims.ExpiresAt
+	if exp.IsZero() {
+		exp = now.Add(AuthCodeTTL)
+	}
+
+	builder := jwt.NewBuilder().
+		Issuer(issuer).
+		Subject(AuthCodeSubject).
+		JwtID(jti).
+		IssuedAt(now).
+		Expiration(exp).
+		Claim("cid", claims.ClientID).
+		Claim("cc", claims.CodeChallenge).
+		Claim("ruri", claims.RedirectURI).
+		Claim("aid", claims.AccountID)
+
+	if claims.UserID != "" {
+		builder = builder.Claim("uid", claims.UserID)
+	}
+	if claims.OrgID != "" {
+		builder = builder.Claim("oid", claims.OrgID)
+	}
+	if claims.ProjectID != "" {
+		builder = builder.Claim("pid", claims.ProjectID)
+	}
+	if len(claims.Scopes) > 0 {
+		// Stored as []any so jwx v4 serializes a JSON array. The decoder
+		// at decodeAuthCodeJWT accepts both []string and []any shapes
+		// (resilience against issuance-side changes), but we emit []any
+		// to match what JSON unmarshal naturally produces on the receive
+		// side — keeps the round-trip lossless.
+		anyScopes := make([]any, len(claims.Scopes))
+		for i, s := range claims.Scopes {
+			anyScopes[i] = s
+		}
+		builder = builder.Claim("scp", anyScopes)
+	}
+
+	tok, err := builder.Build()
+	if err != nil {
+		return "", fmt.Errorf("authcode mint: jwt build failed: %w", err)
+	}
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256(), []byte(hmacSecret)))
+	if err != nil {
+		return "", fmt.Errorf("authcode mint: jwt sign failed: %w", err)
+	}
+
+	return string(signed), nil
+}

--- a/internal/service/authcode_issue_test.go
+++ b/internal/service/authcode_issue_test.go
@@ -1,0 +1,288 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for mintAuthCodeJWT — the pure-function half of the
+// authorization_code grant's issuance side. The decoder lives next to
+// it (decodeAuthCodeJWT) and is already covered by the existing
+// integration tests for /oauth2/token. These tests pin the symmetry:
+// what mintAuthCodeJWT produces, decodeAuthCodeJWT consumes.
+
+const (
+	testMintHMAC   = "test-hmac-secret-do-not-use-in-prod-32b!"
+	testMintIssuer = "https://auth.test.example.com"
+)
+
+// TestMintAuthCodeJWT_RoundTripsThroughDecoder is the load-bearing
+// contract test for this PR — it pins that the mint side produces a
+// JWT shape the decode side accepts unchanged. If a future change
+// renames a claim or tightens validation on either end and forgets to
+// update the other, this test breaks here, surfacing the drift before
+// any handler-level test does.
+func TestMintAuthCodeJWT_RoundTripsThroughDecoder(t *testing.T) {
+	t.Parallel()
+
+	verifier := strings.Repeat("a", 43) // RFC 7636 minimum
+	hash := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(hash[:])
+
+	now := time.Now()
+	in := &AuthCodeClaims{
+		ClientID:      "test-cli",
+		CodeChallenge: challenge,
+		RedirectURI:   "http://localhost:17580/callback",
+		Scopes:        []string{"read:thing", "write:thing"},
+		UserID:        "user-42",
+		OrgID:         "org-99",
+		AccountID:     "acct-001",
+		ProjectID:     "proj-001",
+	}
+
+	code, err := mintAuthCodeJWT(in, testMintHMAC, testMintIssuer, now)
+	if err != nil {
+		t.Fatalf("mintAuthCodeJWT failed: %v", err)
+	}
+	if code == "" {
+		t.Fatal("mintAuthCodeJWT returned empty code")
+	}
+
+	// Decode using the same parser /oauth2/token uses at exchange time.
+	out, err := decodeAuthCodeJWT(code, testMintHMAC, testMintIssuer)
+	if err != nil {
+		t.Fatalf("decodeAuthCodeJWT failed on minted code: %v", err)
+	}
+
+	// Pin every claim — this is the contract between mint and decode.
+	if out.ClientID != in.ClientID {
+		t.Errorf("ClientID: got %q want %q", out.ClientID, in.ClientID)
+	}
+	if out.CodeChallenge != in.CodeChallenge {
+		t.Errorf("CodeChallenge: got %q want %q", out.CodeChallenge, in.CodeChallenge)
+	}
+	if out.RedirectURI != in.RedirectURI {
+		t.Errorf("RedirectURI: got %q want %q", out.RedirectURI, in.RedirectURI)
+	}
+	if out.UserID != in.UserID {
+		t.Errorf("UserID: got %q want %q", out.UserID, in.UserID)
+	}
+	if out.OrgID != in.OrgID {
+		t.Errorf("OrgID: got %q want %q", out.OrgID, in.OrgID)
+	}
+	if out.AccountID != in.AccountID {
+		t.Errorf("AccountID: got %q want %q", out.AccountID, in.AccountID)
+	}
+	if out.ProjectID != in.ProjectID {
+		t.Errorf("ProjectID: got %q want %q", out.ProjectID, in.ProjectID)
+	}
+	if len(out.Scopes) != len(in.Scopes) {
+		t.Errorf("Scopes length: got %d want %d", len(out.Scopes), len(in.Scopes))
+	}
+	for i, s := range in.Scopes {
+		if i < len(out.Scopes) && out.Scopes[i] != s {
+			t.Errorf("Scopes[%d]: got %q want %q", i, out.Scopes[i], s)
+		}
+	}
+	if out.JTI == "" {
+		t.Error("JTI is empty — single-use enforcement at /oauth2/token would silently fail")
+	}
+
+	// Verifier→challenge round-trip — the PKCE invariant.
+	rehash := sha256.Sum256([]byte(verifier))
+	recomputed := base64.RawURLEncoding.EncodeToString(rehash[:])
+	if out.CodeChallenge != recomputed {
+		t.Errorf("PKCE round-trip broken: cc=%q sha256(verifier)=%q", out.CodeChallenge, recomputed)
+	}
+}
+
+// TestMintAuthCodeJWT_OptionalClaimsOmittedWhenEmpty pins that empty
+// UserID / OrgID / ProjectID don't produce empty-string claims in the
+// JWT (which would be confusing for downstream consumers reading the
+// "oid"/"pid"/"uid" fields), and also that Scopes=nil produces no scp
+// claim at all.
+func TestMintAuthCodeJWT_OptionalClaimsOmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	in := &AuthCodeClaims{
+		ClientID:      "test-cli",
+		CodeChallenge: "some-challenge",
+		RedirectURI:   "http://localhost:17580/callback",
+		AccountID:     "acct-001",
+		// UserID, OrgID, ProjectID, Scopes deliberately omitted.
+	}
+	code, err := mintAuthCodeJWT(in, testMintHMAC, testMintIssuer, now)
+	if err != nil {
+		t.Fatalf("mintAuthCodeJWT failed: %v", err)
+	}
+	out, err := decodeAuthCodeJWT(code, testMintHMAC, testMintIssuer)
+	if err != nil {
+		t.Fatalf("decodeAuthCodeJWT failed: %v", err)
+	}
+	if out.UserID != "" {
+		t.Errorf("UserID should be empty when not provided; got %q", out.UserID)
+	}
+	if out.OrgID != "" {
+		t.Errorf("OrgID should be empty when not provided; got %q", out.OrgID)
+	}
+	if out.ProjectID != "" {
+		t.Errorf("ProjectID should be empty when not provided; got %q", out.ProjectID)
+	}
+	if len(out.Scopes) != 0 {
+		t.Errorf("Scopes should be empty when not provided; got %v", out.Scopes)
+	}
+	if out.AccountID != "acct-001" {
+		t.Errorf("AccountID should round-trip; got %q want %q", out.AccountID, "acct-001")
+	}
+}
+
+// TestMintAuthCodeJWT_RejectsMissingRequiredFields pins that mint
+// rejects an incompletely-populated AuthCodeClaims before producing a
+// JWT that would later fail at the decoder for unclear reasons. Each
+// case omits exactly one required field and expects a non-nil error.
+func TestMintAuthCodeJWT_RejectsMissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	full := func() *AuthCodeClaims {
+		return &AuthCodeClaims{
+			ClientID:      "c",
+			CodeChallenge: "ch",
+			RedirectURI:   "http://localhost/cb",
+			AccountID:     "a",
+		}
+	}
+
+	cases := []struct {
+		name     string
+		mutate   func(*AuthCodeClaims)
+		hmac     string
+		issuer   string
+		wantSubs string
+	}{
+		{"empty hmac secret", func(c *AuthCodeClaims) {}, "", testMintIssuer, "hmac secret"},
+		{"empty issuer", func(c *AuthCodeClaims) {}, testMintHMAC, "", "issuer"},
+		{"nil claims", func(c *AuthCodeClaims) {}, testMintHMAC, testMintIssuer, "claims are nil"},
+		{"empty client_id", func(c *AuthCodeClaims) { c.ClientID = "" }, testMintHMAC, testMintIssuer, "client_id"},
+		{"empty code_challenge", func(c *AuthCodeClaims) { c.CodeChallenge = "" }, testMintHMAC, testMintIssuer, "code_challenge"},
+		{"empty redirect_uri", func(c *AuthCodeClaims) { c.RedirectURI = "" }, testMintHMAC, testMintIssuer, "redirect_uri"},
+		{"empty account_id", func(c *AuthCodeClaims) { c.AccountID = "" }, testMintHMAC, testMintIssuer, "account_id"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var c *AuthCodeClaims
+			if tc.name != "nil claims" {
+				c = full()
+				tc.mutate(c)
+			}
+			_, err := mintAuthCodeJWT(c, tc.hmac, tc.issuer, time.Now())
+			if err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubs) {
+				t.Errorf("%s: error %q does not mention %q", tc.name, err.Error(), tc.wantSubs)
+			}
+		})
+	}
+}
+
+// TestMintAuthCodeJWT_RespectsCustomJTI pins that a caller-supplied
+// jti is preserved through the mint, allowing tests (and production
+// callers that want deterministic codes for replay-test fixtures) to
+// pin the value rather than fight the time-derived default.
+func TestMintAuthCodeJWT_RespectsCustomJTI(t *testing.T) {
+	t.Parallel()
+
+	const customJTI = "my-deterministic-test-jti-xyz"
+	in := &AuthCodeClaims{
+		JTI:           customJTI,
+		ClientID:      "c",
+		CodeChallenge: "ch",
+		RedirectURI:   "http://localhost/cb",
+		AccountID:     "a",
+	}
+	code, err := mintAuthCodeJWT(in, testMintHMAC, testMintIssuer, time.Now())
+	if err != nil {
+		t.Fatalf("mintAuthCodeJWT failed: %v", err)
+	}
+	out, err := decodeAuthCodeJWT(code, testMintHMAC, testMintIssuer)
+	if err != nil {
+		t.Fatalf("decodeAuthCodeJWT failed: %v", err)
+	}
+	if out.JTI != customJTI {
+		t.Errorf("JTI: got %q want %q (caller-supplied jti must round-trip)", out.JTI, customJTI)
+	}
+}
+
+// TestMintAuthCodeJWT_DefaultExpHonoursAuthCodeTTL pins that an
+// AuthCodeClaims with zero ExpiresAt gets the default AuthCodeTTL
+// applied, matching the documented invariant.
+func TestMintAuthCodeJWT_DefaultExpHonoursAuthCodeTTL(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	in := &AuthCodeClaims{
+		ClientID:      "c",
+		CodeChallenge: "ch",
+		RedirectURI:   "http://localhost/cb",
+		AccountID:     "a",
+	}
+	code, err := mintAuthCodeJWT(in, testMintHMAC, testMintIssuer, now)
+	if err != nil {
+		t.Fatalf("mintAuthCodeJWT failed: %v", err)
+	}
+	out, err := decodeAuthCodeJWT(code, testMintHMAC, testMintIssuer)
+	if err != nil {
+		t.Fatalf("decodeAuthCodeJWT failed: %v", err)
+	}
+	// Allow ±2s drift between mint and decode for clock noise on slow runners.
+	wantExp := now.Add(AuthCodeTTL)
+	drift := out.ExpiresAt.Sub(wantExp)
+	if drift < -2*time.Second || drift > 2*time.Second {
+		t.Errorf("default exp = %v, expected %v ± 2s (AuthCodeTTL = %v)", out.ExpiresAt, wantExp, AuthCodeTTL)
+	}
+}
+
+// TestRedirectURIAllowed pins the loopback normalization rule applied
+// at IssueAuthCode-time: 127.0.0.1 and localhost are equivalent (RFC
+// 8252 §7.3), but other normalisations (case folding, default ports,
+// trailing slashes) are NOT applied — clients must register the exact
+// URI they'll use otherwise.
+func TestRedirectURIAllowed(t *testing.T) {
+	t.Parallel()
+	registered := []string{
+		"http://localhost:17580/callback",
+		"https://app.example.com/oauth/callback",
+	}
+	cases := []struct {
+		name      string
+		candidate string
+		want      bool
+	}{
+		{"exact match localhost", "http://localhost:17580/callback", true},
+		{"127.0.0.1 ↔ localhost equiv", "http://127.0.0.1:17580/callback", true},
+		{"exact match https", "https://app.example.com/oauth/callback", true},
+		{"wrong port", "http://localhost:17581/callback", false},
+		{"wrong path", "http://localhost:17580/other", false},
+		{"wrong host", "https://attacker.example.com/oauth/callback", false},
+		{"unregistered scheme", "http://app.example.com/oauth/callback", false},
+		{"empty candidate", "", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := redirectURIAllowed(tc.candidate, registered)
+			if got != tc.want {
+				t.Errorf("redirectURIAllowed(%q) = %v, want %v", tc.candidate, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -756,19 +756,94 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 	return accessToken, nil
 }
 
-// apiKeyGrant validates a zid_sk_* API key and issues an RS256 JWT.
-// Tenant is derived from the API key record — no caller-supplied headers needed.
-func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*domain.AccessToken, error) {
-	if req.APIKey == "" {
-		return nil, oauthBadRequest(oautherror.InvalidRequest, "api_key is required for api_key grant")
-	}
+// APIKeyResolution is the public result of OAuthService.ResolveAPIKey —
+// a narrow, stable type that does not leak zeroid internals (Identity,
+// APIKey row, policy records). Consumers project this onto whatever
+// shape their layer needs (e.g. mapping to zeroid.Principal for the
+// /oauth2/authorize PrincipalResolver hook).
+//
+// The Scopes field is the api key's intrinsic scope set BEFORE policy
+// intersection — credential-policy and identity-policy narrowing happen
+// at issuance time and may produce a smaller effective set on the
+// minted token. Callers that just need "what tenant + user does this
+// key belong to" should ignore Scopes; callers that need to mirror
+// zeroid's pre-token-mint authority surface should treat this as the
+// starting point.
+type APIKeyResolution struct {
+	AccountID string
+	ProjectID string
+	// UserID is the human who created the API key (sk.CreatedBy) — i.e.
+	// the developer whose CLI is being used right now. Empty for keys
+	// minted programmatically without a creator.
+	UserID string
+	// Scopes is the api key's intrinsic scope set. Empty means "no
+	// per-key restriction"; downstream policy may still narrow.
+	Scopes []string
+	// KeyID is the API key's row UUID. Useful for audit/log
+	// attribution — never returned to end users.
+	KeyID string
+}
 
-	if !s.jwksSvc.HasRSAKeys() {
-		return nil, oauthServerError("api_key grant requires RSA keys to be configured", nil)
+// apiKeyContext is the rich internal result of resolveAPIKeyContext —
+// everything apiKeyGrant needs to continue past resolution into policy
+// + scope intersection + token mint. Not exported because Identity is
+// an internal-shaped type and consumers should use the public
+// APIKeyResolution projection instead.
+type apiKeyContext struct {
+	// Resolution is the narrow public projection — what ResolveAPIKey
+	// returns to deployers.
+	Resolution *APIKeyResolution
+	// APIKey is the resolved row, in case the caller needs metadata
+	// (expires_at, credential_policy_id) beyond the projection.
+	APIKey *domain.APIKey
+	// Identity is the linked identity record OR a synthetic minimal
+	// identity built from the api key's tenant scalars when the key
+	// has no linked identity. Never nil after a successful resolution.
+	Identity *domain.Identity
+}
+
+// ResolveAPIKey looks up a zid_sk_* API key and returns the resolved
+// tenant context + user binding. This is the public surface used by
+// deployer-supplied PrincipalResolvers for the /oauth2/authorize
+// endpoint, and any other consumer that needs to authenticate an api
+// key out-of-band from the token endpoint.
+//
+// Returns:
+//   - (*APIKeyResolution, nil) on a valid, active, non-expired key.
+//   - (nil, *OAuthError) with code invalid_grant and HTTP 400 when the
+//     key is unknown, deactivated, or linked to a suspended/expired
+//     identity. Error is shaped for direct return from the
+//     /oauth2/authorize handler.
+//
+// Identity-state checks (IsUsable / IsExpired) match what apiKeyGrant
+// already enforces at token-mint time — a key whose identity is
+// suspended must not even authenticate at /authorize, let alone mint
+// a token. Same gate, same error shape.
+func (s *OAuthService) ResolveAPIKey(ctx context.Context, apiKey string) (*APIKeyResolution, error) {
+	rc, err := s.resolveAPIKeyContext(ctx, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return rc.Resolution, nil
+}
+
+// resolveAPIKeyContext is the shared resolution core used by both
+// apiKeyGrant (which needs the rich Identity for policy intersection)
+// and ResolveAPIKey (which projects to the narrow public type). Kept
+// unexported because *domain.Identity is not part of zeroid's public
+// surface.
+//
+// The function never returns a nil Identity on success — it builds a
+// synthetic identity from the key's tenant scalars when the key has no
+// linked identity row, matching the established api_key behaviour. This
+// lets downstream callers always assume Identity is populated.
+func (s *OAuthService) resolveAPIKeyContext(ctx context.Context, apiKey string) (*apiKeyContext, error) {
+	if apiKey == "" {
+		return nil, oauthBadRequest(oautherror.InvalidRequest, "api_key is required")
 	}
 
 	// Hash the API key with SHA-256 to look up in the database.
-	hash := sha256.Sum256([]byte(req.APIKey))
+	hash := sha256.Sum256([]byte(apiKey))
 	keyHash := hex.EncodeToString(hash[:])
 
 	sk, err := s.apiKeyRepo.GetByKeyHash(ctx, keyHash)
@@ -804,6 +879,37 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 			Status:    domain.IdentityStatusActive,
 		}
 	}
+
+	return &apiKeyContext{
+		Resolution: &APIKeyResolution{
+			AccountID: sk.AccountID,
+			ProjectID: sk.ProjectID,
+			UserID:    sk.CreatedBy,
+			Scopes:    append([]string(nil), sk.Scopes...),
+			KeyID:     sk.ID,
+		},
+		APIKey:   sk,
+		Identity: identity,
+	}, nil
+}
+
+// apiKeyGrant validates a zid_sk_* API key and issues an RS256 JWT.
+// Tenant is derived from the API key record — no caller-supplied headers needed.
+func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*domain.AccessToken, error) {
+	if req.APIKey == "" {
+		return nil, oauthBadRequest(oautherror.InvalidRequest, "api_key is required for api_key grant")
+	}
+
+	if !s.jwksSvc.HasRSAKeys() {
+		return nil, oauthServerError("api_key grant requires RSA keys to be configured", nil)
+	}
+
+	rc, err := s.resolveAPIKeyContext(ctx, req.APIKey)
+	if err != nil {
+		return nil, err
+	}
+	sk := rc.APIKey
+	identity := rc.Identity
 
 	// Resolve the identity policy (authority ceiling) whenever the key is
 	// linked to a real identity. api_key tokens then pass through both
@@ -883,6 +989,199 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 	}()
 
 	return accessToken, nil
+}
+
+// IssueAuthCodeRequest is the input shape for OAuthService.IssueAuthCode —
+// the upstream half of the authorization_code grant. Callers (the /oauth2/
+// authorize handler in this repo, plus deployer code that wants to issue
+// codes programmatically) populate every field; zeroid enforces every
+// invariant the authorizationCode decoder later validates.
+//
+// All fields are required except OrgID and Scopes (both optional).
+type IssueAuthCodeRequest struct {
+	// ClientID identifies the OAuth client requesting the code. Must
+	// be registered, active, and have "authorization_code" in its
+	// GrantTypes — IssueAuthCode rejects clients that don't.
+	ClientID string
+
+	// RedirectURI is the callback URI the issued code's holder will
+	// receive at after token exchange. IssueAuthCode validates that it
+	// matches one of the client's pre-registered RedirectURIs
+	// (normalizeLoopback applied per RFC 8252). Mismatched URIs are
+	// rejected with invalid_request so an attacker cannot redirect the
+	// code to their own callback.
+	RedirectURI string
+
+	// CodeChallenge is the PKCE S256 challenge (RFC 7636 §4.2). Will
+	// be encoded into the auth code as the "cc" claim and verified at
+	// /oauth2/token against the caller-supplied code_verifier.
+	CodeChallenge string
+
+	// CodeChallengeMethod is the PKCE method. ONLY "S256" is accepted —
+	// "plain" (RFC 7636 §4.2) confers no protection and OAuth 2.1
+	// removes it entirely. Misconfigured CLI clients cannot downgrade
+	// themselves silently; "plain" returns invalid_request.
+	CodeChallengeMethod string
+
+	// AccountID and ProjectID are the tenant scalars baked into the
+	// auth code's "aid"/"pid" claims. AccountID is required; ProjectID
+	// is optional but strongly recommended (zeroid won't reject an
+	// empty pid, but downstream tenant-isolation gates may).
+	AccountID string
+	ProjectID string
+
+	// UserID is the human (or workload) the issued token will be bound
+	// to. Baked into the "uid" claim. May be empty for tenant-only
+	// tokens.
+	UserID string
+
+	// OrgID is an optional org-level scope above AccountID. Baked into
+	// the "oid" claim only when non-empty; omitted otherwise.
+	OrgID string
+
+	// Scopes is the pre-narrowed scope set this code authorizes the
+	// token exchange to mint. IssueAuthCode intersects this with the
+	// OAuth client's registered Scopes — a code can never authorize a
+	// scope the client itself isn't allowed. Empty means "no
+	// resolver-side narrowing"; the client's full registered scope
+	// surface is encoded.
+	Scopes []string
+}
+
+// IssueAuthCode is the upstream half of the OAuth 2.0 + PKCE
+// authorization_code grant — the symmetric counterpart to the
+// authorizationCode method below (which consumes codes at /oauth2/token).
+// It validates the OAuth context, intersects the requested scopes against
+// the client's registered allow-list, and mints a stateless HS256 JWT in
+// the AuthCodeClaims shape that decodeAuthCodeJWT reads. No row is
+// inserted at issuance — the authCodeRepo is touched only at consumption
+// time (ON CONFLICT (jti) DO NOTHING), so issuance is a pure signing
+// operation with no DB write and no race.
+//
+// Validation gates (in order):
+//
+//  1. Required fields: client_id, redirect_uri, code_challenge,
+//     code_challenge_method, account_id.
+//  2. code_challenge_method must be "S256" (plain rejected, OAuth 2.1).
+//  3. Client must exist + be active (GetPublicClient).
+//  4. Client must have "authorization_code" in its registered grant
+//     types.
+//  5. Redirect URI must match one of the client's registered URIs
+//     (loopback-normalized).
+//  6. HMAC secret must be configured on the service (deployer wired
+//     cfg.Token.HMACSecret).
+//
+// Returns a signed JWT on success, or an *OAuthError shaped for direct
+// surfacing from the /oauth2/authorize handler.
+func (s *OAuthService) IssueAuthCode(ctx context.Context, req IssueAuthCodeRequest) (string, error) {
+	// Required-field gate.
+	if req.ClientID == "" {
+		return "", oauthBadRequest(oautherror.InvalidRequest, "client_id is required")
+	}
+	if req.RedirectURI == "" {
+		return "", oauthBadRequest(oautherror.InvalidRequest, "redirect_uri is required")
+	}
+	if req.CodeChallenge == "" {
+		return "", oauthBadRequest(oautherror.InvalidRequest, "code_challenge is required")
+	}
+	if req.CodeChallengeMethod == "" {
+		return "", oauthBadRequest(oautherror.InvalidRequest, "code_challenge_method is required")
+	}
+	if req.AccountID == "" {
+		return "", oauthBadRequest(oautherror.InvalidRequest, "account_id is required")
+	}
+
+	// S256-only. plain is deprecated (RFC 7636 §4.2) and removed in
+	// OAuth 2.1 — reject explicitly so misconfigured CLI clients
+	// cannot downgrade themselves silently.
+	if req.CodeChallengeMethod != "S256" {
+		return "", oauthBadRequest(oautherror.InvalidRequest,
+			"code_challenge_method must be S256 (plain is not supported)")
+	}
+
+	if s.hmacSecret == "" {
+		return "", oauthServerError("authorization_code issuance requires HMAC secret to be configured", nil)
+	}
+
+	// Client lookup. GetPublicClient verifies the client exists and is
+	// active; no secret is required because PKCE provides the proof of
+	// possession at exchange time.
+	oauthClient, err := s.oauthClientSvc.GetPublicClient(ctx, req.ClientID)
+	if err != nil {
+		return "", oauthUnauthorized("unknown or inactive client_id", err)
+	}
+
+	// Grant-type allow-list. Same check that authorizationCode runs at
+	// exchange — applied here too so a client without the grant cannot
+	// even obtain a code, not just fail at exchange.
+	if !slices.Contains(oauthClient.GrantTypes, string(domain.GrantTypeAuthorizationCode)) {
+		return "", oauthBadRequest(oautherror.UnauthorizedClient,
+			"client is not authorized for authorization_code grant")
+	}
+
+	// Redirect-URI allow-list. The redirect_uri the caller supplies
+	// must be one the client pre-registered, otherwise an attacker
+	// who steals a code could redirect it to their own callback.
+	// normalizeLoopback handles the 127.0.0.1 ↔ localhost equivalence
+	// (RFC 8252 §7.3) so native-app CLI clients aren't tripped up by
+	// the form their loopback URI takes.
+	if !redirectURIAllowed(req.RedirectURI, oauthClient.RedirectURIs) {
+		return "", oauthBadRequest(oautherror.InvalidRequest,
+			"redirect_uri is not in the client's registered list")
+	}
+
+	// Scope intersection: the issued code can never authorize a scope
+	// the client itself isn't allowed. Empty req.Scopes means
+	// "no resolver-side narrowing" — pass through the client's full
+	// registered surface.
+	scopes := req.Scopes
+	if len(scopes) == 0 {
+		scopes = oauthClient.Scopes
+	} else {
+		scopes = intersectScopes(scopes, oauthClient.Scopes)
+	}
+
+	// Build the claim shape that decodeAuthCodeJWT reads. Use time.Now
+	// as the issuance instant — mintAuthCodeJWT derives jti + exp from
+	// it. Centralising the timestamp here (rather than inside the pure
+	// mint helper) keeps the mint helper deterministic and testable
+	// with an injectable time.
+	now := time.Now()
+	claims := &AuthCodeClaims{
+		ExpiresAt:     now.Add(AuthCodeTTL),
+		ClientID:      req.ClientID,
+		CodeChallenge: req.CodeChallenge,
+		RedirectURI:   req.RedirectURI,
+		Scopes:        scopes,
+		UserID:        req.UserID,
+		OrgID:         req.OrgID,
+		AccountID:     req.AccountID,
+		ProjectID:     req.ProjectID,
+	}
+
+	signed, err := mintAuthCodeJWT(claims, s.hmacSecret, s.authCodeIssuer, now)
+	if err != nil {
+		// Reach here only when mintAuthCodeJWT's defensive checks
+		// trip — should not happen given the gates above. Surface as
+		// 500 (server-side misconfiguration) rather than 400.
+		return "", oauthServerError("failed to mint authorization code", err)
+	}
+
+	return signed, nil
+}
+
+// redirectURIAllowed reports whether candidate matches any of the
+// registered URIs under loopback normalization (RFC 8252 §7.3). Used by
+// IssueAuthCode at /oauth2/authorize time AND by authorizationCode at
+// /oauth2/token time so both ends apply the same allow-list rule.
+func redirectURIAllowed(candidate string, registered []string) bool {
+	normCand := normalizeLoopback(candidate)
+	for _, r := range registered {
+		if normalizeLoopback(r) == normCand {
+			return true
+		}
+	}
+	return false
 }
 
 // authorizationCode handles the PKCE authorization code grant (RFC 6749 section 4.1).

--- a/internal/service/principal.go
+++ b/internal/service/principal.go
@@ -123,3 +123,17 @@ type PrincipalResolver func(ctx context.Context, req *AuthorizeRequest) (*Princi
 // the resolver doesn't see itself in this request — not "this request
 // is invalid."
 var ErrPrincipalNotApplicable = errors.New("zeroid: principal resolver not applicable")
+
+// ErrNoResolversRegistered is the sentinel Server.resolvePrincipal
+// returns when the /oauth2/authorize endpoint is reached but the
+// deployer never registered any PrincipalResolver. The handler maps
+// this to 503 Service Unavailable so embedders see a clear
+// "you forgot to wire this up" signal — distinct from 401, which
+// signals "you wired it up but no credential matched."
+//
+// This is a configuration error, not a runtime credential error;
+// hence 503 (server is missing required configuration) rather than
+// 500 (something went wrong). Surfacing it as its own sentinel lets
+// the handler distinguish from the "all resolvers returned
+// ErrPrincipalNotApplicable" case, which is a legitimate 401.
+var ErrNoResolversRegistered = errors.New("zeroid: no principal resolvers registered")

--- a/internal/service/principal.go
+++ b/internal/service/principal.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"errors"
+)
+
+// Principal is the resolved caller at /oauth2/authorize. The fields here
+// become the {aid, pid, uid, oid, scp} claims on the issued auth-code JWT
+// and travel through to the access token minted at code exchange.
+//
+// Resolvers (see PrincipalResolver) build a Principal from whatever
+// authentication material the request carried — an api_key, a session
+// cookie, an mTLS chain. zeroid is intentionally agnostic about how the
+// principal is authenticated; it only knows what the resolved tenant +
+// user identifiers are.
+//
+// Defined in package service so internal/handler can reference it directly
+// (handler is below zeroid in the dependency tree). The top-level zeroid
+// package re-exports it as a type alias for the public API surface
+// deployers see.
+type Principal struct {
+	// AccountID and ProjectID are required — they define the tenant
+	// scope of the issued authorization code. An authorization code
+	// minted without a tenant context would produce a token unbound
+	// from multi-tenancy; zeroid rejects an empty AccountID at
+	// IssueAuthCode time.
+	AccountID string
+	ProjectID string
+
+	// UserID is the human (or workload) the issued token will be bound
+	// to. Optional — when empty, zeroid issues a tenant-bound token
+	// with no user binding. Resolvers SHOULD populate this whenever the
+	// underlying credential names a user (e.g. an API key whose
+	// `created_by` field carries the developer's user ID).
+	UserID string
+
+	// OrgID is an optional organisational identifier above account-
+	// level scope. Populated only when the resolver has a meaningful
+	// value; the auth-code JWT carries it in the `oid` claim and the
+	// downstream access token surfaces it for resource servers that
+	// need cross-account org context.
+	OrgID string
+
+	// Scopes is the resolver-narrowed list of scopes the principal is
+	// allowed to obtain. The /oauth2/authorize handler intersects this
+	// with the OAuth client's registered scope surface and the caller-
+	// requested scope before stamping the authorization code. Empty
+	// means "no resolver-side narrowing".
+	Scopes []string
+}
+
+// AuthorizeRequest is a typed, read-only snapshot of the parsed
+// /oauth2/authorize request handed to every PrincipalResolver. Built by
+// zeroid from the inbound *http.Request once and reused across the
+// resolver chain. Resolvers never see net/http types directly — that's
+// deliberate. zeroid's whole surface accepts typed structs (TokenRequest,
+// BcAuthorizeInput, IssueAuthCodeRequest); this snapshot keeps the
+// extensibility hook consistent with that pattern instead of letting one
+// hook leak transport-layer details into deployer code.
+//
+// The Form / Header / Cookie accessors expose the source request's
+// fields without exposing the request itself. Resolvers can read any
+// header or form value they need (api_key form param, session cookie,
+// mTLS chain header) — they just can't mutate the request, re-parse the
+// body, or call ServeHTTP-level helpers. Multi-value headers collapse
+// to comma-joined per RFC 9110 §5.3; fields missing from the request
+// return the empty string.
+type AuthorizeRequest struct {
+	// Standard OAuth 2.0 + PKCE fields (RFC 6749 §4.1.1, RFC 7636 §4.3).
+	// Parsed and validated by zeroid before resolvers see them.
+	ClientID            string
+	RedirectURI         string
+	ResponseType        string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	State               string
+	Scope               string
+
+	// Form returns a body form value parsed by zeroid, or "" if absent.
+	// Resolvers use this to read principal-credential fields they own
+	// (e.g. "api_key" for the api_key resolver, "session_id" for a
+	// session-cookie resolver fallback path).
+	Form func(name string) string
+
+	// Header returns a request header value, or "" if absent. Multi-
+	// value headers collapse to a comma-joined string per RFC 9110 §5.3.
+	Header func(name string) string
+
+	// Cookie returns a request cookie value by name, or "" if absent.
+	Cookie func(name string) string
+}
+
+// PrincipalResolver authenticates the caller at /oauth2/authorize and
+// returns the resolved Principal whose tenant + user context will be
+// baked into the issued authorization code.
+//
+// Resolvers are registered with Server.RegisterPrincipalResolver (in the
+// top-level zeroid package) and tried in registration order. The first
+// resolver to return a non-nil Principal wins. A resolver that doesn't
+// apply to the current request (e.g. the api_key resolver seeing no
+// api_key form field) MUST return (nil, ErrPrincipalNotApplicable) —
+// that signals "skip me, try the next one." Any other returned error
+// fails the request immediately with 401 invalid_client, and the
+// resolver chain stops.
+//
+// Resolvers run in the request goroutine — keep them fast (no network
+// I/O beyond cache hits, no DB queries beyond in-process pools). The
+// only DB call zeroid expects from a typical resolver is a single
+// credential lookup (e.g. ResolveAPIKey).
+type PrincipalResolver func(ctx context.Context, req *AuthorizeRequest) (*Principal, error)
+
+// ErrPrincipalNotApplicable is the sentinel a PrincipalResolver returns
+// when the current request does not carry the kind of credential the
+// resolver handles. zeroid moves to the next registered resolver. When
+// every resolver returns this sentinel, the chain has no applicable
+// principal and the request fails with 401 invalid_client.
+//
+// Distinguish this from a credential-found-but-invalid error (a wrong
+// api_key, an expired cookie): those return a non-sentinel error so
+// zeroid fails fast with the resolver's specific reason instead of
+// silently trying the next one. "Not applicable" is a positive signal
+// the resolver doesn't see itself in this request — not "this request
+// is invalid."
+var ErrPrincipalNotApplicable = errors.New("zeroid: principal resolver not applicable")

--- a/server.go
+++ b/server.go
@@ -593,20 +593,24 @@ func (s *Server) RegisterPrincipalResolver(name string, r PrincipalResolver) {
 // used by the /oauth2/authorize handler for log attribution.
 //
 // Errors:
-//   - All resolvers returning ErrPrincipalNotApplicable → returns
-//     (nil, "", nil). Caller (the authorize handler) maps this to a
-//     401 invalid_client.
+//   - No resolvers registered → returns
+//     (nil, "", ErrNoResolversRegistered). Handler maps this to 503
+//     so the deployer sees a clear "you forgot to wire this up"
+//     signal, distinct from the 401 "credential didn't match" case.
+//   - All registered resolvers returning ErrPrincipalNotApplicable →
+//     returns (nil, "", nil). Handler maps to 401 invalid_client.
 //   - Any resolver returning a non-sentinel error → returns
 //     (nil, resolverName, err). The chain stops at the first such
-//     error; caller surfaces it as 401 invalid_client with the
-//     resolver's description.
-//   - No resolvers registered → returns (nil, "", nil). Handler maps
-//     to 503 — the deployer never wired this up.
+//     error; handler surfaces it as 401 invalid_client.
 func (s *Server) resolvePrincipal(ctx context.Context, req *AuthorizeRequest) (*Principal, string, error) {
 	s.mu.RLock()
 	resolvers := make([]namedPrincipalResolver, len(s.principalResolvers))
 	copy(resolvers, s.principalResolvers)
 	s.mu.RUnlock()
+
+	if len(resolvers) == 0 {
+		return nil, "", ErrNoResolversRegistered
+	}
 
 	for _, r := range resolvers {
 		p, err := r.fn(ctx, req)
@@ -625,16 +629,6 @@ func (s *Server) resolvePrincipal(ctx context.Context, req *AuthorizeRequest) (*
 	}
 
 	return nil, "", nil
-}
-
-// hasPrincipalResolvers reports whether any PrincipalResolver has been
-// registered. Used by the /oauth2/authorize handler to distinguish a
-// "deployer never wired the endpoint" 503 from a "credential rejected"
-// 401, so embedders get a clear setup-error message in the former case.
-func (s *Server) hasPrincipalResolvers() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.principalResolvers) > 0
 }
 
 // AdminAuth sets an optional authentication middleware for admin routes.
@@ -1167,22 +1161,44 @@ func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// nonJSONContentTypeExemptPaths lists endpoints that accept
+// non-application/json POST bodies. The body-size cap still applies to
+// these paths (preserved as a generic DoS guard); the Content-Type
+// enforcement is what's exempted.
+//
+// /oauth2/authorize is here because its chi handler reads raw
+// application/x-www-form-urlencoded bodies directly — see
+// internal/handler/authorize.go for why it's chi-not-Huma. Other
+// /oauth2/* endpoints (token, introspect, revoke, bc-authorize) get
+// their form-encoded bodies REWRITTEN to JSON by
+// oauthFormCompatMiddleware before requestValidationMiddleware runs,
+// so by the time the Content-Type check fires they look like JSON.
+// /oauth2/authorize is not in OAuthFormEndpoints (no rewrite), so it
+// arrives here still form-encoded and must be exempted explicitly.
+var nonJSONContentTypeExemptPaths = map[string]struct{}{
+	"/oauth2/authorize": {},
+}
+
 // requestValidationMiddleware limits request body size to 10 MiB and enforces
-// application/json Content-Type on mutating requests (POST, PUT, PATCH).
+// application/json Content-Type on mutating requests (POST, PUT, PATCH),
+// except for paths in nonJSONContentTypeExemptPaths which handle their
+// own content negotiation.
 func requestValidationMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		const maxBodySize = 10 * 1024 * 1024
 		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 
 		if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
-			ct := r.Header.Get("Content-Type")
-			if ct == "" {
-				writeValidationError(w, r, "Content-Type header is required for "+r.Method+" requests")
-				return
-			}
-			if !mediaTypeEquals(ct, "application/json") {
-				writeValidationError(w, r, "Content-Type must be application/json, got: "+ct)
-				return
+			if _, exempt := nonJSONContentTypeExemptPaths[r.URL.Path]; !exempt {
+				ct := r.Header.Get("Content-Type")
+				if ct == "" {
+					writeValidationError(w, r, "Content-Type header is required for "+r.Method+" requests")
+					return
+				}
+				if !mediaTypeEquals(ct, "application/json") {
+					writeValidationError(w, r, "Content-Type must be application/json, got: "+ct)
+					return
+				}
 			}
 		}
 

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -86,10 +87,19 @@ type Server struct {
 	workerCancel  context.CancelFunc
 
 	// Extensibility
-	mu              sync.RWMutex
-	claimsEnrichers []ClaimsEnricher
-	adminAuthState  *middlewareHolder
-	globalMWState   *middlewareHolder
+	mu                 sync.RWMutex
+	claimsEnrichers    []ClaimsEnricher
+	principalResolvers []namedPrincipalResolver
+	adminAuthState     *middlewareHolder
+	globalMWState      *middlewareHolder
+}
+
+// namedPrincipalResolver pairs a registered PrincipalResolver with the
+// deployer-supplied name used in /oauth2/authorize logs and metrics.
+// Stored in registration order so the chain walk is deterministic.
+type namedPrincipalResolver struct {
+	name string
+	fn   PrincipalResolver
 }
 
 // NewServer initializes all ZeroID subsystems: database, migrations, signing keys,
@@ -401,6 +411,12 @@ func NewServer(cfg Config) (*Server, error) {
 	// resolved.
 	srv.cleanupWorker.SetIdentityExpirer(identitySvc)
 
+	// Hand the principal-resolver chain walker to the API handler. The
+	// handler invokes this on every /oauth2/authorize request to walk
+	// the resolvers registered via Server.RegisterPrincipalResolver.
+	// Wired here (not in NewAPI) so srv exists for the method binding.
+	apiHandler.SetPrincipalResolverFunc(srv.resolvePrincipal)
+
 	return srv, nil
 }
 
@@ -532,6 +548,93 @@ func (s *Server) OnClaimsIssue(enricher ClaimsEnricher) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.claimsEnrichers = append(s.claimsEnrichers, enricher)
+}
+
+// RegisterPrincipalResolver registers a PrincipalResolver against the
+// /oauth2/authorize endpoint. Resolvers are tried in registration order;
+// the first to return a non-nil Principal wins. name is used for
+// log/metric attribution and must be non-empty.
+//
+// Typical usage from a deployer that owns api_key resolution:
+//
+//	srv.RegisterPrincipalResolver("api_key", func(ctx context.Context, req *zeroid.AuthorizeRequest) (*zeroid.Principal, error) {
+//	    key := req.Form("api_key")
+//	    if key == "" {
+//	        return nil, zeroid.ErrPrincipalNotApplicable
+//	    }
+//	    res, err := srv.ResolveAPIKey(ctx, key)
+//	    if err != nil {
+//	        return nil, err
+//	    }
+//	    return &zeroid.Principal{
+//	        AccountID: res.AccountID,
+//	        ProjectID: res.ProjectID,
+//	        UserID:    res.UserID,
+//	        Scopes:    res.Scopes,
+//	    }, nil
+//	})
+//
+// Safe to call after NewServer and before Start. Multiple resolvers are
+// supported — register the most-specific first (e.g. session cookie
+// before api_key fallback) because order determines precedence on
+// overlapping requests.
+func (s *Server) RegisterPrincipalResolver(name string, r PrincipalResolver) {
+	if name == "" || r == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.principalResolvers = append(s.principalResolvers, namedPrincipalResolver{name: name, fn: r})
+}
+
+// resolvePrincipal walks the registered PrincipalResolver chain in
+// registration order, returning the first non-nil Principal. The
+// matchedName return is the resolver name that produced the Principal —
+// used by the /oauth2/authorize handler for log attribution.
+//
+// Errors:
+//   - All resolvers returning ErrPrincipalNotApplicable → returns
+//     (nil, "", nil). Caller (the authorize handler) maps this to a
+//     401 invalid_client.
+//   - Any resolver returning a non-sentinel error → returns
+//     (nil, resolverName, err). The chain stops at the first such
+//     error; caller surfaces it as 401 invalid_client with the
+//     resolver's description.
+//   - No resolvers registered → returns (nil, "", nil). Handler maps
+//     to 503 — the deployer never wired this up.
+func (s *Server) resolvePrincipal(ctx context.Context, req *AuthorizeRequest) (*Principal, string, error) {
+	s.mu.RLock()
+	resolvers := make([]namedPrincipalResolver, len(s.principalResolvers))
+	copy(resolvers, s.principalResolvers)
+	s.mu.RUnlock()
+
+	for _, r := range resolvers {
+		p, err := r.fn(ctx, req)
+		if err != nil {
+			if errors.Is(err, ErrPrincipalNotApplicable) {
+				continue
+			}
+			return nil, r.name, err
+		}
+		if p != nil {
+			return p, r.name, nil
+		}
+		// nil principal + nil error: defensive — treat as "not applicable"
+		// rather than returning a nil Principal that downstream would
+		// have to nil-check anyway.
+	}
+
+	return nil, "", nil
+}
+
+// hasPrincipalResolvers reports whether any PrincipalResolver has been
+// registered. Used by the /oauth2/authorize handler to distinguish a
+// "deployer never wired the endpoint" 503 from a "credential rejected"
+// 401, so embedders get a clear setup-error message in the former case.
+func (s *Server) hasPrincipalResolvers() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.principalResolvers) > 0
 }
 
 // AdminAuth sets an optional authentication middleware for admin routes.
@@ -943,6 +1046,15 @@ var OAuthFormEndpoints = map[string]struct{}{
 	"/oauth2/token/introspect": {},
 	"/oauth2/token/revoke":     {},
 	"/oauth2/bc-authorize":     {},
+	// /oauth2/authorize is intentionally NOT here. Its handler is a
+	// plain chi route (not Huma) — see internal/handler/authorize.go —
+	// because the endpoint's principal-credential field set is
+	// resolver-dependent (api_key today, session cookie / mTLS
+	// tomorrow) and doesn't fit a static OpenAPI input schema. The
+	// chi handler parses the raw application/x-www-form-urlencoded
+	// body directly; routing it through this middleware would rewrite
+	// the form to JSON before the handler sees it, breaking form
+	// access.
 }
 
 // jsonShapedFormFields are OAuth form parameters whose value is itself JSON

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -290,6 +290,32 @@ func runTests(m *testing.M) int {
 		return "", fmt.Errorf("caller is not a trusted service")
 	})
 
+	// Stub PrincipalResolver for /oauth2/authorize tests. Reads its
+	// behaviour from magic form fields so a single resolver covers
+	// every test shape (happy path, not-applicable, rejected). Tests
+	// that don't hit /oauth2/authorize never trigger it.
+	//
+	// Form-field protocol:
+	//   test_principal_account → AccountID (required to "apply")
+	//   test_principal_project → ProjectID
+	//   test_principal_user    → UserID
+	//   test_principal_reject  → "true" returns a non-sentinel error
+	//   (anything else)        → ErrPrincipalNotApplicable
+	srv.RegisterPrincipalResolver("test-stub", func(_ context.Context, req *zeroid.AuthorizeRequest) (*zeroid.Principal, error) {
+		if req.Form("test_principal_reject") == "true" {
+			return nil, fmt.Errorf("stub resolver: deliberate rejection for test")
+		}
+		acct := req.Form("test_principal_account")
+		if acct == "" {
+			return nil, zeroid.ErrPrincipalNotApplicable
+		}
+		return &zeroid.Principal{
+			AccountID: acct,
+			ProjectID: req.Form("test_principal_project"),
+			UserID:    req.Form("test_principal_user"),
+		}, nil
+	})
+
 	testServer = httptest.NewServer(srv.Router())
 	defer testServer.Close()
 

--- a/tests/integration/oauth_authorize_test.go
+++ b/tests/integration/oauth_authorize_test.go
@@ -1,0 +1,375 @@
+// /oauth2/authorize integration tests — the upstream half of the
+// authorization_code grant. Exercises the new endpoint end-to-end:
+// register a stub PrincipalResolver (see helpers_test.go TestMain),
+// POST form-encoded params, assert 302 with the code in the
+// Location query, exchange the code at /oauth2/token, and verify
+// the resulting access token carries the resolver-supplied tenant
+// context.
+//
+// The decoder/consumer side at /oauth2/token is covered by
+// authorization_code_test.go and pkce_compliance_test.go; this file
+// covers the mint + resolve side that those tests previously couldn't
+// exercise (no /oauth2/authorize existed).
+
+package integration_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// postAuthorize posts form-encoded values to /oauth2/authorize and
+// returns the raw response. Form encoding (not JSON) because the
+// /oauth2/authorize handler is a plain chi route that reads
+// r.PostForm directly — see internal/handler/authorize.go.
+//
+// follow=false because the endpoint always 302s on success and we want
+// to assert on the Location header.
+func postAuthorize(t *testing.T, form url.Values) *http.Response {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, testServer.URL+"/oauth2/authorize",
+		strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	client := &http.Client{
+		// Don't follow redirects — we assert on the 302.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// authorizeBaseForm returns the minimum required form values for a
+// /oauth2/authorize POST, plus the matching PKCE verifier so tests can
+// exchange the resulting code at /oauth2/token. Tests add /override
+// fields as needed.
+func authorizeBaseForm(t *testing.T) (form url.Values, verifier string) {
+	t.Helper()
+	verifier, challenge := buildPKCEPair(t)
+	form = url.Values{
+		"client_id":             {testCLIClientID},
+		"redirect_uri":          {testRedirectURI},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"test-state-abc"},
+		// Stub PrincipalResolver — see TestMain in helpers_test.go.
+		"test_principal_account": {testAccountID},
+		"test_principal_project": {testProjectID},
+		"test_principal_user":    {"user-authorize-test"},
+	}
+	return form, verifier
+}
+
+// TestAuthorize_HappyPath is the load-bearing integration test for the
+// new endpoint. Walks the full /oauth2/authorize → /oauth2/token flow:
+//
+//  1. POST /oauth2/authorize with PKCE form + resolver-credential
+//     fields → expect 302 with Location: redirect_uri?code=...&state=...
+//  2. Extract the code, post it to /oauth2/token with the matching
+//     verifier → expect 200 with access_token
+//  3. Decode the access token and pin the tenant context the resolver
+//     produced (account_id, project_id, sub)
+func TestAuthorize_HappyPath(t *testing.T) {
+	form, verifier := authorizeBaseForm(t)
+
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusFound, resp.StatusCode,
+		"expected 302 from /oauth2/authorize")
+
+	loc := resp.Header.Get("Location")
+	require.NotEmpty(t, loc, "302 must carry Location header")
+
+	u, err := url.Parse(loc)
+	require.NoError(t, err)
+	require.Equal(t, testRedirectURI,
+		(&url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path}).String(),
+		"Location host+path must match redirect_uri exactly")
+
+	code := u.Query().Get("code")
+	state := u.Query().Get("state")
+	require.NotEmpty(t, code, "Location must carry ?code=")
+	require.Equal(t, "test-state-abc", state,
+		"state must round-trip unchanged (RFC 6749 §4.1.1 CSRF chain)")
+
+	// Cache-Control: no-store per RFC 6749 §5.1 — tokens (and codes)
+	// must not be cached by intermediaries.
+	assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+
+	// Step 2: exchange the code at /oauth2/token.
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testCLIClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode,
+		"code exchange must succeed (the code zeroid just minted must verify against zeroid's own decoder)")
+
+	tok := decode(t, tokenResp)
+	accessToken, _ := tok["access_token"].(string)
+	require.NotEmpty(t, accessToken)
+
+	// Step 3: introspect to pin the tenant context the resolver
+	// supplied flowed through to the access token unchanged.
+	intro := introspect(t, accessToken)
+	assert.True(t, intro["active"].(bool), "introspection must report active=true")
+	assert.Equal(t, testAccountID, intro["account_id"],
+		"account_id must match what the PrincipalResolver returned")
+	assert.Equal(t, testProjectID, intro["project_id"],
+		"project_id must match what the PrincipalResolver returned")
+	assert.Equal(t, "user-authorize-test", intro["sub"],
+		"sub must match the resolver-supplied UserID")
+}
+
+// TestAuthorize_StateOmitted pins the state-handling contract: when
+// the caller omits state, the redirect Location must NOT carry a
+// state= query param at all (vs. carrying state=""). Some clients
+// distinguish missing vs empty when assembling their CSRF chain.
+func TestAuthorize_StateOmitted(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	form.Del("state")
+
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	u, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	_, present := u.Query()["state"]
+	assert.False(t, present, "Location must not include state= when caller omitted it")
+}
+
+// TestAuthorize_MissingRequiredFields walks every required form field
+// and pins that omitting it produces a 400 invalid_request response
+// with a per-field error_description. Validates the handler-layer
+// required-field gate (Step 3 in authorizeHandler), which provides
+// actionable feedback before any DB hit.
+func TestAuthorize_MissingRequiredFields(t *testing.T) {
+	cases := []struct {
+		field       string
+		wantDescSub string
+	}{
+		{"client_id", "client_id is required"},
+		{"redirect_uri", "redirect_uri is required"},
+		{"code_challenge", "code_challenge is required"},
+		{"code_challenge_method", "code_challenge_method is required"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.field, func(t *testing.T) {
+			form, _ := authorizeBaseForm(t)
+			form.Del(tc.field)
+			resp := postAuthorize(t, form)
+			defer func() { _ = resp.Body.Close() }()
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+				"missing %s must return 400", tc.field)
+			body := decode(t, resp)
+			assert.Equal(t, "invalid_request", body["error"])
+			desc, _ := body["error_description"].(string)
+			assert.Contains(t, desc, tc.wantDescSub,
+				"error_description must mention the missing field")
+		})
+	}
+}
+
+// TestAuthorize_NonS256ChallengeMethod pins that plain (deprecated,
+// removed in OAuth 2.1) is rejected. Misconfigured CLI clients cannot
+// downgrade themselves silently.
+func TestAuthorize_NonS256ChallengeMethod(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	form.Set("code_challenge_method", "plain")
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_request", body["error"])
+	desc, _ := body["error_description"].(string)
+	assert.Contains(t, desc, "S256")
+}
+
+// TestAuthorize_NonCodeResponseType pins that response_type values
+// other than "code" are rejected — we only support authorization_code,
+// and silently accepting an unknown response_type would set the
+// caller's expectations wrong about what flow is in play.
+func TestAuthorize_NonCodeResponseType(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	form.Set("response_type", "token")
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// TestAuthorize_UnknownClient pins that an unregistered client_id is
+// rejected at the IssueAuthCode-side client lookup (Step 6 in
+// authorizeHandler delegates to OAuthService.IssueAuthCode →
+// oauthClientSvc.GetPublicClient). 401 invalid_client matches the
+// /oauth2/token contract for the same condition.
+func TestAuthorize_UnknownClient(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	form.Set("client_id", "nonexistent-client-id")
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_client", body["error"])
+}
+
+// TestAuthorize_RedirectURIMismatch pins that a redirect_uri not in
+// the client's pre-registered list is rejected. This is the gate that
+// prevents an attacker who stole a code from redirecting it to their
+// own callback.
+func TestAuthorize_RedirectURIMismatch(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	form.Set("redirect_uri", "https://attacker.example.com/callback")
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_request", body["error"])
+	desc, _ := body["error_description"].(string)
+	assert.Contains(t, desc, "redirect_uri")
+}
+
+// TestAuthorize_RedirectURILoopbackEquivalence pins the RFC 8252 §7.3
+// loopback equivalence rule: 127.0.0.1 and localhost are interchangeable
+// for native-app callbacks. The CLI registers one form; the user might
+// hit the other depending on their /etc/hosts.
+func TestAuthorize_RedirectURILoopbackEquivalence(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	// testRedirectURI registers "http://localhost:9999/callback"
+	// (see helpers_test.go constant); hit the 127.0.0.1 form.
+	form.Set("redirect_uri", "http://127.0.0.1:9999/callback")
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusFound, resp.StatusCode,
+		"127.0.0.1 form must be accepted when localhost form is registered (RFC 8252 §7.3)")
+}
+
+// TestAuthorize_NoPrincipalMatched pins the chain-end behavior: when
+// every registered resolver returns ErrPrincipalNotApplicable (in this
+// test setup, that means the caller didn't supply
+// test_principal_account), the handler returns 401 invalid_client with
+// the "no applicable credential" description.
+func TestAuthorize_NoPrincipalMatched(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	// Remove the magic field that makes the stub resolver match.
+	form.Del("test_principal_account")
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_client", body["error"])
+	desc, _ := body["error_description"].(string)
+	assert.Contains(t, desc, "no applicable credential")
+}
+
+// TestAuthorize_ResolverError pins the non-sentinel-error path: when a
+// resolver matches the request but rejects the credential (e.g. an
+// api_key is present but invalid), the chain stops and the handler
+// returns 401 invalid_client. The specific error from the resolver is
+// logged but NOT surfaced to the caller (to avoid leaking which
+// resolver path matched).
+func TestAuthorize_ResolverError(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	form.Set("test_principal_reject", "true")
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_client", body["error"])
+	desc, _ := body["error_description"].(string)
+	assert.Equal(t, "credential rejected", desc,
+		"the resolver's specific error must not leak — handler returns a generic description")
+}
+
+// TestAuthorize_IssuedCodeShapeMatchesDecoder pins the issuance side
+// of the contract more directly than the happy-path test: extract the
+// minted JWT and parse it with the same HS256 + issuer args that
+// /oauth2/token uses internally (decodeAuthCodeJWT). If issuance ever
+// drifts from the decoder's expectations, this test surfaces it before
+// the exchange test would.
+func TestAuthorize_IssuedCodeShapeMatchesDecoder(t *testing.T) {
+	form, _ := authorizeBaseForm(t)
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	u, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	code := u.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	tok, err := jwt.Parse([]byte(code),
+		jwt.WithKey(jwa.HS256(), []byte(testHMACSecret)),
+		jwt.WithValidate(true),
+	)
+	require.NoError(t, err, "minted code must verify under the same HMAC + issuer the decoder uses")
+
+	iss, _ := tok.Issuer()
+	sub, _ := tok.Subject()
+	jti, _ := tok.JwtID()
+
+	assert.Equal(t, testIssuer, iss, "iss claim must match cfg.Token.Issuer (AuthCodeIssuer defaults to it)")
+	assert.Equal(t, "auth-code", sub, "sub must be the auth-code sentinel string")
+	assert.NotEmpty(t, jti, "jti must be present — single-use enforcement at exchange depends on it")
+}
+
+// TestAuthorize_PKCERoundTrip pins the verifier→challenge round-trip
+// works end-to-end: build a verifier, derive the challenge, post to
+// /oauth2/authorize, exchange the resulting code with the same
+// verifier. This is the integration-level counterpart to the unit
+// test mintAuthCodeJWT_RoundTripsThroughDecoder.
+func TestAuthorize_PKCERoundTrip(t *testing.T) {
+	verifier := strings.Repeat("a", 64) // RFC 7636 allows 43-128
+	hash := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(hash[:])
+
+	form := url.Values{
+		"client_id":              {testCLIClientID},
+		"redirect_uri":           {testRedirectURI},
+		"response_type":          {"code"},
+		"code_challenge":         {challenge},
+		"code_challenge_method":  {"S256"},
+		"test_principal_account": {testAccountID},
+		"test_principal_project": {testProjectID},
+		"test_principal_user":    {"user-pkce-round-trip"},
+	}
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	u, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	code := u.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	exchangeResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testCLIClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	defer func() { _ = exchangeResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, exchangeResp.StatusCode)
+}


### PR DESCRIPTION
## Summary

Adds the upstream half of the OAuth 2.0 + RFC 7636 PKCE `authorization_code` grant — `POST /oauth2/authorize` — that mints the auth-code JWT zeroid already consumes at `/oauth2/token`. Closes the asymmetry where zeroid owned `decodeAuthCodeJWT` + `authCodeRepo.Consume` but never shipped the issuance side.

Together with the new `PrincipalResolver` hook (peer of `ClaimsEnricher`, `GrantHandler`, `BackchannelNotifier`), deployers can plug zeroid into any principal-authentication source (`api_key` today, browser session / mTLS / SPIFFE chain tomorrow) without forking the OAuth contract.

## New public surface (zeroid top-level)

```go
// Hooks
type Principal struct {
    AccountID, ProjectID, UserID, OrgID string
    Scopes []string
}

type AuthorizeRequest struct {
    ClientID, RedirectURI, ResponseType,
    CodeChallenge, CodeChallengeMethod,
    State, Scope string
    Form, Header, Cookie func(name string) string
}

type PrincipalResolver func(ctx context.Context, req *AuthorizeRequest) (*Principal, error)
var  ErrPrincipalNotApplicable = errors.New(...)

// Server
func (s *Server) RegisterPrincipalResolver(name string, r PrincipalResolver)
```

## New public surface (service package)

```go
// Authorization-code issuance (the missing half)
type IssueAuthCodeRequest struct {
    ClientID, RedirectURI, CodeChallenge, CodeChallengeMethod string
    AccountID, ProjectID, UserID, OrgID string
    Scopes []string
}
func (s *OAuthService) IssueAuthCode(ctx context.Context, req IssueAuthCodeRequest) (string, error)

// API-key resolution (extracted from apiKeyGrant via refactor — no duplicate logic)
type APIKeyResolution struct {
    AccountID, ProjectID, UserID, KeyID string
    Scopes []string
}
func (s *OAuthService) ResolveAPIKey(ctx context.Context, apiKey string) (*APIKeyResolution, error)
```

## Design decisions worth flagging

- **`AuthorizeRequest` is a typed snapshot, not `*http.Request`.** Resolvers see typed `Form`/`Header`/`Cookie` accessors; never net/http. Keeps the hook consistent with zeroid's existing typed-input pattern (`TokenRequest`, `BcAuthorizeInput`) instead of letting one hook leak transport details.
- **`ResolveAPIKey` returns a narrow `APIKeyResolution`, not `*domain.Identity`.** The full Identity stays internal (`apiKeyContext`); public callers get a stable projection that doesn't break if the Identity struct changes.
- **`/oauth2/authorize` is a chi route, not Huma.** The endpoint is 302-on-success with a resolver-dependent principal-credential field set — neither shape fits a static JSON I/O schema cleanly. Mirrors `/oauth2/token/verify` which is also chi-not-Huma.
- **`Principal`, `AuthorizeRequest`, `PrincipalResolver` are defined in `internal/service` and aliased at zeroid top level.** Necessary because `internal/handler` can't import the top-level `zeroid` package (circular). Aliases (`type Principal = service.Principal`) make the public API identical.
- **`/oauth2/authorize` is intentionally NOT in `OAuthFormEndpoints`.** That middleware rewrites form→JSON for Huma handlers; my chi handler reads the form-encoded body directly.

## Refactor: `apiKeyGrant` → `resolveAPIKeyContext` + grant-specific work

`apiKeyGrant` was 125 lines doing both api_key resolution AND token minting. Extracted the resolution piece (~50 lines) into `resolveAPIKeyContext`, which both `apiKeyGrant` and the new public `ResolveAPIKey` call. No behaviour change for `apiKeyGrant` — same lookup, same identity-state checks, same error shapes.

## Validation gates in `IssueAuthCode`

Each enforced before any DB hit / JWT mint:

1. Required fields: `client_id`, `redirect_uri`, `code_challenge`, `code_challenge_method`, `account_id`
2. `code_challenge_method` MUST be `S256` (plain rejected — RFC 7636 §4.2 deprecation + OAuth 2.1 removal)
3. HMAC secret must be configured (defensive 500 if not)
4. Client exists + is active (`oauthClientSvc.GetPublicClient`)
5. Client has `authorization_code` in its registered `grant_types`
6. `redirect_uri` matches one of the client's registered URIs (`normalizeLoopback` for RFC 8252 §7.3 equivalence)
7. Scope intersection: requested ∩ client's registered scopes

Same checks `authorizationCode` (the consume side) runs at exchange time — applied here too so a client without the grant cannot even obtain a code, not just fail at exchange.

## Tests

**Unit** — `internal/service/authcode_issue_test.go` (5 tests, pure, no DB):
- `TestMintAuthCodeJWT_RoundTripsThroughDecoder` — load-bearing contract pin
- `TestMintAuthCodeJWT_OptionalClaimsOmittedWhenEmpty`
- `TestMintAuthCodeJWT_RejectsMissingRequiredFields` (table-driven)
- `TestMintAuthCodeJWT_RespectsCustomJTI`
- `TestMintAuthCodeJWT_DefaultExpHonoursAuthCodeTTL`
- `TestRedirectURIAllowed` (table-driven)

**Integration** — `tests/integration/oauth_authorize_test.go` (11 tests, real Postgres via testcontainers):
- `TestAuthorize_HappyPath` — full mint → exchange → introspect round-trip
- `TestAuthorize_StateOmitted` — state= absence vs empty string
- `TestAuthorize_MissingRequiredFields` (table-driven on every required form field)
- `TestAuthorize_NonS256ChallengeMethod`
- `TestAuthorize_NonCodeResponseType`
- `TestAuthorize_UnknownClient`
- `TestAuthorize_RedirectURIMismatch`
- `TestAuthorize_RedirectURILoopbackEquivalence`
- `TestAuthorize_NoPrincipalMatched` (chain-end with `ErrPrincipalNotApplicable`)
- `TestAuthorize_ResolverError` (non-sentinel error path)
- `TestAuthorize_IssuedCodeShapeMatchesDecoder` — explicit JWT shape pin
- `TestAuthorize_PKCERoundTrip` — extra verifier→challenge round-trip

A stub `PrincipalResolver` is registered in `TestMain` reading magic `test_principal_*` form fields so a single resolver covers every test shape without per-test registration.

## Migration notes for consumers

`highflame-authn` is the first consumer. Today its `highflame-authn#93` PR (currently in draft) carries its own `IssueAuthCode` + `/oauth2/authorize` handler — that will be replaced by:

- A ~30-line `api_key` `PrincipalResolver` in authn that calls `zeroid.ResolveAPIKey` and projects to `*zeroid.Principal`
- A one-line `srv.RegisterPrincipalResolver("api_key", resolver)` in authn's `cmd/server/main.go`
- Deletion of the duplicate `IssueAuthCode` + ugly `httptest.NewRecorder` roundtrip currently in authn

The companion regression test (`highflame-regression#85`) doesn't change — same wire contract.

## Test plan

- [ ] CI passes (golangci-lint + unit + integration with testcontainers)
- [ ] Spot-check OpenAPI spec — `/oauth2/authorize` is intentionally absent from it (chi route); document this in CHANGELOG if reviewers want it
- [ ] Review the `PrincipalResolver` abstraction — does it cover the cases zeroid wants to support for v2 (browser session, mTLS, SPIFFE chain)?
- [ ] Review the refactor of `apiKeyGrant` — no behaviour change intended; the test suite should catch any regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)