### PR TITLE
feat: carry mission_id across refresh-token rotation (issue #81)

### DIFF
--- a/domain/refresh_token.go
+++ b/domain/refresh_token.go
@@ -44,4 +44,12 @@ type RefreshToken struct {
 	// Copied verbatim onto every successor row on rotation; checked against
 	// the presented proof inside the rotation transaction (RFC 9449 §5).
 	DPoPKeyThumbprint string `bun:"dpop_key_thumbprint,nullzero" json:"-"`
+	// MissionID is the delegation-tree identifier (issue #81) of the access
+	// token this refresh family was minted alongside. Copied verbatim onto
+	// every successor row on rotation and read back when the refresh grant
+	// issues a new access token, so a refreshed token inherits the original
+	// mission instead of re-rooting it. nullzero ⇒ empty Go string round-trips
+	// as SQL NULL (pre-migration families, or flows that carried no mission_id);
+	// the refresh path falls back to re-rooting for those. Opaque to consumers.
+	MissionID string `bun:"mission_id,nullzero" json:"mission_id,omitempty"`
 }

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -1317,7 +1317,7 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 		identityPolicyID = policy.ID
 	}
 
-	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+	accessToken, cred, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:          identity,
 		IdentityPolicyID:  identityPolicyID,
 		GrantType:         domain.GrantTypeAuthorizationCode,
@@ -1349,6 +1349,10 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 			Scopes:            strings.Join(authCode.Scopes, " "),
 			TTL:               oauthClient.RefreshTokenTTL,
 			DPoPKeyThumbprint: req.DPoPKeyThumbprint,
+			// Seed the family with the access token's mission so every later
+			// rotation (and the access token each one mints) stays inside the
+			// same delegation tree (issue #81).
+			MissionID: cred.MissionID,
 		})
 		if rtErr != nil {
 			log.Error().Err(rtErr).Msg("Failed to issue refresh token — returning access token only")
@@ -1485,6 +1489,12 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 		TTL:               accessTTL,
 		Scopes:            parseScopeString(oldToken.Scopes),
 		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
+		// Inherit the mission from the refresh family rather than re-rooting
+		// it (issue #81). A refresh is continuity of an existing grant, not a
+		// new delegation tree. Empty when the family predates this column —
+		// IssueCredential then falls back to defaulting mission_id to the new
+		// credential's own JTI (the pre-fix behavior).
+		MissionID: oldToken.MissionID,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/refresh_token.go
+++ b/internal/service/refresh_token.go
@@ -52,6 +52,11 @@ type RefreshTokenParams struct {
 	// proof; every later rotation must present a proof signed by the same
 	// key. Empty ⇒ unbound (Bearer).
 	DPoPKeyThumbprint string
+	// MissionID is the delegation-tree identifier (issue #81) of the access
+	// token issued alongside this refresh token. Persisted on the family so
+	// every rotation can re-emit it, keeping a refreshing session inside one
+	// mission. Empty ⇒ no mission to carry (refresh falls back to re-rooting).
+	MissionID string
 }
 
 // ErrDPoPBindingMismatch is returned when a refresh-token rotation presents a
@@ -90,6 +95,7 @@ func (s *RefreshTokenService) IssueRefreshToken(ctx context.Context, params *Ref
 		State:             domain.RefreshTokenStateActive,
 		ExpiresAt:         expiresAt,
 		DPoPKeyThumbprint: params.DPoPKeyThumbprint,
+		MissionID:         params.MissionID,
 	}
 
 	if err := s.repo.Create(ctx, s.db, record); err != nil {
@@ -162,6 +168,11 @@ func (s *RefreshTokenService) RotateRefreshToken(ctx context.Context, rawToken s
 			// opt-in at original issuance. See docs/dpop-and-dcr.md
 			// "Refresh-token binding" for the full rationale.
 			DPoPKeyThumbprint: c.DPoPKeyThumbprint,
+			// Carry the delegation tree forward (issue #81). Without this the
+			// mission would survive the first refresh (seeded on the family at
+			// issuance) but be lost on the second rotation, re-fragmenting the
+			// tree. Copied verbatim like the DPoP thumbprint above.
+			MissionID: c.MissionID,
 		}
 		return s.repo.Create(ctx, tx, successor)
 	})

--- a/migrations/030_refresh_token_mission_id.down.sql
+++ b/migrations/030_refresh_token_mission_id.down.sql
@@ -1,0 +1,9 @@
+-- Dropping mission_id erases the delegation-tree linkage for every active
+-- refresh-token family. After down + re-apply, refreshed access tokens will
+-- re-root their mission (the pre-#81-fix behavior) until each family is
+-- re-issued. No security impact — mission_id is an audit-correlation field —
+-- but workflow-scoped audit queries lose continuity across the gap.
+
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE refresh_tokens DROP COLUMN IF EXISTS mission_id;

--- a/migrations/030_refresh_token_mission_id.up.sql
+++ b/migrations/030_refresh_token_mission_id.up.sql
@@ -1,0 +1,29 @@
+-- 030_refresh_token_mission_id.up.sql
+-- Carry mission_id (issue #81) across refresh-token rotation.
+--
+-- A refresh is continuity of an existing grant, not the origination of a new
+-- delegation tree — yet today the refresh_token grant defaults mission_id to
+-- the freshly minted credential's own JTI, re-rooting the mission on every
+-- refresh and fragmenting a single workflow's delegation tree into N missions.
+-- That breaks workflow-scoped audit queries (GET /credentials?mission_id=) for
+-- any session that refreshes mid-flight.
+--
+-- This column persists the mission_id of the access token the refresh family
+-- was minted alongside, is copied to the successor row on every rotation, and
+-- is read back in refreshToken() so the refreshed access token inherits the
+-- original mission instead of starting a new one. NULL ⇒ pre-migration family
+-- (or a flow that never carried a mission_id); the refresh path falls back to
+-- today's re-root behavior for those.
+--
+-- Opaque value contract (issue #81): consumers MUST treat mission_id as opaque
+-- — do not assume it is a JTI, do not look up a credential by it.
+--
+-- No index: this column is only ever read alongside the row it lives on
+-- (claimed by token_hash, rotated within its family), never filtered on.
+--
+-- Lock posture: metadata-only ADD COLUMN on PG 11+ (nullable, no default).
+
+SET LOCAL lock_timeout = '3s';
+
+ALTER TABLE refresh_tokens
+    ADD COLUMN IF NOT EXISTS mission_id VARCHAR(255);

--- a/tests/integration/mission_id_test.go
+++ b/tests/integration/mission_id_test.go
@@ -129,6 +129,70 @@ func TestMissionID_ChainPropagation(t *testing.T) {
 		"credentials must be ordered root → leaves by delegation_depth")
 }
 
+// TestMissionID_SurvivesRefresh pins the issue #81 refresh-continuity
+// invariant: a refresh is continuity of an existing grant, not the
+// origination of a new delegation tree, so the refreshed access token must
+// inherit the original mission_id rather than re-rooting it.
+//
+// Regression guard for the refresh_token grant defaulting mission_id to the
+// freshly minted credential's own JTI — which fragmented a single workflow's
+// delegation tree into N missions, breaking GET /credentials?mission_id= for
+// any session that refreshed mid-flight.
+//
+// Flow (MCP client — issues refresh tokens):
+//
+//	authorization_code   → root mission (mission_id = access token's own jti)
+//	   └── refresh_token  → must carry the SAME mission_id   (touch-point: issuance seed)
+//	          └── refresh_token  → must STILL carry it       (touch-point: rotation copy)
+//
+// The second refresh is load-bearing: it proves mission_id is copied onto the
+// successor row on rotation, not merely seeded once at issuance.
+func TestMissionID_SurvivesRefresh(t *testing.T) {
+	// ── Step 1: authorization_code (MCP client) → access token + refresh token. ──
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, testMCPClientID, "user-mission-rt", testRedirectURI, challenge, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testMCPClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	initial := decode(t, resp)
+
+	rootMission := decodeJWTUnsafe(t, initial["access_token"].(string))["mission_id"].(string)
+	require.NotEmpty(t, rootMission, "authorization_code access token must carry a mission_id")
+	refreshToken := initial["refresh_token"].(string)
+
+	// ── Step 2: first refresh → mission_id must be inherited, not re-rooted. ──
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     testMCPClientID,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	refreshed := decode(t, resp)
+
+	refreshedMission := decodeJWTUnsafe(t, refreshed["access_token"].(string))["mission_id"]
+	assert.Equal(t, rootMission, refreshedMission,
+		"refreshed access token must inherit the original mission_id, not re-root it")
+	refreshToken2 := refreshed["refresh_token"].(string)
+
+	// ── Step 3: second refresh → mission_id must STILL hold (rotation copy). ──
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken2,
+		"client_id":     testMCPClientID,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	refreshed2 := decode(t, resp)
+
+	assert.Equal(t, rootMission, decodeJWTUnsafe(t, refreshed2["access_token"].(string))["mission_id"],
+		"mission_id must survive a second rotation — proves it is copied onto the successor row, not just seeded once")
+}
+
 // TestMissionID_RejectAmbiguousFilter pins the handler-level guard:
 // the new mission_id query is mutually exclusive with the existing
 // identity_id query. Both omitted = 400 (no dump-everything path).


### PR DESCRIPTION
## Summary

Follow-up to #123 (issue #81). Makes `mission_id` survive the `refresh_token` grant so a refreshing session stays inside one delegation tree.

**The bug.** A refresh is *continuity* of an existing grant, not the *origination* of a new delegation tree — yet `refresh_token` was treated as a first-issuance grant, so `IssueCredential` defaulted `mission_id` to the freshly minted credential's own JTI. Every refresh re-rooted the mission. Any session that refreshed mid-flight fragmented its single logical delegation tree into N separate missions, breaking workflow-scoped audit queries (`GET /credentials?mission_id=`) — the exact CoSAI "reconstruct a full workflow end-to-end" query #81 was built to make O(1).

Note this was *explicit* in #81 (refresh was listed among first-issuance grants), but #81's own motivation argues against it — fragmenting a workflow on refresh undercuts the audit goal. This PR corrects that line and records the decision here.

`token_exchange` already propagates `mission_id` correctly (#123), so pure agent→sub-agent→tool delegation trees were never affected — only sessions that refresh.

## Change

`mission_id` is already available at the refresh-issuance point: `IssueCredential` returns `(*AccessToken, *IssuedCredential, error)` and the `IssuedCredential` carries `.MissionID`. So this is plumbing it onto the refresh-token row and reading it back on rotation — no change to the `AccessToken` shape.

| File | Change |
|---|---|
| `migrations/030_refresh_token_mission_id.{up,down}.sql` | Nullable `mission_id VARCHAR(255)` on `refresh_tokens`. **No index** — read only alongside the row it lives on (claimed by `token_hash`, rotated within its family), never filtered. Metadata-only `ADD COLUMN`. Reversible. |
| `domain/refresh_token.go` | `MissionID string` with `nullzero` (empty Go string ⇄ SQL NULL), mirroring the existing `dpop_key_thumbprint` column. |
| `internal/service/refresh_token.go` | `RefreshTokenParams.MissionID`; `IssueRefreshToken` persists it; **`RotateRefreshToken` copies it onto the successor row** (same place the DPoP thumbprint is copied). |
| `internal/service/oauth.go` | authorization_code path captures `cred.MissionID` and seeds the family; `refreshToken()` passes `oldToken.MissionID` into the `IssueRequest` so the refreshed access token inherits the mission. |
| `tests/integration/mission_id_test.go` | `TestMissionID_SurvivesRefresh`: authorization_code → refresh → refresh, asserting `mission_id` stays equal to the root across **both** rotations. |

## Why two rotations in the test

The second refresh is load-bearing: seeding `mission_id` at issuance alone would make it survive the *first* refresh but be lost on the *second* (the successor row would carry NULL). The test pins the rotation-copy, not just the seed.

## Compatibility

- **Additive + nullable.** Pre-migration refresh families have `mission_id = NULL` → `refreshToken()` falls back to today's re-root behavior. No backfill; families age out via TTL. Same compat stance as #81.
- **No new index, no claim change, no `AccessToken` change.** `token_exchange` propagation untouched.
- `client_credentials` doesn't issue refresh tokens, so it's unaffected.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go build ./...` clean
- [x] `GOEXPERIMENT=jsonv2 go vet ./...` clean (typechecks the new integration test)
- [x] `go test ./pkg/... ./domain/... ./internal/...` — 145 pass
- [ ] Integration suite (`TestMissionID_SurvivesRefresh` + existing `TestMissionID_*`) — runs in CI (testcontainers; Docker unavailable on this machine, migration 030 applies fresh per run)