### PR TITLE
fix: GetGraph walks all credentials instead of only most recent

### DIFF
--- a/internal/service/delegation.go
+++ b/internal/service/delegation.go
@@ -144,6 +144,12 @@ func (s *DelegationService) GetGraph(ctx context.Context, identityID string, dep
 
 	// Walk every credential's delegation tree so the graph covers all
 	// mission chains, not just the most recent one.
+	//
+	// FIX: Previously only creds[0] (most recent) was walked, so identities
+	// with multiple credentials/missions only showed one tree in the graph.
+	// This loop fixes that but issues N×(WalkUp+WalkDown) queries — for
+	// identities with many credentials this may need rethinking (e.g. a
+	// single multi-root CTE, or pagination/lazy-load per mission).
 	var all []*domain.IssuedCredential
 	for _, c := range creds {
 		up, err := s.delegRepo.WalkUp(ctx, c.JTI, accountID, projectID, depth)

--- a/internal/service/delegation.go
+++ b/internal/service/delegation.go
@@ -150,6 +150,7 @@ func (s *DelegationService) GetGraph(ctx context.Context, identityID string, dep
 	// This loop fixes that but issues N×(WalkUp+WalkDown) queries — for
 	// identities with many credentials this may need rethinking (e.g. a
 	// single multi-root CTE, or pagination/lazy-load per mission).
+	seen := make(map[string]struct{})
 	var all []*domain.IssuedCredential
 	for _, c := range creds {
 		up, err := s.delegRepo.WalkUp(ctx, c.JTI, accountID, projectID, depth)
@@ -160,7 +161,18 @@ func (s *DelegationService) GetGraph(ctx context.Context, identityID string, dep
 		if err != nil {
 			return nil, err
 		}
-		all = mergeByJTI(all, mergeByJTI(up, down))
+		for _, item := range up {
+			if _, ok := seen[item.JTI]; !ok {
+				seen[item.JTI] = struct{}{}
+				all = append(all, item)
+			}
+		}
+		for _, item := range down {
+			if _, ok := seen[item.JTI]; !ok {
+				seen[item.JTI] = struct{}{}
+				all = append(all, item)
+			}
+		}
 	}
 
 	graph := s.buildGraph(ctx, all, accountID, projectID, identityID)

--- a/internal/service/delegation.go
+++ b/internal/service/delegation.go
@@ -142,21 +142,22 @@ func (s *DelegationService) GetGraph(ctx context.Context, identityID string, dep
 		}, nil
 	}
 
-	// creds is ordered issued_at DESC by ListByIdentity, so creds[0] is
-	// the most recent. Anchor the walk on its jti.
-	focal := creds[0]
-
-	up, err := s.delegRepo.WalkUp(ctx, focal.JTI, accountID, projectID, depth)
-	if err != nil {
-		return nil, err
+	// Walk every credential's delegation tree so the graph covers all
+	// mission chains, not just the most recent one.
+	var all []*domain.IssuedCredential
+	for _, c := range creds {
+		up, err := s.delegRepo.WalkUp(ctx, c.JTI, accountID, projectID, depth)
+		if err != nil {
+			return nil, err
+		}
+		down, err := s.delegRepo.WalkDown(ctx, c.JTI, accountID, projectID, depth)
+		if err != nil {
+			return nil, err
+		}
+		all = mergeByJTI(all, mergeByJTI(up, down))
 	}
-	down, err := s.delegRepo.WalkDown(ctx, focal.JTI, accountID, projectID, depth)
-	if err != nil {
-		return nil, err
-	}
 
-	merged := mergeByJTI(up, down)
-	graph := s.buildGraph(ctx, merged, accountID, projectID, identityID)
+	graph := s.buildGraph(ctx, all, accountID, projectID, identityID)
 	return graph, nil
 }
 

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -270,12 +270,9 @@ func TestDelegationGraph_DepthLimitsTheWalk(t *testing.T) {
 
 // TestDelegationGraph_MostRecentCredentialIsFocal pins the Option-B
 // design choice: when an identity participates in multiple unrelated
-// chains, GetGraph centers on the most recent credential and the older
-// chain is invisible.
-//
-// Without this guard the focal selection could silently flip between
-// chains as old credentials happen to sort differently.
-func TestDelegationGraph_MostRecentCredentialIsFocal(t *testing.T) {
+// chains, GetGraph now walks ALL credentials so every mission tree is
+// visible — not just the most recent one.
+func TestDelegationGraph_AllCredentialsVisible(t *testing.T) {
 	policyID := delegationPolicy(t, uid("focal-policy"), []string{"data:read"})
 
 	// Issue two unrelated root credentials for the same identity. Each
@@ -317,13 +314,14 @@ func TestDelegationGraph_MostRecentCredentialIsFocal(t *testing.T) {
 	body := decode(t, resp)
 
 	edges, _ := body["edges"].([]any)
-	require.Len(t, edges, 1,
-		"focal must walk only the most-recent credential's chain; the older chain is invisible")
-	gotJTI := edges[0].(map[string]any)["jti"].(string)
-	assert.Equal(t, jtiSecond, gotJTI,
-		"focal credential must be the most recent issuance")
-	assert.NotEqual(t, jtiFirst, gotJTI,
-		"older credential's chain must NOT be selected as focal")
+	require.Len(t, edges, 2,
+		"graph must include edges from both credentials / mission trees")
+	jtis := map[string]bool{}
+	for _, e := range edges {
+		jtis[e.(map[string]any)["jti"].(string)] = true
+	}
+	assert.True(t, jtis[jtiFirst], "first credential's edge must be in the graph")
+	assert.True(t, jtis[jtiSecond], "second credential's edge must be in the graph")
 }
 
 // TestDelegationGraph_RevokedCredentialAppears pins that the graph is

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -268,7 +268,7 @@ func TestDelegationGraph_DepthLimitsTheWalk(t *testing.T) {
 		"A's parent (orch) is beyond the depth cap; edge.from must be empty")
 }
 
-// TestDelegationGraph_MostRecentCredentialIsFocal pins the Option-B
+// TestDelegationGraph_AllCredentialsVisible pins the Option-B
 // design choice: when an identity participates in multiple unrelated
 // chains, GetGraph now walks ALL credentials so every mission tree is
 // visible — not just the most recent one.


### PR DESCRIPTION
## Problem

`GetGraph` only walked the **most recent credential** (`creds[0]`) when building the delegation graph for an identity. Identities that participated in multiple missions (i.e. had multiple credentials) would only see **one** mission's delegation tree — all other trees were silently invisible in the graph view.

**Root cause:** After fetching all credentials for an identity (ordered by `issued_at DESC`), the code hard-coded `focal := creds[0]` and ran `WalkUp`/`WalkDown` only on that single JTI, discarding the rest.

## Fix

- Iterate over **all** credentials for the identity, running `WalkUp` + `WalkDown` for each
- Deduplicate merged results by JTI (using an inline `seen` map) to avoid duplicate nodes when trees overlap
- Removed the now-unnecessary `mergeByJTI` helper call since dedup happens inline during the loop
- Added a comment flagging the N×(WalkUp+WalkDown) query cost as a future optimization area for identities with many credentials

## Changed files

- **`internal/service/delegation.go`** — replaced single-credential walk with a loop over all credentials + inline dedup
- **`tests/integration/delegation_test.go`** — updated `TestDelegationGraph_AllCredentialsVisible` (renamed from `_MostRecentCredentialIsFocal`) to assert both credential edges appear in the graph

## Test plan
- [x] Updated integration test asserts both credential trees are present
- [ ] Verify graph renders correctly in Studio for identities with >1 credential
- [ ] Confirm no regression on single-credential identities

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<img width="1509" height="804" alt="Screenshot 2026-06-04 at 8 05 45 PM" src="https://github.com/user-attachments/assets/678c1f7d-c7d0-4192-89b9-b58b0c771cbb" />

