### PR TITLE
devops: tag pkg/dpop sub-module on release alongside pkg/authjwt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,18 +97,35 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Tag pkg/authjwt sub-module
+      # Each entry below is a nested Go module (its own go.mod under
+      # the repo root) and must be tagged independently of the root —
+      # Go's module proxy resolves `go get github.com/highflame-ai/
+      # zeroid/<subpath>@vX.Y.Z` against a `<subpath>/vX.Y.Z` tag, not
+      # the root `vX.Y.Z` tag. Without these tags, downstream consumers
+      # cannot pin a specific version of the sub-module.
+      #
+      # Idempotent — skips tags that already exist (handles re-runs
+      # of a published release, and out-of-band manual tags). To add
+      # another sub-module, append it to the loop and confirm it has a
+      # go.mod at that path.
+      - name: Tag sub-modules
         shell: bash
         run: |
           VERSION="${{ env.RELEASE_NAME }}"
-          SUBTAG="pkg/authjwt/${VERSION}"
-          if git rev-parse "${SUBTAG}" >/dev/null 2>&1; then
-            echo "Tag ${SUBTAG} already exists, skipping"
-          else
-            git tag "${SUBTAG}"
-            git push origin "${SUBTAG}"
-            echo "Created and pushed tag ${SUBTAG}"
-          fi
+          SUBMODULES=(
+            pkg/authjwt
+            pkg/dpop
+          )
+          for SUBMODULE in "${SUBMODULES[@]}"; do
+            SUBTAG="${SUBMODULE}/${VERSION}"
+            if git rev-parse "${SUBTAG}" >/dev/null 2>&1; then
+              echo "Tag ${SUBTAG} already exists, skipping"
+            else
+              git tag "${SUBTAG}"
+              git push origin "${SUBTAG}"
+              echo "Created and pushed tag ${SUBTAG}"
+            fi
+          done
 
   highflame-sast:
     needs:


### PR DESCRIPTION
## Summary

The release workflow's `tag-submodules` job hardcoded `pkg/authjwt` only. When [#174](https://github.com/highflame-ai/zeroid/pull/174) landed `pkg/dpop` as a separate Go module (its own `go.mod` declaring `github.com/highflame-ai/zeroid/pkg/dpop`), it never extended this job — so every release since has silently skipped tagging dpop.

**Why this matters:** Go's module proxy resolves `go get github.com/highflame-ai/zeroid/pkg/dpop@vX.Y.Z` against a `pkg/dpop/vX.Y.Z` tag, **not** the root `vX.Y.Z` tag. Without sub-module tags, downstream consumers can't pin a version. A `pkg/dpop/v1.5.3` tag exists today because someone created it manually out-of-band — that's evidence of the gap, not a fix.

## Change

Generalises the single hardcoded step into a loop:

```bash
SUBMODULES=(
  pkg/authjwt
  pkg/dpop
)
for SUBMODULE in "${SUBMODULES[@]}"; do
  SUBTAG="${SUBMODULE}/${VERSION}"
  if git rev-parse "${SUBTAG}" >/dev/null 2>&1; then
    echo "Tag ${SUBTAG} already exists, skipping"
  else
    git tag "${SUBTAG}"
    git push origin "${SUBTAG}"
    echo "Created and pushed tag ${SUBTAG}"
  fi
done
```

Same idempotent skip-if-exists pattern as before. Same default checkout token. Same `permissions: contents: write`. No behaviour change for `pkg/authjwt` — the first iteration produces the identical commands the old single step ran.

## Sub-module inventory

Confirmed via `find pkg/ -name go.mod -maxdepth 2` — exactly two today:

- `pkg/authjwt/go.mod` ← already tagged on releases
- `pkg/dpop/go.mod` ← gap closed by this PR

To add a third in the future, append it to the `SUBMODULES` array and confirm it has a `go.mod` at that path.

## Test plan

- [ ] CI green (lint + workflow syntax)
- [ ] Verify on next release: both `pkg/authjwt/vX.Y.Z` and `pkg/dpop/vX.Y.Z` tags appear on the remote
- [ ] Spot-check: `go list -m github.com/highflame-ai/zeroid/pkg/dpop@vX.Y.Z` resolves from a clean module cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)