### PR TITLE
fix: credential-policy delete queried phantom api_keys table (500 on every delete)

### DIFF
--- a/internal/handler/credential_policy.go
+++ b/internal/handler/credential_policy.go
@@ -213,6 +213,15 @@ func (a *API) deletePolicyOp(ctx context.Context, input *PolicyIDInput) (*struct
 	}
 
 	if err := a.credentialPolicySvc.DeletePolicy(ctx, input.ID, tenant.AccountID, tenant.ProjectID); err != nil {
+		if errors.Is(err, service.ErrPolicyInUse) {
+			// Safe to surface: the delete dialog already tells the operator
+			// the policy is still attached to keys. Tenant-scoped query means
+			// no cross-tenant information leaks.
+			return nil, huma.Error409Conflict("credential policy is still in use by one or more service keys")
+		}
+		if errors.Is(err, service.ErrPolicyNotFound) {
+			return nil, huma.Error404NotFound("credential policy not found")
+		}
 		log.Error().Err(err).Str("policy_id", input.ID).Msg("failed to delete credential policy")
 		return nil, huma.Error500InternalServerError("failed to delete credential policy")
 	}

--- a/internal/service/credential_policy.go
+++ b/internal/service/credential_policy.go
@@ -23,6 +23,11 @@ var ErrPolicyViolation = errors.New("credential policy violation")
 // ErrPolicyNameConflict is returned when a policy with the same name already exists in the tenant.
 var ErrPolicyNameConflict = errors.New("credential policy with this name already exists")
 
+// ErrPolicyInUse is returned by DeletePolicy when the policy is still
+// referenced by one or more service keys. Maps to 409 Conflict at the HTTP
+// boundary — the delete is refused, the policy is left intact.
+var ErrPolicyInUse = errors.New("credential policy is still in use")
+
 // ErrInvalidPolicyField marks caller-fixable input errors emitted by
 // UpdatePolicy when the tri-state expires_at PATCH string fails to parse
 // (malformed RFC3339) or is backdated. Maps to 400 at the HTTP boundary.
@@ -276,9 +281,23 @@ func (s *CredentialPolicyService) UpdatePolicy(ctx context.Context, id, accountI
 	return policy, nil
 }
 
-// DeletePolicy deletes a credential policy if no identities reference it.
+// DeletePolicy deletes a credential policy if no service keys reference it.
+// It translates the store-layer sentinels into the service-layer sentinels the
+// handler maps to HTTP status codes:
+//   - ErrPolicyInUse     → still referenced by at least one service key (409)
+//   - ErrPolicyNotFound  → no policy with this id in the tenant (404)
 func (s *CredentialPolicyService) DeletePolicy(ctx context.Context, id, accountID, projectID string) error {
-	return s.repo.Delete(ctx, id, accountID, projectID)
+	err := s.repo.Delete(ctx, id, accountID, projectID)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, postgres.ErrCredentialPolicyInUse):
+		return fmt.Errorf("%w: %w", ErrPolicyInUse, err)
+	case errors.Is(err, postgres.ErrCredentialPolicyNotFound):
+		return ErrPolicyNotFound
+	default:
+		return err
+	}
 }
 
 // EnforcePolicy checks all six credential policy constraints against an issuance request.

--- a/internal/store/postgres/credential_policy.go
+++ b/internal/store/postgres/credential_policy.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,6 +10,15 @@ import (
 
 	"github.com/highflame-ai/zeroid/domain"
 )
+
+// ErrCredentialPolicyNotFound is returned by Delete when no policy matches the
+// id within the caller's tenant (including cross-tenant attempts, which are
+// indistinguishable from a truly-absent policy by design).
+var ErrCredentialPolicyNotFound = errors.New("credential policy not found")
+
+// ErrCredentialPolicyInUse is returned by Delete when one or more service keys
+// still reference the policy. The policy is left intact.
+var ErrCredentialPolicyInUse = errors.New("credential policy is still referenced by service keys")
 
 // CredentialPolicyRepository handles database operations for credential policies.
 type CredentialPolicyRepository struct {
@@ -84,11 +94,16 @@ func (r *CredentialPolicyRepository) GetDefaultByTenant(ctx context.Context, acc
 	return policy, nil
 }
 
-// Delete removes a credential policy. Returns an error if any API keys still reference it.
+// Delete removes a credential policy, scoped to tenant. It refuses to delete a
+// policy that is still referenced by any service key (returns
+// ErrCredentialPolicyInUse) and reports ErrCredentialPolicyNotFound when no
+// policy matches the id within the tenant.
 func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, projectID string) error {
-	// Check if any API keys reference this policy.
+	// Check whether any service key still references this policy. The keys
+	// table is service_keys (see migration 006); credential_policy_id, plus
+	// the account_id/project_id tenant scope, all live on that table.
 	count, err := r.db.NewSelect().
-		TableExpr("api_keys").
+		TableExpr("service_keys").
 		Where("credential_policy_id = ?", id).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
@@ -97,10 +112,10 @@ func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, 
 		return fmt.Errorf("failed to check policy references: %w", err)
 	}
 	if count > 0 {
-		return fmt.Errorf("credential policy is still referenced by %d API keys", count)
+		return fmt.Errorf("%w: referenced by %d service key(s)", ErrCredentialPolicyInUse, count)
 	}
 
-	_, err = r.db.NewDelete().
+	res, err := r.db.NewDelete().
 		TableExpr("credential_policies").
 		Where("id = ?", id).
 		Where("account_id = ?", accountID).
@@ -108,6 +123,13 @@ func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, 
 		Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to delete credential policy: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to read delete result: %w", err)
+	}
+	if n == 0 {
+		return ErrCredentialPolicyNotFound
 	}
 	return nil
 }

--- a/internal/store/postgres/credential_policy.go
+++ b/internal/store/postgres/credential_policy.go
@@ -99,11 +99,14 @@ func (r *CredentialPolicyRepository) GetDefaultByTenant(ctx context.Context, acc
 // ErrCredentialPolicyInUse) and reports ErrCredentialPolicyNotFound when no
 // policy matches the id within the tenant.
 func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, projectID string) error {
-	// Check whether any service key still references this policy. The keys
-	// table is service_keys (see migration 006); credential_policy_id, plus
-	// the account_id/project_id tenant scope, all live on that table.
+	// Check whether any service key still references this policy. Use the
+	// strongly-typed Bun model (domain.APIKey is bun:"table:service_keys",
+	// migration 006) rather than a string literal: the original bug was a
+	// hardcoded table-name typo, and Model() makes that class of error
+	// impossible. credential_policy_id plus the account_id/project_id tenant
+	// scope all live on service_keys.
 	count, err := r.db.NewSelect().
-		TableExpr("service_keys").
+		Model((*domain.APIKey)(nil)).
 		Where("credential_policy_id = ?", id).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
@@ -116,7 +119,7 @@ func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, 
 	}
 
 	res, err := r.db.NewDelete().
-		TableExpr("credential_policies").
+		Model((*domain.CredentialPolicy)(nil)).
 		Where("id = ?", id).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).

--- a/tests/integration/credential_policy_delete_test.go
+++ b/tests/integration/credential_policy_delete_test.go
@@ -1,0 +1,154 @@
+package integration_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// deleteCredentialPolicy issues DELETE /credential-policies/{id} and returns
+// the HTTP status code. Body is drained/closed so the shared client stays
+// healthy for subsequent requests.
+func deleteCredentialPolicy(t *testing.T, id string, headers map[string]string) int {
+	t.Helper()
+	resp := doRequest(t, http.MethodDelete, adminPath("/credential-policies/"+id), nil, headers)
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+// countServiceKeysForPolicy counts service_keys rows referencing the given
+// policy within a tenant, straight from the DB. Used to assert the reference
+// state the in-use guard reads — and to prove that once the reference is gone,
+// the policy deletes cleanly.
+func countServiceKeysForPolicy(t *testing.T, policyID, accountID, projectID string) int {
+	t.Helper()
+	n, err := testDB.NewSelect().
+		Model((*domain.APIKey)(nil)).
+		Where("credential_policy_id = ?", policyID).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Count(context.Background())
+	require.NoError(t, err)
+	return n
+}
+
+// TestDeleteCredentialPolicy_Unreferenced_Succeeds is the primary regression
+// for the phantom-table bug. Before the fix, the Delete reference-check ran
+// `SELECT count(*) FROM api_keys` — a table that does not exist — so EVERY
+// credential-policy delete failed with a Postgres "relation api_keys does not
+// exist" error that the handler mapped to 500. The keys table is service_keys
+// (migration 006). With the fix, deleting an unreferenced policy returns 204.
+func TestDeleteCredentialPolicy_Unreferenced_Succeeds(t *testing.T) {
+	headers := adminHeaders()
+	headers["X-User-ID"] = "test-user"
+
+	policyID := createCredentialPolicy(t, uid("del-unref-cp"), headers)
+
+	status := deleteCredentialPolicy(t, policyID, headers)
+	assert.Equal(t, http.StatusNoContent, status,
+		"deleting an unreferenced credential policy must return 204 (regression: phantom api_keys table previously forced a 500)")
+
+	// A second delete of the now-absent policy must be a clean 404, not 500 —
+	// proves the not-found path is wired through the service/handler mapping.
+	status = deleteCredentialPolicy(t, policyID, headers)
+	assert.Equal(t, http.StatusNotFound, status,
+		"deleting an already-deleted policy must return 404")
+}
+
+// TestDeleteCredentialPolicy_InUse_Returns409 verifies the in-use path: a
+// policy still referenced by a service key cannot be deleted and the handler
+// returns 409 Conflict (not 500). Creating an API key with credential_policy_id
+// set writes a service_keys row referencing the policy — exactly the reference
+// the Delete guard must detect.
+func TestDeleteCredentialPolicy_InUse_Returns409(t *testing.T) {
+	headers := adminHeaders()
+	headers["X-User-ID"] = "test-user"
+
+	policyID := createCredentialPolicy(t, uid("del-inuse-cp"), headers)
+
+	// Create a key that references the policy → seeds a service_keys row.
+	resp := post(t, adminPath("/api-keys"), map[string]any{
+		"name":                 "del-inuse-key",
+		"product":              "del-inuse-test",
+		"credential_policy_id": policyID,
+	}, headers)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	require.Equal(t, 1, countServiceKeysForPolicy(t, policyID, testAccountID, testProjectID),
+		"precondition: exactly one service key should reference the policy")
+
+	status := deleteCredentialPolicy(t, policyID, headers)
+	assert.Equal(t, http.StatusConflict, status,
+		"deleting a policy still referenced by a service key must return 409 Conflict, not 500")
+
+	// The policy must still exist after a refused delete.
+	getResp := get(t, adminPath("/credential-policies/"+policyID), headers)
+	assert.Equal(t, http.StatusOK, getResp.StatusCode,
+		"a refused (409) delete must leave the policy intact")
+	_ = getResp.Body.Close()
+}
+
+// TestDeleteCredentialPolicy_AfterReferenceRemoved_Succeeds proves the in-use
+// guard is a real reference count, not an always-true short-circuit: once the
+// referencing service_keys row is gone, the same policy deletes cleanly (204).
+// The api-key surface only soft-revokes (the row, and its credential_policy_id,
+// survive a revoke), so we remove the reference at the DB layer via the test
+// bun handle the harness exposes for exactly this kind of repo-level setup.
+func TestDeleteCredentialPolicy_AfterReferenceRemoved_Succeeds(t *testing.T) {
+	headers := adminHeaders()
+	headers["X-User-ID"] = "test-user"
+
+	policyID := createCredentialPolicy(t, uid("del-freed-cp"), headers)
+
+	resp := post(t, adminPath("/api-keys"), map[string]any{
+		"name":                 "del-freed-key",
+		"product":              "del-freed-test",
+		"credential_policy_id": policyID,
+	}, headers)
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	created := decode(t, resp)
+	keyID := created["id"].(string)
+	require.NotEmpty(t, keyID)
+
+	// While referenced, delete is refused.
+	require.Equal(t, http.StatusConflict, deleteCredentialPolicy(t, policyID, headers))
+
+	// Remove the reference directly, then the policy must delete cleanly.
+	_, err := testDB.NewDelete().
+		Model((*domain.APIKey)(nil)).
+		Where("id = ?", keyID).
+		Exec(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, countServiceKeysForPolicy(t, policyID, testAccountID, testProjectID),
+		"precondition: reference must be gone before the clean-delete assertion")
+
+	assert.Equal(t, http.StatusNoContent, deleteCredentialPolicy(t, policyID, headers),
+		"once no service key references the policy, delete must return 204")
+}
+
+// TestDeleteCredentialPolicy_CrossTenant_NotFound verifies tenant isolation on
+// delete: tenant B cannot delete tenant A's policy, and gets a 404 (not a 403
+// or a 204) so existence in another tenant never leaks. Tenant A's policy must
+// remain intact.
+func TestDeleteCredentialPolicy_CrossTenant_NotFound(t *testing.T) {
+	tenantA := tenantHeaders("acct-del-cp-a-"+uid(""), "proj-del-cp-a-"+uid(""))
+	tenantB := tenantHeaders("acct-del-cp-b-"+uid(""), "proj-del-cp-b-"+uid(""))
+
+	policyID := createCredentialPolicy(t, uid("del-xtenant-cp"), tenantA)
+
+	status := deleteCredentialPolicy(t, policyID, tenantB)
+	assert.Equal(t, http.StatusNotFound, status,
+		"tenant B deleting tenant A's policy must get 404 — no cross-tenant deletion, no existence leak")
+
+	// Tenant A's policy must survive the cross-tenant delete attempt.
+	getResp := get(t, adminPath("/credential-policies/"+policyID), tenantA)
+	assert.Equal(t, http.StatusOK, getResp.StatusCode,
+		"cross-tenant delete attempt must not affect the owning tenant's policy")
+	_ = getResp.Body.Close()
+}


### PR DESCRIPTION
## The bug

`DELETE /credential-policies/{id}` returns **500 on every call** — deterministic, in production.

`CredentialPolicyRepository.Delete` ran its reference-check against a **table that does not exist**:

```go
count, err := r.db.NewSelect().
    TableExpr("api_keys").       // ← no such table
    Where("credential_policy_id = ?", id)...
```

The keys table is **`service_keys`** (migration `006_service_keys.up.sql`; `domain.APIKey` is `bun:"table:service_keys"`). So the count query failed with Postgres `relation "api_keys" does not exist` (SQLSTATE 42P01); the store returned that error, and `deletePolicyOp` mapped any non-nil error to `huma.Error500InternalServerError`. No credential policy could ever be deleted.

## Fix 1 — the table name (the actual bug)

`TableExpr("api_keys")` → `TableExpr("service_keys")`. `credential_policy_id` and the `account_id`/`project_id` tenant scope all exist on `service_keys`, so the existing tenant-scoped reference count is correct against the real table. Tenant scoping is unchanged.

## Fix 2 — correct status codes

500 is wrong for "still referenced" and "not found". Mirrors the create/update mapping already in this area:

- **store** (`internal/store/postgres/credential_policy.go`): adds `ErrCredentialPolicyInUse` (count > 0) and `ErrCredentialPolicyNotFound` (delete affected 0 rows, via `RowsAffected()`).
- **service** (`internal/service/credential_policy.go`): adds the `ErrPolicyInUse` sentinel (alongside `ErrPolicyNotFound`/`ErrPolicyNameConflict`); `DeletePolicy` translates the store sentinels — in-use → wrapped `ErrPolicyInUse`, no-row → `ErrPolicyNotFound`.
- **handler** (`internal/handler/credential_policy.go`): `errors.Is(err, ErrPolicyInUse)` → **409 Conflict**, `errors.Is(err, ErrPolicyNotFound)` → **404 Not Found**, default → 500.

Not-found returns **404** (matching the api-key revoke/delete convention in `handler/apikey.go`) so a cross-tenant id is indistinguishable from a truly-absent one — no existence leak. The 409 message states the policy is in use (safe to surface; the delete dialog already shows this). All queries stay tenant-scoped (`account_id` + `project_id`).

## Tests (none existed for Delete)

New `tests/integration/credential_policy_delete_test.go`, driven through the real HTTP surface against the testcontainers Postgres:

- **unreferenced → 204** — on the pre-fix code this fails with `relation "api_keys" does not exist` → 500 (verified by temporarily reverting the table name).
- **referenced by a service key → 409**, policy left intact (creating an API key with `credential_policy_id` seeds the `service_keys` row).
- **reference removed → 204** — proves the count is a real reference count, not an always-true short-circuit.
- **cross-tenant delete → 404**, owning tenant's policy untouched.

## Validation evidence

**zeroid**
- `go build ./...` + `go vet ./...` clean.
- `golangci-lint` set (govet, staticcheck, gofmt): govet + gofmt clean locally.
- `go test ./internal/...` green; full integration suite (`go test ./tests/integration/`) green (51s); new tests pass.
- Confirmed the new tests reproduce the bug: reverting `service_keys` → `api_keys` makes the unreferenced-delete test fail with the exact 42P01 error → 500.

**Downstream consumer (highflame-authn)** — validated locally with a temporary `replace github.com/highflame-ai/zeroid => ../zeroid` (since released versions hadn't bumped yet):
- `go build ./...` + `go vet ./...` clean.
- `go test ./...` green (incl. authn integration tests).
- The temporary `replace` was **reverted** — authn's `go.mod`/`go.sum` are back to pinning the published `v1.6.2`, working tree clean.

## Scope

Pure zeroid bug fix — table name + error mapping + tests. No product-specific (authn/aarm) references introduced. **authn's `v1.6.2` pin is NOT bumped here**: after this merges and a new zeroid version is released, a separate authn PR bumps the pin to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)