### PR TITLE
feat: self-service actor-key enrollment and rotation

### DIFF
--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -258,11 +258,11 @@ func (a *API) setOwnPublicKeyOp(ctx context.Context, input *SetOwnPublicKeyInput
 			return nil, huma.Error403Forbidden(err.Error())
 		case errors.Is(err, service.ErrInvalidIdentityField):
 			return nil, huma.Error400BadRequest(err.Error())
-		case errors.Is(err, service.ErrIdentityNotFound):
-			return nil, huma.Error404NotFound("identity not found")
 		default:
-			log.Error().Err(err).Str("identity_id", claims.IdentityID).Msg("failed to set actor public key")
-			return nil, huma.Error500InternalServerError("failed to set public key")
+			// mapErr maps not-found to 404, domain.ErrIdentityExpired /
+			// ErrIdentityNotUsable to 400, and logs + 500s anything unexpected —
+			// keeping status codes consistent with the other agent handlers.
+			return nil, mapErr(err)
 		}
 	}
 	return &SetOwnPublicKeyOutput{Body: resp}, nil

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -113,6 +113,11 @@ type UpdateAgentInput struct {
 		Metadata     json.RawMessage `json:"metadata,omitempty" doc:"Product-specific metadata"`
 		Status       *string         `json:"status,omitempty" enum:"active,suspended,deactivated" doc:"Identity status"`
 		UpdatedBy    string          `json:"updated_by,omitempty" doc:"User ID of the updater"`
+		// PublicKeyPEM force-sets the actor-assertion key without proof-of-
+		// possession — the admin recovery path. This route is secret-gated
+		// (management API), so admin authority is the authorization. Agents
+		// rotate their own key via POST /agents/self/public-key with proofs.
+		PublicKeyPEM *string `json:"public_key_pem,omitempty" doc:"Force-set the agent's actor-assertion public key (admin recovery; no proof-of-possession)."`
 	}
 }
 
@@ -196,6 +201,71 @@ func (a *API) registerAgentRoutes(api huma.API) {
 		Summary:     "Rotate an agent's API key (revokes old, issues new)",
 		Tags:        []string{"Agents"},
 	}, a.rotateAgentKeyOp)
+}
+
+// registerAgentSelfServiceRoute registers the agent self-service actor-key
+// endpoint. It MUST be mounted on the public router behind AgentAuthMiddleware
+// (not the secret-gated admin group) so an agent can reach it directly with its
+// own access token. The identity is taken from the validated token claims, never
+// from the path — an agent can only set its own key.
+func (a *API) registerAgentSelfServiceRoute(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "set-own-public-key",
+		Method:      http.MethodPost,
+		Path:        "/agents/self/public-key",
+		Summary:     "Enroll or rotate the calling agent's actor-assertion public key",
+		Tags:        []string{"Agents"},
+	}, a.setOwnPublicKeyOp)
+}
+
+// SetOwnPublicKeyInput is the body for POST /agents/self/public-key. The target
+// identity is the authenticated caller (from its access token), so there is no
+// id in the path or body.
+type SetOwnPublicKeyInput struct {
+	Body struct {
+		NewPublicKeyPEM string `json:"new_public_key_pem" required:"true" minLength:"1" doc:"SPKI EC P-256 public key (PEM) to enroll or rotate to."`
+		NewKeyProof     string `json:"new_key_proof" required:"true" minLength:"1" doc:"Compact ES256 JWS signed by the NEW key, proving control of it. Claims: aud=<issuer>/agents/self/public-key, sub=<caller WIMSE URI>, plus jti, iat, exp (lifetime <= 2m)."`
+		CurrentKeyProof string `json:"current_key_proof,omitempty" doc:"Required only when rotating an already-enrolled key: compact ES256 JWS signed by the CURRENT key, same claims plus nkt=base64url(SHA-256(new SPKI DER)) binding it to the new key."`
+	}
+}
+
+type SetOwnPublicKeyOutput struct {
+	Body *service.AgentResponse
+}
+
+// setOwnPublicKeyOp enrolls or rotates the actor-assertion public key for the
+// authenticated agent identity (self-service). Identity + tenant come from the
+// agent's own access-token claims (AgentAuthMiddleware), never from caller input.
+func (a *API) setOwnPublicKeyOp(ctx context.Context, input *SetOwnPublicKeyInput) (*SetOwnPublicKeyOutput, error) {
+	claims, ok := internalMiddleware.GetAgentClaims(ctx)
+	if !ok || claims.IdentityID == "" {
+		return nil, huma.Error401Unauthorized("missing or invalid agent token")
+	}
+
+	// Attribute the key change to the agent itself in the audit trail (this
+	// endpoint runs outside TenantContextMiddleware, so modified_by is otherwise
+	// unset).
+	ctx = internalMiddleware.SetCallerName(ctx, claims.Subject)
+
+	resp, err := a.agentSvc.SetPublicKey(ctx, claims.IdentityID, claims.AccountID, claims.ProjectID, service.SetPublicKeyRequest{
+		NewPublicKeyPEM: input.Body.NewPublicKeyPEM,
+		NewKeyProof:     input.Body.NewKeyProof,
+		CurrentKeyProof: input.Body.CurrentKeyProof,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrKeyProofInvalid):
+			return nil, huma.Error403Forbidden(err.Error())
+		case errors.Is(err, service.ErrInvalidIdentityField):
+			return nil, huma.Error400BadRequest(err.Error())
+		case errors.Is(err, service.ErrIdentityNotFound):
+			return nil, huma.Error404NotFound("identity not found")
+		default:
+			log.Error().Err(err).Str("identity_id", claims.IdentityID).Msg("failed to set actor public key")
+			return nil, huma.Error500InternalServerError("failed to set public key")
+		}
+	}
+	return &SetOwnPublicKeyOutput{Body: resp}, nil
 }
 
 func (a *API) registerAgentOp(ctx context.Context, input *RegisterAgentInput) (*RegisterAgentOutput, error) {
@@ -302,6 +372,7 @@ func (a *API) updateAgentOp(ctx context.Context, input *UpdateAgentInput) (*GetA
 		Labels:       input.Body.Labels,
 		Metadata:     input.Body.Metadata,
 		Status:       input.Body.Status,
+		PublicKeyPEM: input.Body.PublicKeyPEM,
 	})
 	if err != nil {
 		return nil, mapErr(err)

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -111,6 +111,26 @@ func NewAPI(
 
 // NewHumaAPI creates a Huma API on the given chi router with goccy/go-json codec.
 func NewHumaAPI(router chi.Router) huma.API {
+	return humachi.New(router, zeroidHumaConfig())
+}
+
+// NewHumaAPISpecless creates a huma API that does NOT register the OpenAPI /
+// docs / schemas routes. Use it for a secondary route group mounted on a router
+// that already serves the canonical spec (e.g. the public agent self-service
+// group sits on the same root router as RegisterPublic). Without this, the
+// secondary instance's /openapi.json would shadow the canonical one
+// (chi last-registration wins), dropping the public OAuth paths from the spec.
+// Routes registered here are documented via the service contract + capability
+// spec rather than this instance's (absent) spec.
+func NewHumaAPISpecless(router chi.Router) huma.API {
+	config := zeroidHumaConfig()
+	config.OpenAPIPath = ""
+	config.DocsPath = ""
+	config.SchemasPath = ""
+	return humachi.New(router, config)
+}
+
+func zeroidHumaConfig() huma.Config {
 	config := huma.DefaultConfig("ZeroID", "1.0.0")
 	config.Info.Description = "Non-Human Identity (NHI) management — agent authentication, credential lifecycle, and delegation."
 
@@ -124,7 +144,7 @@ func NewHumaAPI(router chi.Router) huma.API {
 		},
 	}
 
-	return humachi.New(router, config)
+	return config
 }
 
 // prmURL returns the absolute URL of this server's RFC 9728 Protected
@@ -184,4 +204,13 @@ func (a *API) RegisterAdmin(api huma.API, router chi.Router) {
 // These run on the admin port behind an additional agent JWT verification layer.
 func (a *API) RegisterAgentAuth(api huma.API) {
 	a.registerProofGenerateRoute(api)
+}
+
+// RegisterAgentSelfService registers endpoints an agent calls with its OWN
+// access token (agent-auth middleware) rather than the internal service secret.
+// Unlike RegisterAgentAuth (proof generation), these are meant to be mounted on
+// the PUBLIC router so they are reachable on the public ingress — the deployer
+// wraps them in AgentAuthMiddleware, and tenant/identity come from token claims.
+func (a *API) RegisterAgentSelfService(api huma.API) {
+	a.registerAgentSelfServiceRoute(api)
 }

--- a/internal/service/actor_key_proof.go
+++ b/internal/service/actor_key_proof.go
@@ -84,6 +84,11 @@ func verifyActorKeyProof(
 	if !ok {
 		return errors.New("proof missing iat claim")
 	}
+	// Guard the subtraction: if exp precedes iat (malicious or skewed claims),
+	// exp.Sub(iat) is negative and would slip under the lifetime cap.
+	if exp.Before(iat) {
+		return errors.New("proof exp claim is before its iat claim")
+	}
 	if exp.Sub(iat) > maxKeyProofLifetime {
 		return fmt.Errorf("proof lifetime exceeds %s", maxKeyProofLifetime)
 	}

--- a/internal/service/actor_key_proof.go
+++ b/internal/service/actor_key_proof.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+
+	"github.com/highflame-ai/zeroid/internal/jwtalg"
+	"github.com/highflame-ai/zeroid/pkg/dpop"
+)
+
+// ErrKeyProofInvalid is returned when an actor-key enrollment/rotation proof
+// fails verification — bad signature, wrong aud/sub, missing/over-long lifetime,
+// replay, or (for rotation) a missing or mismatched current-key proof. The
+// caller is authenticated (its access token is valid) but has not proven control
+// of the key, so handlers map this to 403, not 401.
+var ErrKeyProofInvalid = errors.New("actor-key proof verification failed")
+
+// maxKeyProofLifetime bounds how long an actor-key-change proof is valid. Proofs
+// are single-use (jti) and audience-bound; the short lifetime caps the replay
+// window even before the jti store has recorded the proof.
+const maxKeyProofLifetime = 2 * time.Minute
+
+// keyProofReplayGuard records single-use proof identifiers (jti) so a captured
+// key-change proof cannot be replayed within its lifetime. Satisfied by the
+// shared Postgres replay store (also used for DPoP). Proof jtis are namespaced
+// before insertion so they never collide with DPoP jtis in the shared table.
+type keyProofReplayGuard interface {
+	Insert(ctx context.Context, jti string, expiresAt time.Time) error
+}
+
+// verifyActorKeyProof validates a proof-of-possession assertion for actor-key
+// enrollment or rotation. The proof is a compact ES256 JWS signed by verifyKey,
+// proving the caller controls that key. Required claims:
+//
+//	aud = the public-key endpoint URL  (binds the proof to this operation)
+//	sub = the identity's WIMSE URI     (binds the proof to this identity)
+//	jti = single-use identifier        (replay-protected)
+//	iat, exp                           (lifetime must be <= maxKeyProofLifetime)
+//
+// When expectNKT is non-empty, the proof must also carry an "nkt" claim equal to
+// it — the base64url SHA-256 of the *new* key's SPKI DER. This binds a
+// current-key proof to one specific replacement key (RFC 8555 §7.3.5 intent), so
+// a captured current-key proof cannot be paired with an attacker's new key.
+//
+// alg is pinned to ES256 (alg=none / HS* are rejected before parsing).
+func verifyActorKeyProof(
+	ctx context.Context,
+	proofJWS string,
+	verifyKey *ecdsa.PublicKey,
+	expectedAud, expectedSub, expectNKT string,
+	replay keyProofReplayGuard,
+) error {
+	if err := jwtalg.Validate(proofJWS); err != nil {
+		return fmt.Errorf("proof uses an unsupported algorithm: %w", err)
+	}
+
+	tok, err := jwt.Parse([]byte(proofJWS),
+		jwt.WithKey(jwa.ES256(), verifyKey),
+		jwt.WithValidate(true),
+		jwt.WithAudience(expectedAud),
+	)
+	if err != nil {
+		return fmt.Errorf("proof signature/validation failed: %w", err)
+	}
+
+	if sub, ok := tok.Subject(); !ok || sub != expectedSub {
+		return errors.New("proof sub does not match the identity")
+	}
+
+	exp, ok := tok.Expiration()
+	if !ok {
+		return errors.New("proof missing exp claim")
+	}
+	iat, ok := tok.IssuedAt()
+	if !ok {
+		return errors.New("proof missing iat claim")
+	}
+	if exp.Sub(iat) > maxKeyProofLifetime {
+		return fmt.Errorf("proof lifetime exceeds %s", maxKeyProofLifetime)
+	}
+
+	jti, ok := tok.JwtID()
+	if !ok || jti == "" {
+		return errors.New("proof missing jti claim")
+	}
+
+	if expectNKT != "" {
+		v, found := tok.Field("nkt")
+		nkt, _ := v.(string)
+		if !found || nkt != expectNKT {
+			return errors.New("proof nkt does not bind the new key")
+		}
+	}
+
+	// Single-use enforcement: record the jti, namespaced so key-proof jtis never
+	// collide with DPoP jtis in the shared replay table. A duplicate is a replay.
+	if err := replay.Insert(ctx, "akp:"+jti, exp); err != nil {
+		if errors.Is(err, dpop.ErrReplay) {
+			return errors.New("proof has already been used (replay)")
+		}
+		return fmt.Errorf("proof replay check failed: %w", err)
+	}
+
+	return nil
+}
+
+// newKeyThumbprint is the value a current-key proof must carry in its "nkt"
+// claim to authorize a rotation: base64url(SHA-256(SPKI DER)) of the new public
+// key. publicKeyPEM is assumed already validated as an SPKI EC P-256 key.
+func newKeyThumbprint(publicKeyPEM string) (string, error) {
+	block, _ := pem.Decode([]byte(publicKeyPEM))
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return "", errors.New("new public key is not a PUBLIC KEY PEM block")
+	}
+	sum := sha256.Sum256(block.Bytes)
+	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}

--- a/internal/service/actor_key_proof_test.go
+++ b/internal/service/actor_key_proof_test.go
@@ -120,6 +120,17 @@ func TestVerifyActorKeyProof_LifetimeTooLong(t *testing.T) {
 	require.ErrorContains(t, err, "lifetime")
 }
 
+func TestVerifyActorKeyProof_ExpBeforeIat(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	// iat AFTER exp → negative lifetime. exp is still in the future so it passes
+	// JWT expiry validation; only the explicit exp.Before(iat) guard rejects it,
+	// closing the "negative duration slips under the lifetime cap" bypass.
+	proof := mintProof(t, key, testProofAud, testProofSub, "jti-skew", now.Add(10*time.Minute), now.Add(5*time.Minute), "")
+	err := verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.Error(t, err)
+}
+
 func TestVerifyActorKeyProof_MissingJTI(t *testing.T) {
 	key := newECKey(t)
 	now := time.Now()

--- a/internal/service/actor_key_proof_test.go
+++ b/internal/service/actor_key_proof_test.go
@@ -1,0 +1,188 @@
+package service
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/pkg/dpop"
+)
+
+const (
+	testProofAud = "https://auth.example.com/agents/self/public-key"
+	testProofSub = "spiffe://example.com/acct-1/proj-1/agent/data-fetcher"
+)
+
+// fakeReplay is an in-memory keyProofReplayGuard. A repeated jti returns
+// dpop.ErrReplay, mirroring the Postgres unique-constraint behavior.
+type fakeReplay struct{ seen map[string]bool }
+
+func newFakeReplay() *fakeReplay { return &fakeReplay{seen: map[string]bool{}} }
+
+func (f *fakeReplay) Insert(_ context.Context, jti string, _ time.Time) error {
+	if f.seen[jti] {
+		return dpop.ErrReplay
+	}
+	f.seen[jti] = true
+	return nil
+}
+
+func newECKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	return k
+}
+
+func spkiPEM(t *testing.T, k *ecdsa.PrivateKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(&k.PublicKey)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+}
+
+// mintProof builds and ES256-signs an actor-key proof with the given claims.
+func mintProof(t *testing.T, key *ecdsa.PrivateKey, aud, sub, jti string, iat, exp time.Time, nkt string) string {
+	t.Helper()
+	b := jwt.NewBuilder().
+		Audience([]string{aud}).
+		Subject(sub).
+		JwtID(jti).
+		IssuedAt(iat).
+		Expiration(exp)
+	if nkt != "" {
+		b = b.Claim("nkt", nkt)
+	}
+	tok, err := b.Build()
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), key))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+func TestVerifyActorKeyProof_Valid(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	proof := mintProof(t, key, testProofAud, testProofSub, "jti-1", now, now.Add(time.Minute), "")
+	err := verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.NoError(t, err)
+}
+
+func TestVerifyActorKeyProof_WrongSigningKey(t *testing.T) {
+	signer, verifier := newECKey(t), newECKey(t)
+	now := time.Now()
+	proof := mintProof(t, signer, testProofAud, testProofSub, "jti-1", now, now.Add(time.Minute), "")
+	// Verify against a different key — must fail at signature validation.
+	err := verifyActorKeyProof(context.Background(), proof, &verifier.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.Error(t, err)
+}
+
+func TestVerifyActorKeyProof_WrongAudience(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	proof := mintProof(t, key, "https://evil.example.com/x", testProofSub, "jti-1", now, now.Add(time.Minute), "")
+	err := verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.Error(t, err)
+}
+
+func TestVerifyActorKeyProof_WrongSubject(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	proof := mintProof(t, key, testProofAud, "spiffe://example.com/acct-1/proj-1/agent/someone-else", "jti-1", now, now.Add(time.Minute), "")
+	err := verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.ErrorContains(t, err, "sub")
+}
+
+func TestVerifyActorKeyProof_Expired(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	proof := mintProof(t, key, testProofAud, testProofSub, "jti-1", now.Add(-90*time.Second), now.Add(-30*time.Second), "")
+	err := verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.Error(t, err)
+}
+
+func TestVerifyActorKeyProof_LifetimeTooLong(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	// exp is in the future (passes jwt validation) but the lifetime exceeds the cap.
+	proof := mintProof(t, key, testProofAud, testProofSub, "jti-1", now, now.Add(maxKeyProofLifetime+time.Minute), "")
+	err := verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.ErrorContains(t, err, "lifetime")
+}
+
+func TestVerifyActorKeyProof_MissingJTI(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	tok, err := jwt.NewBuilder().
+		Audience([]string{testProofAud}).Subject(testProofSub).
+		IssuedAt(now).Expiration(now.Add(time.Minute)).Build()
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), key))
+	require.NoError(t, err)
+	err = verifyActorKeyProof(context.Background(), string(signed), &key.PublicKey, testProofAud, testProofSub, "", newFakeReplay())
+	require.ErrorContains(t, err, "jti")
+}
+
+func TestVerifyActorKeyProof_Replay(t *testing.T) {
+	key := newECKey(t)
+	now := time.Now()
+	replay := newFakeReplay()
+	proof := mintProof(t, key, testProofAud, testProofSub, "jti-reused", now, now.Add(time.Minute), "")
+	require.NoError(t, verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", replay))
+	// Same jti again → replay.
+	err := verifyActorKeyProof(context.Background(), proof, &key.PublicKey, testProofAud, testProofSub, "", replay)
+	require.ErrorContains(t, err, "replay")
+}
+
+func TestVerifyActorKeyProof_NKTBinding(t *testing.T) {
+	currentKey, newKey := newECKey(t), newECKey(t)
+	now := time.Now()
+
+	nkt, err := newKeyThumbprint(spkiPEM(t, newKey))
+	require.NoError(t, err)
+
+	// Current-key proof bound to the correct new key → ok.
+	good := mintProof(t, currentKey, testProofAud, testProofSub, "jti-ok", now, now.Add(time.Minute), nkt)
+	require.NoError(t, verifyActorKeyProof(context.Background(), good, &currentKey.PublicKey, testProofAud, testProofSub, nkt, newFakeReplay()))
+
+	// Current-key proof with NO nkt, but a binding is expected → rejected.
+	missing := mintProof(t, currentKey, testProofAud, testProofSub, "jti-missing", now, now.Add(time.Minute), "")
+	require.ErrorContains(t, verifyActorKeyProof(context.Background(), missing, &currentKey.PublicKey, testProofAud, testProofSub, nkt, newFakeReplay()), "nkt")
+
+	// Current-key proof bound to a DIFFERENT key → rejected (can't repurpose).
+	other := mintProof(t, currentKey, testProofAud, testProofSub, "jti-other", now, now.Add(time.Minute), "some-other-thumbprint")
+	require.ErrorContains(t, verifyActorKeyProof(context.Background(), other, &currentKey.PublicKey, testProofAud, testProofSub, nkt, newFakeReplay()), "nkt")
+}
+
+func TestNewKeyThumbprint(t *testing.T) {
+	key := newECKey(t)
+	pemStr := spkiPEM(t, key)
+
+	tp1, err := newKeyThumbprint(pemStr)
+	require.NoError(t, err)
+	require.NotEmpty(t, tp1)
+
+	// Deterministic for the same key.
+	tp2, err := newKeyThumbprint(pemStr)
+	require.NoError(t, err)
+	assert.Equal(t, tp1, tp2)
+
+	// Different key → different thumbprint.
+	other, err := newKeyThumbprint(spkiPEM(t, newECKey(t)))
+	require.NoError(t, err)
+	assert.NotEqual(t, tp1, other)
+
+	// Non-PUBLIC-KEY PEM → error.
+	_, err = newKeyThumbprint("-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----")
+	require.Error(t, err)
+}

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -12,19 +12,35 @@ import (
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
-// AgentService handles agent registration (atomic identity + API key creation).
+// AgentService handles agent registration (atomic identity + API key creation)
+// and self-service actor-key enrollment/rotation.
 type AgentService struct {
 	identitySvc *IdentityService
 	apiKeySvc   *APIKeyService
 	apiKeyRepo  *postgres.APIKeyRepository
+	// keyProofReplay records single-use jtis for actor-key-change proofs.
+	keyProofReplay keyProofReplayGuard
+	// issuer is this server's token issuer URL; the audience a self-service key
+	// proof must target is derived from it (see keyProofAudience).
+	issuer string
 }
 
-// NewAgentService creates a new AgentService.
-func NewAgentService(identitySvc *IdentityService, apiKeySvc *APIKeyService, apiKeyRepo *postgres.APIKeyRepository) *AgentService {
+// NewAgentService creates a new AgentService. keyProofReplay backs single-use
+// enforcement of actor-key-change proofs; issuer is the token issuer URL used to
+// derive the expected proof audience.
+func NewAgentService(
+	identitySvc *IdentityService,
+	apiKeySvc *APIKeyService,
+	apiKeyRepo *postgres.APIKeyRepository,
+	keyProofReplay keyProofReplayGuard,
+	issuer string,
+) *AgentService {
 	return &AgentService{
-		identitySvc: identitySvc,
-		apiKeySvc:   apiKeySvc,
-		apiKeyRepo:  apiKeyRepo,
+		identitySvc:    identitySvc,
+		apiKeySvc:      apiKeySvc,
+		apiKeyRepo:     apiKeyRepo,
+		keyProofReplay: keyProofReplay,
+		issuer:         issuer,
 	}
 }
 
@@ -117,6 +133,27 @@ type UpdateAgentRequest struct {
 	Labels       json.RawMessage `json:"labels,omitempty"`
 	Metadata     json.RawMessage `json:"metadata,omitempty"`
 	Status       *string         `json:"status,omitempty"`
+	// PublicKeyPEM, when non-nil, force-sets the identity's actor-assertion key.
+	// This is the admin recovery path: it is reachable only on the secret-gated
+	// management route (no proof-of-possession), so a tenant admin can replace a
+	// key the agent can no longer prove control of. Self-service rotation (with
+	// proof-of-possession) goes through SetPublicKey instead.
+	PublicKeyPEM *string `json:"public_key_pem,omitempty"`
+}
+
+// SetPublicKeyRequest carries a self-service actor-key enrollment or rotation.
+type SetPublicKeyRequest struct {
+	// NewPublicKeyPEM is the SPKI EC P-256 public key to enroll.
+	NewPublicKeyPEM string
+	// NewKeyProof is a compact ES256 JWS signed by the NEW private key, proving
+	// the caller controls the key being registered. Required for both first-set
+	// and rotation.
+	NewKeyProof string
+	// CurrentKeyProof is a compact ES256 JWS signed by the identity's CURRENT
+	// private key, authorizing the rotation (proof-of-possession, bound to the
+	// new key). Required only when the identity already has a key; ignored on
+	// first-set (trust-on-first-use).
+	CurrentKeyProof string
 }
 
 // RegisterAgent atomically creates an identity and linked API key.
@@ -266,8 +303,96 @@ func (s *AgentService) UpdateAgent(ctx context.Context, id, accountID, projectID
 		return nil, err
 	}
 
+	// Admin force-set of the actor key (admin recovery path). Only the
+	// secret-gated management route can reach UpdateAgent, so this is authorized
+	// by admin authority — no proof-of-possession. Self-service rotation goes
+	// through SetPublicKey with proofs instead.
+	if req.PublicKeyPEM != nil {
+		identity, err = s.identitySvc.SetPublicKey(ctx, id, accountID, projectID, *req.PublicKeyPEM)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	keyPrefix := s.getKeyPrefix(ctx, identity.ID)
 	resp := identityToAgentResponse(identity, keyPrefix)
+	return &resp, nil
+}
+
+// keyProofAudience is the aud value a self-service actor-key proof must carry.
+// Bound to the issuer + the public-key endpoint path so a proof minted for this
+// operation cannot be replayed against a different audience.
+func (s *AgentService) keyProofAudience() string {
+	return s.issuer + "/agents/self/public-key"
+}
+
+// SetPublicKey enrolls or rotates the actor-assertion public key for the
+// authenticated identity (self-service). identityID/accountID/projectID come
+// from the agent's own access-token claims — never from caller-supplied input —
+// so an agent can only set its own key.
+//
+//   - First-set (identity has no key): trust-on-first-use, authorized by the
+//     agent's access token. NewKeyProof proves control of the new key.
+//   - Rotation (identity already has a key): additionally requires
+//     CurrentKeyProof — proof-of-possession of the current key, bound to the new
+//     key (RFC 8555 §7.3.5), so a stolen access token alone (no current private
+//     key) cannot rotate an enrolled key.
+func (s *AgentService) SetPublicKey(ctx context.Context, identityID, accountID, projectID string, req SetPublicKeyRequest) (*AgentResponse, error) {
+	if req.NewPublicKeyPEM == "" {
+		return nil, fmt.Errorf("%w: new_public_key_pem is required", ErrInvalidIdentityField)
+	}
+	newKey, err := parseECPublicKeyPEM(req.NewPublicKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("%w: new_public_key_pem: %v", ErrInvalidIdentityField, err)
+	}
+	if req.NewKeyProof == "" {
+		return nil, fmt.Errorf("%w: new_key_proof is required", ErrKeyProofInvalid)
+	}
+
+	identity, err := s.identitySvc.GetIdentity(ctx, identityID, accountID, projectID)
+	if err != nil {
+		return nil, err
+	}
+	if !identity.Status.IsUsable() {
+		return nil, fmt.Errorf("%w: identity is suspended or deactivated", ErrInvalidIdentityField)
+	}
+	if identity.IsExpired() {
+		return nil, fmt.Errorf("%w: identity is expired", ErrInvalidIdentityField)
+	}
+
+	aud := s.keyProofAudience()
+
+	// Always prove control of the NEW key (prevents binding a key the caller
+	// does not control).
+	if err := verifyActorKeyProof(ctx, req.NewKeyProof, newKey, aud, identity.WIMSEURI, "", s.keyProofReplay); err != nil {
+		return nil, fmt.Errorf("%w: new_key_proof: %v", ErrKeyProofInvalid, err)
+	}
+
+	// Rotation: an enrolled key may only be replaced by also proving possession
+	// of the current key, bound to this specific new key.
+	if identity.PublicKeyPEM != "" {
+		if req.CurrentKeyProof == "" {
+			return nil, fmt.Errorf("%w: current_key_proof is required to rotate an enrolled key", ErrKeyProofInvalid)
+		}
+		currentKey, err := parseECPublicKeyPEM(identity.PublicKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("stored public key is invalid: %w", err)
+		}
+		nkt, err := newKeyThumbprint(req.NewPublicKeyPEM)
+		if err != nil {
+			return nil, err
+		}
+		if err := verifyActorKeyProof(ctx, req.CurrentKeyProof, currentKey, aud, identity.WIMSEURI, nkt, s.keyProofReplay); err != nil {
+			return nil, fmt.Errorf("%w: current_key_proof: %v", ErrKeyProofInvalid, err)
+		}
+	}
+
+	updated, err := s.identitySvc.SetPublicKey(ctx, identityID, accountID, projectID, req.NewPublicKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	keyPrefix := s.getKeyPrefix(ctx, updated.ID)
+	resp := identityToAgentResponse(updated, keyPrefix)
 	return &resp, nil
 }
 

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -298,20 +298,16 @@ func (s *AgentService) UpdateAgent(ctx context.Context, id, accountID, projectID
 		Labels:       req.Labels,
 		Metadata:     req.Metadata,
 		Status:       status,
+		// Admin force-set of the actor key (admin recovery path) — validated and
+		// applied in the same update (UpdateIdentity validates PublicKeyPEM when
+		// non-empty). derefStr(nil) is "", which UpdateIdentity treats as "leave
+		// unchanged". Only the secret-gated management route reaches UpdateAgent,
+		// so this is authorized by admin authority with no proof-of-possession;
+		// self-service rotation (with proofs) goes through SetPublicKey instead.
+		PublicKeyPEM: derefStr(req.PublicKeyPEM),
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	// Admin force-set of the actor key (admin recovery path). Only the
-	// secret-gated management route can reach UpdateAgent, so this is authorized
-	// by admin authority — no proof-of-possession. Self-service rotation goes
-	// through SetPublicKey with proofs instead.
-	if req.PublicKeyPEM != nil {
-		identity, err = s.identitySvc.SetPublicKey(ctx, id, accountID, projectID, *req.PublicKeyPEM)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	keyPrefix := s.getKeyPrefix(ctx, identity.ID)
@@ -354,10 +350,10 @@ func (s *AgentService) SetPublicKey(ctx context.Context, identityID, accountID, 
 		return nil, err
 	}
 	if !identity.Status.IsUsable() {
-		return nil, fmt.Errorf("%w: identity is suspended or deactivated", ErrInvalidIdentityField)
+		return nil, fmt.Errorf("%w (status: %s)", domain.ErrIdentityNotUsable, identity.Status)
 	}
 	if identity.IsExpired() {
-		return nil, fmt.Errorf("%w: identity is expired", ErrInvalidIdentityField)
+		return nil, fmt.Errorf("%w: identity %s", domain.ErrIdentityExpired, identity.ID)
 	}
 
 	aud := s.keyProofAudience()

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -256,6 +256,29 @@ func (s *IdentityService) GetIdentity(ctx context.Context, id, accountID, projec
 	return s.repo.GetByID(ctx, id, accountID, projectID)
 }
 
+// SetPublicKey replaces the identity's EC actor-assertion public key (the key
+// used to verify its self-signed assertion on the jwt_bearer and token_exchange
+// grants). The PEM is validated as an SPKI EC P-256 key. Persisted via
+// repo.Update so the AFTER UPDATE audit trigger records the change with the
+// caller as modified_by. Authorization — proof-of-possession for a self-service
+// rotation, or admin authority for a force-set — is the caller's
+// responsibility; this method only validates and persists. Returns the updated
+// identity.
+func (s *IdentityService) SetPublicKey(ctx context.Context, id, accountID, projectID, publicKeyPEM string) (*domain.Identity, error) {
+	if err := validateECPublicKeyPEM(publicKeyPEM); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidIdentityField, err)
+	}
+	identity, err := s.repo.GetByID(ctx, id, accountID, projectID)
+	if err != nil {
+		return nil, err
+	}
+	identity.PublicKeyPEM = publicKeyPEM
+	if err := s.repo.Update(ctx, identity); err != nil {
+		return nil, err
+	}
+	return identity, nil
+}
+
 // GetIdentityByExternalID retrieves an identity by its external_id within a tenant.
 func (s *IdentityService) GetIdentityByExternalID(ctx context.Context, externalID, accountID, projectID string) (*domain.Identity, error) {
 	return s.repo.GetByExternalID(ctx, externalID, accountID, projectID)

--- a/server.go
+++ b/server.go
@@ -233,7 +233,7 @@ func NewServer(cfg Config) (*Server, error) {
 		AuthCodeIssuer: authCodeIssuer,
 	})
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
-	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo)
+	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo, postgres.NewDPoPReplayStore(db), cfg.Token.Issuer)
 
 	// BackchannelService (CIBA) is constructed after oauthSvc/credentialSvc and
 	// then wired back into oauthSvc.SetBackchannelService — the CIBA grant
@@ -321,6 +321,30 @@ func NewServer(cfg Config) (*Server, error) {
 	humaPublic := handler.NewHumaAPI(r)
 	apiHandler.RegisterPublic(humaPublic, r)
 
+	// AgentAuthMiddleware config — verifies an agent's own ZeroID-issued ES256
+	// access token and sets tenant/identity from the validated claims. Shared by
+	// the self-service group below (public) and the proof-generation group on the
+	// admin router further down.
+	agentAuthCfg := internalMiddleware.AgentAuthConfig{
+		PublicKey: jwksSvc.PublicKey(),
+		Issuer:    cfg.Token.Issuer,
+		// RFC 9728 §5.1 breadcrumb on 401s — points cold-start clients at the PRM
+		// document so they can chain resource → PRM → AS metadata.
+		ResourceMetadataURL: cfg.Token.Issuer + "/.well-known/oauth-protected-resource",
+	}
+
+	// Agent self-service group — authenticated by the agent's OWN access token
+	// (NOT the admin/internal secret) and mounted on the public router so agents
+	// can reach it directly on the public ingress. Tenant + identity come from the
+	// validated token claims (never headers). Holds POST /agents/self/public-key.
+	r.Group(func(r chi.Router) {
+		r.Use(internalMiddleware.AgentAuthMiddleware(agentAuthCfg))
+		// Specless: this group shares the root router with RegisterPublic, so it
+		// must not register a second /openapi.json that would shadow the canonical
+		// public spec.
+		apiHandler.RegisterAgentSelfService(handler.NewHumaAPISpecless(r))
+	})
+
 	// Admin routes — mounted under AdminPathPrefix (default "/api/v1").
 	// No built-in auth by default. Protected at the network layer or via AdminAuth hook.
 	adminPrefix := cfg.Server.GetAdminPathPrefix()
@@ -345,16 +369,9 @@ func NewServer(cfg Config) (*Server, error) {
 		humaAdmin := handler.NewHumaAPI(r)
 		apiHandler.RegisterAdmin(humaAdmin, r)
 
-		// Agent-auth sub-group for proof generation (requires agent JWT).
+		// Agent-auth sub-group for proof generation (requires agent JWT). Reuses
+		// the agentAuthCfg defined above for the public self-service group.
 		r.Group(func(r chi.Router) {
-			agentAuthCfg := internalMiddleware.AgentAuthConfig{
-				PublicKey: jwksSvc.PublicKey(),
-				Issuer:    cfg.Token.Issuer,
-				// RFC 9728 §5.1 breadcrumb on 401s — points cold-start
-				// clients at the PRM document so they can chain
-				// resource → PRM → AS metadata without prior knowledge.
-				ResourceMetadataURL: cfg.Token.Issuer + "/.well-known/oauth-protected-resource",
-			}
 			r.Use(internalMiddleware.AgentAuthMiddleware(agentAuthCfg))
 
 			humaAgentAuth := handler.NewHumaAPI(r)


### PR DESCRIPTION
## Summary

Adds **`POST /agents/self/public-key`** so an agent can enroll or rotate its own EC P-256 actor-assertion public key **after** registration.

Today `public_key_pem` is only settable at registration and is immutable afterward. An identity registered without a key can therefore never act as a `jwt_bearer` (RFC 7523) or `token_exchange` (RFC 8693) actor — it gets `400 invalid_grant: no public key registered`. This endpoint closes that gap and makes the key rotatable.

## Auth model

Mounted on the **public router behind `AgentAuthMiddleware`** — *not* the internal-secret admin group — so an agent reaches it directly with its own `api_key`-grant access token. Identity + tenant are taken from the validated token claims, never from request headers or the path, so an agent can only set **its own** key.

## Proof-of-possession (RFC 8555 §7.3.5-style)

| Case | Required proofs |
|------|-----------------|
| **First-set** (no key yet) | `new_key_proof` — ES256 JWS signed by the **new** key (proves control of the key being registered). Trust-on-first-use, authorized by the access token. |
| **Rotation** (key exists) | `new_key_proof` **+** `current_key_proof` — ES256 JWS signed by the **current** key, bound to the new key via an `nkt` thumbprint claim. A stolen access token alone (no current private key) cannot rotate an enrolled key. |

All proofs are **audience-bound** (`<issuer>/agents/self/public-key`), **lifetime-capped** (≤ 2 min), and **single-use** (`jti` recorded in the shared replay store, namespaced so it can't collide with DPoP jtis). Algorithm pinned to ES256.

## Also

- **Admin force-set:** `PATCH /agents/registry/{id}` now accepts `public_key_pem` on the secret-gated management route — an operator recovery path when an agent can no longer prove control of its key (no proof-of-possession; admin authority is the authorization).
- Key changes are **audit-logged** via the existing identity-update trigger (`modified_by` = the agent's WIMSE URI for self-service).
- The self-service huma instance is registered **without** OpenAPI/docs routes (`NewHumaAPISpecless`) so it doesn't shadow the canonical public `/openapi.json`.

## Tests
- Unit: proof verifier — valid, wrong signing key, wrong aud, wrong sub, expired, over-long lifetime, missing `jti`, replay, `nkt` binding; plus the thumbprint helper. (`internal/service/actor_key_proof_test.go`)
- Full existing suite green (`go test ./...`), incl. the integration suite. Downstream consumer builds verified against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)