### PR TITLE
fix: revoke endpoint silent no-op + surface revoke audit in graph edges

### DIFF
--- a/internal/handler/credential.go
+++ b/internal/handler/credential.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -208,6 +209,13 @@ func (a *API) revokeCredentialOp(ctx context.Context, input *RevokeCredentialInp
 	}
 
 	if err := a.credSvc.RevokeCredential(ctx, input.ID, tenant.AccountID, tenant.ProjectID, input.Body.Reason); err != nil {
+		if errors.Is(err, service.ErrCredentialNotFound) {
+			// Zero rows matched. Could be: wrong id, tenant-scope mismatch,
+			// already revoked, or already expired. All four are "this revoke
+			// did not mutate state" — surface as 404 so the caller knows,
+			// instead of the previous silent 200-OK.
+			return nil, huma.Error404NotFound("credential not found, already revoked, or expired")
+		}
 		log.Error().Err(err).Str("credential_id", input.ID).Msg("failed to revoke credential")
 		return nil, huma.Error500InternalServerError("failed to revoke credential")
 	}

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -511,6 +511,15 @@ func (s *CredentialService) SetRevocationDispatcher(d *RevocationDispatcher) {
 // descendants. Fires one RevocationNotifier event per affected JTI after the
 // revocation commits (on a detached goroutine — never on the request's
 // critical path).
+//
+// Returns ErrCredentialNotFound when the underlying cascade matches zero
+// rows. The SQL function filters on id + account_id + project_id, and skips
+// rows that are already revoked or past expires_at — so a zero-row outcome
+// means one of: wrong id, tenant-scope mismatch, already revoked, or
+// already expired. Mapping all four to a typed error turns what used to be
+// a silent 200-OK no-op (the handler always set revoked:true) into an
+// explicit failure the caller can react to. Real DB errors still surface
+// as the underlying error.
 func (s *CredentialService) RevokeCredential(ctx context.Context, id, accountID, projectID, reason string) error {
 	if reason == "" {
 		reason = "manual_revocation"
@@ -518,6 +527,9 @@ func (s *CredentialService) RevokeCredential(ctx context.Context, id, accountID,
 	revoked, err := s.repo.Revoke(ctx, id, accountID, projectID, reason)
 	if err != nil {
 		return err
+	}
+	if len(revoked) == 0 {
+		return ErrCredentialNotFound
 	}
 	s.dispatchRevocations(ctx, revoked, reason)
 	return nil

--- a/internal/service/delegation.go
+++ b/internal/service/delegation.go
@@ -46,20 +46,28 @@ type GraphNode struct {
 // identities. ScopesIn/ScopesOut/Attenuated are the scope-attenuation
 // triple; for root credentials (no parent) ScopesIn equals ScopesOut and
 // Attenuated is empty.
+//
+// RevokedAt and RevokeReason surface the durable audit fields from the
+// underlying credential row — populated only when IsRevoked is true so
+// downstream UIs can render "revoked at T by reason R" without a second
+// round-trip to the credential repository. Both are omitempty so the wire
+// shape stays unchanged for unrevoked edges.
 type GraphEdge struct {
-	From            string    `json:"from,omitempty"`
-	To              string    `json:"to,omitempty"`
-	JTI             string    `json:"jti"`
-	ParentJTI       string    `json:"parent_jti,omitempty"`
-	MissionID       string    `json:"mission_id,omitempty"`
-	IssuedAt        time.Time `json:"issued_at"`
-	ExpiresAt       time.Time `json:"expires_at"`
-	GrantType       string    `json:"grant_type"`
-	DelegationDepth int       `json:"delegation_depth"`
-	ScopesIn        []string  `json:"scopes_in"`
-	ScopesOut       []string  `json:"scopes_out"`
-	Attenuated      []string  `json:"attenuated"`
-	IsRevoked       bool      `json:"is_revoked"`
+	From            string     `json:"from,omitempty"`
+	To              string     `json:"to,omitempty"`
+	JTI             string     `json:"jti"`
+	ParentJTI       string     `json:"parent_jti,omitempty"`
+	MissionID       string     `json:"mission_id,omitempty"`
+	IssuedAt        time.Time  `json:"issued_at"`
+	ExpiresAt       time.Time  `json:"expires_at"`
+	GrantType       string     `json:"grant_type"`
+	DelegationDepth int        `json:"delegation_depth"`
+	ScopesIn        []string   `json:"scopes_in"`
+	ScopesOut       []string   `json:"scopes_out"`
+	Attenuated      []string   `json:"attenuated"`
+	IsRevoked       bool       `json:"is_revoked"`
+	RevokedAt       *time.Time `json:"revoked_at,omitempty"`
+	RevokeReason    string     `json:"revoke_reason,omitempty"`
 }
 
 // Graph is the response shape for /delegations/graph — a depth-bounded
@@ -318,10 +326,12 @@ func credentialToEdge(c *domain.IssuedCredential) *GraphEdge {
 		// ScopesIn defaults to ScopesOut for root credentials so the
 		// triple is always populated; the parent-lookup branch
 		// overwrites this for non-root edges.
-		ScopesIn:   scopesOut,
-		ScopesOut:  scopesOut,
-		Attenuated: []string{},
-		IsRevoked:  c.IsRevoked,
+		ScopesIn:     scopesOut,
+		ScopesOut:    scopesOut,
+		Attenuated:   []string{},
+		IsRevoked:    c.IsRevoked,
+		RevokedAt:    c.RevokedAt,
+		RevokeReason: c.RevokeReason,
 	}
 }
 

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -364,6 +365,88 @@ func TestDelegationGraph_RevokedCredentialAppears(t *testing.T) {
 	require.NotNil(t, aEdge, "A's edge must still appear after revocation")
 	assert.True(t, aEdge["is_revoked"].(bool),
 		"revoked credential's edge must carry is_revoked=true")
+
+	// The revoke audit fields must surface alongside is_revoked so
+	// downstream UIs can render "revoked at T by reason R" without a
+	// second round-trip to the credential repository.
+	revokedAt, ok := aEdge["revoked_at"].(string)
+	assert.True(t, ok && revokedAt != "",
+		"revoked credential's edge must carry a non-empty revoked_at timestamp")
+	assert.Equal(t, "test-revoke", aEdge["revoke_reason"],
+		"revoked credential's edge must carry the revoke_reason")
+}
+
+// TestRevokeCredential_NotFound_Returns404 pins the bug fix for what was
+// previously a silent 200-OK no-op: when the revoke endpoint's cascade
+// matches zero rows, the handler returns 404 instead of cheerfully
+// reporting "revoked: true".
+//
+// Zero-row outcomes cover four real cases:
+//
+//	1. Wrong / never-existed credential id
+//	2. Tenant-scope mismatch (account_id / project_id headers don't match the row)
+//	3. Already revoked
+//	4. Already expired
+//
+// Pre-fix, all four returned 200 — leaving the caller convinced the revoke
+// happened when it hadn't. Now they all 404.
+func TestRevokeCredential_NotFound_Returns404(t *testing.T) {
+	// Case 1: completely fictional credential id under a real tenant.
+	fakeID := uuid.New().String()
+	rev := post(t, adminPath("/credentials/"+fakeID+"/revoke"),
+		map[string]any{"reason": "test-404"}, adminHeaders())
+	require.Equal(t, http.StatusNotFound, rev.StatusCode,
+		"revoke on a non-existent credential id must return 404 (was previously a silent 200)")
+
+	// Case 3: already-revoked. Mint a real credential, revoke it once
+	// (200), then revoke it again — the SQL function's is_revoked = FALSE
+	// filter skips it, returning 0 rows.
+	policyID := delegationPolicy(t, uid("revoke-404-policy"), []string{"data:read"})
+	identityID, _, _ := issueRootCredential(t, policyID, "revoke-404", []string{"data:read"})
+
+	credResp := get(t, adminPath("/credentials?identity_id="+identityID), adminHeaders())
+	require.Equal(t, http.StatusOK, credResp.StatusCode)
+	creds := decode(t, credResp)["credentials"].([]any)
+	require.NotEmpty(t, creds, "identity must have at least one credential")
+	realID := creds[0].(map[string]any)["id"].(string)
+
+	first := post(t, adminPath("/credentials/"+realID+"/revoke"),
+		map[string]any{"reason": "first"}, adminHeaders())
+	require.Equal(t, http.StatusOK, first.StatusCode, "first revoke must succeed")
+
+	second := post(t, adminPath("/credentials/"+realID+"/revoke"),
+		map[string]any{"reason": "second"}, adminHeaders())
+	require.Equal(t, http.StatusNotFound, second.StatusCode,
+		"revoking an already-revoked credential must return 404 (zero rows mutated)")
+}
+
+// TestRevokeCredential_TenantMismatch_Returns404 pins that a revoke
+// request with the wrong X-Account-ID / X-Project-ID also produces a 404
+// — the SQL cascade filters on both, so a mismatched tenant matches zero
+// rows. Pre-fix this was the silent 200 most likely to bite in production
+// where Studio → Admin → AuthN may pass the wrong tenant scope for the
+// credential being revoked.
+func TestRevokeCredential_TenantMismatch_Returns404(t *testing.T) {
+	policyID := delegationPolicy(t, uid("revoke-mismatch-policy"), []string{"data:read"})
+	identityID, _, _ := issueRootCredential(t, policyID, "revoke-mismatch", []string{"data:read"})
+
+	credResp := get(t, adminPath("/credentials?identity_id="+identityID), adminHeaders())
+	require.Equal(t, http.StatusOK, credResp.StatusCode)
+	creds := decode(t, credResp)["credentials"].([]any)
+	require.NotEmpty(t, creds, "identity must have at least one credential")
+	realID := creds[0].(map[string]any)["id"].(string)
+
+	// Forge wrong-tenant headers by overriding the X-Account-ID +
+	// X-Project-ID on the request. The internal-service auth still
+	// matches; only the tenant scope differs.
+	wrongHeaders := adminHeaders()
+	wrongHeaders["X-Account-ID"] = "wrong-account-id"
+	wrongHeaders["X-Project-ID"] = uuid.New().String()
+
+	rev := post(t, adminPath("/credentials/"+realID+"/revoke"),
+		map[string]any{"reason": "wrong-tenant"}, wrongHeaders)
+	require.Equal(t, http.StatusNotFound, rev.StatusCode,
+		"revoke with mismatched tenant scope must return 404 (zero rows mutated)")
 }
 
 // TestDelegationGraph_DepthOutOfRange_Rejected pins the Huma-side

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -395,6 +395,7 @@ func TestRevokeCredential_NotFound_Returns404(t *testing.T) {
 	fakeID := uuid.New().String()
 	rev := post(t, adminPath("/credentials/"+fakeID+"/revoke"),
 		map[string]any{"reason": "test-404"}, adminHeaders())
+	defer func() { _ = rev.Body.Close() }()
 	require.Equal(t, http.StatusNotFound, rev.StatusCode,
 		"revoke on a non-existent credential id must return 404 (was previously a silent 200)")
 
@@ -412,10 +413,12 @@ func TestRevokeCredential_NotFound_Returns404(t *testing.T) {
 
 	first := post(t, adminPath("/credentials/"+realID+"/revoke"),
 		map[string]any{"reason": "first"}, adminHeaders())
+	defer func() { _ = first.Body.Close() }()
 	require.Equal(t, http.StatusOK, first.StatusCode, "first revoke must succeed")
 
 	second := post(t, adminPath("/credentials/"+realID+"/revoke"),
 		map[string]any{"reason": "second"}, adminHeaders())
+	defer func() { _ = second.Body.Close() }()
 	require.Equal(t, http.StatusNotFound, second.StatusCode,
 		"revoking an already-revoked credential must return 404 (zero rows mutated)")
 }
@@ -445,6 +448,7 @@ func TestRevokeCredential_TenantMismatch_Returns404(t *testing.T) {
 
 	rev := post(t, adminPath("/credentials/"+realID+"/revoke"),
 		map[string]any{"reason": "wrong-tenant"}, wrongHeaders)
+	defer func() { _ = rev.Body.Close() }()
 	require.Equal(t, http.StatusNotFound, rev.StatusCode,
 		"revoke with mismatched tenant scope must return 404 (zero rows mutated)")
 }

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -383,10 +383,10 @@ func TestDelegationGraph_RevokedCredentialAppears(t *testing.T) {
 //
 // Zero-row outcomes cover four real cases:
 //
-//	1. Wrong / never-existed credential id
-//	2. Tenant-scope mismatch (account_id / project_id headers don't match the row)
-//	3. Already revoked
-//	4. Already expired
+//  1. Wrong / never-existed credential id
+//  2. Tenant-scope mismatch (account_id / project_id headers don't match the row)
+//  3. Already revoked
+//  4. Already expired
 //
 // Pre-fix, all four returned 200 — leaving the caller convinced the revoke
 // happened when it hadn't. Now they all 404.


### PR DESCRIPTION
## Summary

Two related fixes uncovered by a live diagnostic on dev1 — a revoke that silently no-oped despite returning `200 OK`, plus graph edges that exposed only `is_revoked` and not the `revoked_at` / `revoke_reason` audit fields.

## Diagnostic that found this

Running the full revoke flow against authn on dev1 (via port-forward to bypass the broken public ingress), the system worked correctly when called with the right tenant headers. But the same code path exposes a class of silent failures that map cleanly onto a bug report we got: revoke API returns `{revoked: true, id: ...}` HTTP 200, yet the credential's row in the DB has `is_revoked = false`.

Root cause: `revoke_credential_cascade` SQL function filters on `id + account_id + project_id + is_revoked = FALSE + expires_at > now()`. Any of those failing → zero rows mutated. The handler chain returned 200 anyway.

## Fix 1 — `RevokeCredential` 200-OK on zero rows mutated

`CredentialService.RevokeCredential` previously returned `nil` whenever the SQL function returned no error, regardless of whether any rows were actually updated. Now:

- Service returns `ErrCredentialNotFound` (already exists as a sentinel in `delegation.go`) when `len(revoked) == 0`.
- Handler maps that to `huma.Error404NotFound("credential not found, already revoked, or expired")`.
- Real DB errors still surface and still map to 500.

Four zero-row cases now produce 404 instead of 200:

1. Wrong / never-existed credential id
2. **Tenant-scope mismatch** — the production trip-wire (Studio → Admin → AuthN passing wrong `X-Account-ID` / `X-Project-ID`)
3. Already revoked
4. Already expired

Other callers of `RevokeCredential` (oauth2 RFC 7009, rotate, auth_code_replay) operate on credentials they just retrieved via `GetCredential`, so the not-found branch can't fire for them in practice — but they still see a typed error instead of a stale "success".

## Fix 2 — `GraphEdge` surfaces `revoked_at` + `revoke_reason`

`GraphEdge` exposed only `is_revoked` boolean. Downstream UIs that wanted "revoked at T by reason R" had to make a second round-trip to the credential repository. `domain.IssuedCredential` already carries `RevokedAt` and `RevokeReason` — they were just dropped by `credentialToEdge`.

Added both with `omitempty` so the wire shape is unchanged for unrevoked edges.

## Tests

| Test | Coverage |
|---|---|
| `TestDelegationGraph_RevokedCredentialAppears` (extended) | asserts new fields populated correctly after a real revoke |
| `TestRevokeCredential_NotFound_Returns404` (new) | wrong-id + already-revoked → 404 |
| `TestRevokeCredential_TenantMismatch_Returns404` (new) | the production trip-wire — mints a real credential, revokes with forged `X-Account-ID` / `X-Project-ID`, asserts 404 |

Full integration sweep ran broadly (per memory note — don't single-prefix `-run`):
```
go test ./tests/integration -run "TestDelegation|TestRevoke|TestCredential|TestRFC7009|TestCAE"
ok  15.196s
```

## Diff

`+130 / -17` across 4 files.

## Out of scope (separate concerns)

- Cleanup worker hard-deletes revoked credentials at expiry (audit-trail loss) — needs a product call on retention semantics; not bundled here.
- Adding `id` to `GraphEdge` so callers can revoke from a graph-derived identifier — UX improvement, separate.

## Test plan

- [x] `go test ./tests/integration -run "TestDelegation|TestRevoke|TestCredential|TestRFC7009|TestCAE"` green locally (testcontainers)
- [x] `go vet ./...` and `go build ./...` clean
- [x] Commit prefix `fix:` passes the zeroid CI regex
- [ ] zeroid CI green on PR
- [ ] Gemini review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)