### PR TITLE
fix: soft-delete identities/agents instead of hard delete (authn#109)

### DIFF
--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -302,6 +302,17 @@ func (a *API) registerAgentOp(ctx context.Context, input *RegisterAgentInput) (*
 		ExpiresAt:                input.Body.ExpiresAt,
 	})
 	if err != nil {
+		// A collision with a soft-deleted identity is actionable — surface the
+		// existing id so the caller can reactivate it instead of being stuck
+		// behind an opaque 409 for a row hidden from the active registry view.
+		var deactErr *service.IdentityDeactivatedConflictError
+		if errors.As(err, &deactErr) {
+			return nil, huma.Error409Conflict(deactErr.Error(), &huma.ErrorDetail{
+				Message:  "reactivate the deactivated identity (POST /agents/registry/{id}/activate) or register with a different external_id",
+				Location: "body.external_id",
+				Value:    deactErr.ExistingID,
+			})
+		}
 		if errors.Is(err, service.ErrIdentityAlreadyExists) {
 			return nil, huma.Error409Conflict("identity with this external_id already exists")
 		}

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -415,9 +415,14 @@ func (a *API) deleteIdentityOp(ctx context.Context, input *IdentityIDInput) (*st
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	if err := a.identitySvc.DeleteIdentity(ctx, input.ID, tenant.AccountID, tenant.ProjectID); err != nil {
-		log.Error().Err(err).Str("identity_id", input.ID).Msg("failed to delete identity")
-		return nil, huma.Error500InternalServerError("failed to delete identity")
+	// Soft delete: deactivate rather than hard-delete. Matches the route's
+	// "Deactivate an identity (soft delete)" summary and the platform "never
+	// hard DELETE" convention, and avoids the non-cascading service_keys FK
+	// that 500s a hard delete on existing deployments (authn#109). mapErr
+	// surfaces a missing identity as 404 rather than a blanket 500.
+	if err := a.identitySvc.DeactivateIdentity(ctx, input.ID, tenant.AccountID, tenant.ProjectID); err != nil {
+		log.Error().Err(err).Str("identity_id", input.ID).Msg("failed to deactivate identity")
+		return nil, mapErr(err)
 	}
 
 	return nil, nil

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -240,6 +240,17 @@ func (a *API) createIdentityOp(ctx context.Context, input *CreateIdentityInput) 
 		ExpiresAt:          input.Body.ExpiresAt,
 	})
 	if err != nil {
+		// A collision with a soft-deleted identity is actionable — surface the
+		// existing id so the caller can reactivate it instead of being stuck
+		// behind an opaque 409 for a row hidden from the active registry view.
+		var deactErr *service.IdentityDeactivatedConflictError
+		if errors.As(err, &deactErr) {
+			return nil, huma.Error409Conflict(deactErr.Error(), &huma.ErrorDetail{
+				Message:  "reactivate the deactivated identity (PUT /identities/{id} with status=active) or register with a different external_id",
+				Location: "body.external_id",
+				Value:    deactErr.ExistingID,
+			})
+		}
 		if errors.Is(err, service.ErrIdentityAlreadyExists) {
 			return nil, huma.Error409Conflict("identity with this external_id already exists")
 		}

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -420,7 +420,7 @@ func (a *API) deleteIdentityOp(ctx context.Context, input *IdentityIDInput) (*st
 	// hard DELETE" convention, and avoids the non-cascading service_keys FK
 	// that 500s a hard delete on existing deployments (authn#109). mapErr
 	// surfaces a missing identity as 404 rather than a blanket 500.
-	if err := a.identitySvc.DeactivateIdentity(ctx, input.ID, tenant.AccountID, tenant.ProjectID); err != nil {
+	if _, err := a.identitySvc.DeactivateIdentity(ctx, input.ID, tenant.AccountID, tenant.ProjectID); err != nil {
 		log.Error().Err(err).Str("identity_id", input.ID).Msg("failed to deactivate identity")
 		return nil, mapErr(err)
 	}

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -411,11 +411,7 @@ func (s *AgentService) SetPublicKey(ctx context.Context, identityID, accountID, 
 // a no-op success (DeactivateIdentity short-circuits the status-transition
 // guard).
 func (s *AgentService) DeleteAgent(ctx context.Context, id, accountID, projectID string) (*AgentResponse, error) {
-	if err := s.identitySvc.DeactivateIdentity(ctx, id, accountID, projectID); err != nil {
-		return nil, err
-	}
-
-	identity, err := s.identitySvc.GetIdentity(ctx, id, accountID, projectID)
+	identity, err := s.identitySvc.DeactivateIdentity(ctx, id, accountID, projectID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -212,8 +212,12 @@ func (s *AgentService) RegisterAgent(ctx context.Context, req RegisterAgentReque
 		ExpiresAt:          req.ExpiresAt,
 	})
 	if err != nil {
-		// Compensating action — deactivate the identity if key creation fails.
-		_ = s.identitySvc.DeleteIdentity(ctx, identity.ID, req.AccountID, req.ProjectID)
+		// Compensating action — hard-purge the half-created identity if key
+		// creation fails. Purge (not deactivate) is correct here: registration
+		// did not complete, so no deactivated ghost should linger holding the
+		// external_id. Safe against the service_keys FK because CreateKey
+		// persists its row last — a failure never leaves a service key behind.
+		_ = s.identitySvc.PurgeIdentity(ctx, identity.ID, req.AccountID, req.ProjectID)
 		return nil, fmt.Errorf("failed to create API key: %w", err)
 	}
 
@@ -392,19 +396,33 @@ func (s *AgentService) SetPublicKey(ctx context.Context, identityID, accountID, 
 	return &resp, nil
 }
 
-// DeleteAgent deactivates an agent and revokes its keys.
+// DeleteAgent soft-deletes an agent. DELETE on the registry deactivates the
+// identity rather than issuing a hard DELETE — matching the endpoint's "soft
+// delete" contract and the platform "never hard DELETE" convention.
+// Deactivation sweeps the agent's API keys, cascade-revokes active
+// credentials, and emits the retirement CAE signal (see DeactivateAgent /
+// IdentityService.runDeactivationCleanup), so it is behaviourally the same as
+// POST /agents/registry/{id}/deactivate.
+//
+// A hard delete here previously returned 500 for any agent that had a service
+// key, because service_keys carries a non-cascading FK to identities on
+// existing deployments (authn#109). Deactivation sidesteps that entirely and
+// keeps the audit trail. Idempotent: deleting an already-deactivated agent is
+// a no-op success (DeactivateIdentity short-circuits the status-transition
+// guard).
 func (s *AgentService) DeleteAgent(ctx context.Context, id, accountID, projectID string) (*AgentResponse, error) {
+	if err := s.identitySvc.DeactivateIdentity(ctx, id, accountID, projectID); err != nil {
+		return nil, err
+	}
+
 	identity, err := s.identitySvc.GetIdentity(ctx, id, accountID, projectID)
 	if err != nil {
 		return nil, err
 	}
 
-	// Hard delete — cascades to api_keys, credentials, etc. via FK ON DELETE CASCADE.
-	if err := s.identitySvc.DeleteIdentity(ctx, id, accountID, projectID); err != nil {
-		return nil, err
-	}
+	keyPrefix := s.getKeyPrefix(ctx, identity.ID)
+	resp := identityToAgentResponse(identity, keyPrefix)
 
-	resp := identityToAgentResponse(identity, "")
 	return &resp, nil
 }
 

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/uptrace/bun/driver/pgdriver"
 )
@@ -11,4 +12,24 @@ import (
 func isDuplicateKeyError(err error) bool {
 	var pgErr pgdriver.Error
 	return errors.As(err, &pgErr) && pgErr.Field('C') == "23505"
+}
+
+// IdentityDeactivatedConflictError is returned by RegisterIdentity when the
+// external_id collides with an existing identity that is DEACTIVATED (soft
+// deleted). Because deletes are soft, the deactivated row keeps the
+// UNIQUE(account_id, project_id, external_id) slot, so registration can't reuse
+// the external_id. Rather than an opaque "already exists" 409 — confusing
+// because the conflicting identity is hidden from the default (active-only)
+// registry view — this carries the existing identity's id so the caller can
+// reactivate it (or knowingly choose a different external_id).
+type IdentityDeactivatedConflictError struct {
+	ExternalID string
+	ExistingID string
+}
+
+func (e *IdentityDeactivatedConflictError) Error() string {
+	return fmt.Sprintf(
+		"an identity with external_id %q already exists but is deactivated (id: %s); reactivate it or register with a different external_id",
+		e.ExternalID, e.ExistingID,
+	)
 }

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -235,6 +235,14 @@ func (s *IdentityService) RegisterIdentity(ctx context.Context, req RegisterIden
 
 	if err := s.repo.Create(ctx, identity); err != nil {
 		if isDuplicateKeyError(err) {
+			// Distinguish a collision with a DEACTIVATED (soft-deleted) identity
+			// — which is actionable via reactivation — from a live duplicate.
+			// Best-effort: if the lookup fails, fall back to the generic error.
+			if existing, gerr := s.repo.GetByExternalID(ctx, req.ExternalID, req.AccountID, req.ProjectID); gerr == nil &&
+				existing != nil && existing.Status == domain.IdentityStatusDeactivated {
+				return nil, &IdentityDeactivatedConflictError{ExternalID: req.ExternalID, ExistingID: existing.ID}
+			}
+
 			return nil, ErrIdentityAlreadyExists
 		}
 		return nil, fmt.Errorf("failed to register identity: %w", err)

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -607,21 +607,27 @@ func (s *IdentityService) PurgeIdentity(ctx context.Context, id, accountID, proj
 // guard (deactivated → deactivated is rejected) and surface a spurious 400,
 // breaking the idempotency callers expect of DELETE. A missing identity
 // returns the repo's not-found error so the handler can map it to 404.
-func (s *IdentityService) DeactivateIdentity(ctx context.Context, id, accountID, projectID string) error {
+// Returns the resulting identity so callers that need to render a response
+// (e.g. AgentService.DeleteAgent) can reuse it instead of issuing a second
+// load.
+func (s *IdentityService) DeactivateIdentity(ctx context.Context, id, accountID, projectID string) (*domain.Identity, error) {
 	identity, err := s.repo.GetByID(ctx, id, accountID, projectID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if identity.Status == domain.IdentityStatusDeactivated {
-		return nil
+		return identity, nil
 	}
 
 	status := domain.IdentityStatusDeactivated
 
-	_, err = s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
+	updated, err := s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
+	if err != nil {
+		return nil, err
+	}
 
-	return err
+	return updated, nil
 }
 
 // runDeactivationCleanup sweeps everything a deactivated or deleted identity

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -567,14 +567,24 @@ func (s *IdentityService) SweepExpiredIdentities(ctx context.Context) (int, erro
 	return count, nil
 }
 
-// DeleteIdentity permanently removes an identity and cascades to related records.
+// PurgeIdentity permanently removes an identity row (hard delete) and cascades
+// to related records. It is reserved for the compensating rollback of a
+// half-created identity (see AgentService.RegisterAgent).
+//
+// User-facing deletes must NOT call this: DELETE /identities/{id} and
+// DELETE /agents/registry/{id} are SOFT deletes (DeactivateIdentity /
+// DeactivateAgent) per the platform "never hard DELETE" convention, which also
+// preserves the audit trail. A hard delete additionally trips the
+// non-cascading service_keys FK on existing deployments (authn#109); that is
+// safe in the rollback path only because it runs before any service key is
+// persisted (CreateKey writes its row last).
 //
 // Cleanup runs before the DB delete: API keys are revoked, active credentials
 // are cascade-revoked, and a retirement CAE signal is emitted. This ensures
 // tokens issued to the identity stop working at the same moment the identity
 // is removed, not just whenever they happen to TTL-expire (which can be up to
 // 90 days for api_key tokens).
-func (s *IdentityService) DeleteIdentity(ctx context.Context, id, accountID, projectID string) error {
+func (s *IdentityService) PurgeIdentity(ctx context.Context, id, accountID, projectID string) error {
 	identity, err := s.repo.GetByID(ctx, id, accountID, projectID)
 	if err != nil {
 		// Fall through to Delete so callers get the same not-found semantics.
@@ -582,6 +592,36 @@ func (s *IdentityService) DeleteIdentity(ctx context.Context, id, accountID, pro
 	}
 	s.runDeactivationCleanup(ctx, identity, "identity_deleted")
 	return s.repo.Delete(ctx, id, accountID, projectID)
+}
+
+// DeactivateIdentity is the soft delete: it flips the identity to the
+// deactivated status via the shared UpdateIdentity path, which sweeps linked
+// API keys, cascade-revokes active credentials, and emits the retirement CAE
+// signal on a fresh transition. This is what DELETE /identities/{id} and
+// DELETE /agents/registry/{id} resolve to — the identity row is RETAINED
+// (preserving the audit trail) and no hard DELETE is issued, so the
+// non-cascading service_keys FK (authn#109) is never touched.
+//
+// Idempotent: an already-deactivated identity is a no-op success. Without this
+// short-circuit a repeated DELETE would hit UpdateIdentity's status-transition
+// guard (deactivated → deactivated is rejected) and surface a spurious 400,
+// breaking the idempotency callers expect of DELETE. A missing identity
+// returns the repo's not-found error so the handler can map it to 404.
+func (s *IdentityService) DeactivateIdentity(ctx context.Context, id, accountID, projectID string) error {
+	identity, err := s.repo.GetByID(ctx, id, accountID, projectID)
+	if err != nil {
+		return err
+	}
+
+	if identity.Status == domain.IdentityStatusDeactivated {
+		return nil
+	}
+
+	status := domain.IdentityStatusDeactivated
+
+	_, err = s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
+
+	return err
 }
 
 // runDeactivationCleanup sweeps everything a deactivated or deleted identity

--- a/tests/integration/agent_test.go
+++ b/tests/integration/agent_test.go
@@ -209,3 +209,54 @@ func TestDeleteAgent_WithServiceKey_SoftDeletes(t *testing.T) {
 	assert.Equal(t, http.StatusOK, delAgain.StatusCode, "repeat DELETE must be idempotent")
 	_ = delAgain.Body.Close()
 }
+
+// TestRegisterAgent_ReusingDeactivatedExternalID_Returns409WithExistingID
+// covers the re-registration UX after a soft delete: because DELETE is now a
+// soft delete, the deactivated row keeps the external_id, so re-registering it
+// collides. The 409 must be actionable — it names the deactivated identity's
+// id (hidden from the active registry view) so the caller can reactivate it
+// instead of hitting an opaque "already exists".
+func TestRegisterAgent_ReusingDeactivatedExternalID_Returns409WithExistingID(t *testing.T) {
+	ext := uid("reregister-deactivated")
+	reg := registerAgent(t, ext)
+
+	delResp, err := doRaw(t, http.MethodDelete, adminPath("/agents/registry/"+reg.AgentID), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, delResp.StatusCode)
+	_ = delResp.Body.Close()
+
+	// Re-registering the same external_id collides with the soft-deleted row.
+	resp := post(t, adminPath("/agents/register"), map[string]any{
+		"name":        ext,
+		"external_id": ext,
+		"sub_type":    "orchestrator",
+		"trust_level": "first_party",
+		"created_by":  "test-user",
+	}, adminHeaders())
+	require.Equal(t, http.StatusConflict, resp.StatusCode,
+		"re-registering a soft-deleted external_id must 409 (actionable), not 500 or an opaque conflict")
+
+	body := decode(t, resp)
+
+	detail, _ := body["detail"].(string)
+	assert.Contains(t, detail, "deactivated",
+		"the 409 detail must explain the existing identity is deactivated; got %q", detail)
+	assert.Contains(t, detail, reg.AgentID,
+		"the 409 detail must include the existing identity id for reactivation; got %q", detail)
+
+	// Machine-readable detail: errors[0].value carries the existing id so a UI
+	// can offer a one-click reactivate.
+	errs, _ := body["errors"].([]any)
+	require.NotEmpty(t, errs, "expected a structured error detail carrying the existing id")
+	first, _ := errs[0].(map[string]any)
+	assert.Equal(t, reg.AgentID, first["value"],
+		"errors[0].value must be the deactivated identity id")
+
+	// Sanity: a genuinely fresh external_id still registers fine.
+	fresh := post(t, adminPath("/agents/register"), map[string]any{
+		"name": uid("fresh"), "external_id": uid("fresh-ext"),
+		"sub_type": "orchestrator", "trust_level": "first_party", "created_by": "test-user",
+	}, adminHeaders())
+	assert.Equal(t, http.StatusCreated, fresh.StatusCode)
+	_ = fresh.Body.Close()
+}

--- a/tests/integration/agent_test.go
+++ b/tests/integration/agent_test.go
@@ -164,3 +164,48 @@ func TestRegisterAgent_CrossTenantCredentialPolicyRejected(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"cross-tenant credential_policy_id must be rejected at register-agent with 400")
 }
+
+// TestDeleteAgent_WithServiceKey_SoftDeletes is the regression for authn#109:
+// DELETE /agents/registry/{id} on an agent that has a service key must SOFT
+// delete (deactivate) it, not hard-delete. Previously the hard delete returned
+// 500 on the non-cascading service_keys FK (every registered agent gets a
+// bootstrap key, so all agent deletes failed). The fix deactivates instead:
+// the request succeeds, the identity row is retained as deactivated (audit
+// trail preserved + matches the "soft delete" contract), and the agent's
+// credentials are revoked on the way out.
+func TestDeleteAgent_WithServiceKey_SoftDeletes(t *testing.T) {
+	ext := uid("delete-agent-softdelete")
+	reg := registerAgent(t, ext) // registration auto-creates a service key
+
+	// Mint a live token from the bootstrap key so we can prove revocation.
+	issueResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    reg.APIKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, issueResp.StatusCode)
+	token := decode(t, issueResp)["access_token"].(string)
+	require.True(t, introspect(t, token)["active"].(bool), "token should be active before delete")
+
+	// DELETE must succeed — not 500 on the service_keys FK.
+	delResp, err := doRaw(t, http.MethodDelete, adminPath("/agents/registry/"+reg.AgentID), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, delResp.StatusCode,
+		"DELETE of an agent with a service key must succeed, not 500 on the service_keys FK")
+	_ = delResp.Body.Close()
+
+	// Soft delete: the identity row is RETAINED and flipped to deactivated.
+	getResp := get(t, adminPath("/identities/"+reg.AgentID), adminHeaders())
+	require.Equal(t, http.StatusOK, getResp.StatusCode, "identity must still exist after a soft delete")
+	assert.Equal(t, "deactivated", decode(t, getResp)["status"],
+		"DELETE must deactivate the agent, not hard-delete it")
+
+	// Credentials revoked on the way out (the "revoke its keys" half of the contract).
+	assert.False(t, introspect(t, token)["active"].(bool),
+		"DELETE must revoke the agent's credentials")
+
+	// Idempotent: deleting an already-deactivated agent still succeeds.
+	delAgain, err := doRaw(t, http.MethodDelete, adminPath("/agents/registry/"+reg.AgentID), nil, adminHeaders())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, delAgain.StatusCode, "repeat DELETE must be idempotent")
+	_ = delAgain.Body.Close()
+}

--- a/tests/integration/deactivation_test.go
+++ b/tests/integration/deactivation_test.go
@@ -221,9 +221,10 @@ func TestAdminIssueOnDeactivatedIdentityRejected(t *testing.T) {
 	assert.Less(t, issueResp.StatusCode, 600)
 }
 
-// TestDeleteIdentityRunsCleanup verifies DeleteIdentity sweeps linked tokens
-// before removing the identity row. Otherwise, credentials with the deleted
-// identity_id would survive (FK set to NULL) and remain valid until TTL.
+// TestDeleteIdentityRunsCleanup verifies DELETE /identities/{id} sweeps linked
+// tokens. The endpoint is a soft delete (deactivate): the identity row is
+// retained but its credentials are revoked, so tokens stop working immediately
+// rather than surviving until TTL.
 func TestDeleteIdentityRunsCleanup(t *testing.T) {
 	ext := uid("delete-cleanup")
 	reg := registerAgent(t, ext)
@@ -236,14 +237,19 @@ func TestDeleteIdentityRunsCleanup(t *testing.T) {
 	token := decode(t, issueResp)["access_token"].(string)
 	require.True(t, introspect(t, token)["active"].(bool))
 
-	// DELETE /identities/{id} — permanent removal.
+	// DELETE /identities/{id} — soft delete (deactivate).
 	delResp, err := doRaw(t, http.MethodDelete, adminPath("/identities/"+reg.AgentID), nil, adminHeaders())
 	require.NoError(t, err)
 	require.True(t, delResp.StatusCode >= 200 && delResp.StatusCode < 300,
 		"DELETE /identities/{id} should succeed")
 	_ = delResp.Body.Close()
 
-	// Token must be revoked — cleanup ran before delete.
+	// The identity row is retained, flipped to deactivated (soft delete).
+	getResp := get(t, adminPath("/identities/"+reg.AgentID), adminHeaders())
+	require.Equal(t, http.StatusOK, getResp.StatusCode, "identity must still exist after a soft delete")
+	assert.Equal(t, "deactivated", decode(t, getResp)["status"])
+
+	// Token must be revoked — cleanup ran on deactivation.
 	assert.False(t, introspect(t, token)["active"].(bool),
-		"DELETE /identities must revoke credentials before removing the identity row")
+		"DELETE /identities must revoke credentials")
 }

--- a/tests/integration/identity_test.go
+++ b/tests/integration/identity_test.go
@@ -205,7 +205,9 @@ func TestUpdateIdentityTrustLevel(t *testing.T) {
 	assert.Equal(t, "verified_third_party", body["trust_level"])
 }
 
-// TestDeleteIdentity verifies that DELETE /api/v1/identities/{id} deactivates the identity.
+// TestDeleteIdentity verifies that DELETE /api/v1/identities/{id} deactivates
+// the identity (soft delete) rather than hard-deleting it: the call returns
+// 204 and the identity row is retained with status=deactivated.
 func TestDeleteIdentity(t *testing.T) {
 	externalID := uid("delete-agent")
 	identity := registerIdentity(t, externalID, []string{"billing:read"})
@@ -214,6 +216,12 @@ func TestDeleteIdentity(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
 	_ = resp.Body.Close()
+
+	// Soft delete: the row survives, flipped to deactivated (not 404/gone).
+	getResp := get(t, adminPath("/identities/"+identity.ID), adminHeaders())
+	require.Equal(t, http.StatusOK, getResp.StatusCode, "identity must still exist after a soft delete")
+	assert.Equal(t, "deactivated", decode(t, getResp)["status"],
+		"DELETE /identities/{id} must deactivate, not hard-delete")
 }
 
 func TestServerGetIdentity(t *testing.T) {


### PR DESCRIPTION
Fixes the 500 reported in [highflame-authn#109](https://github.com/highflame-ai/highflame-authn/issues/109): `DELETE /agents/registry/{id}` (and `DELETE /identities/{id}`) fail with a `service_keys_identity_id_fkey` violation for any identity that has a service key. Since every registered agent gets a bootstrap API key, **all agent deletes fail** from Studio's Registry.

## Root cause

Both endpoints **hard-delete** the identity row (`DeleteIdentity` → `repo.Delete`), but their route summaries already advertise *"soft delete"* / *"Deactivate ... (soft delete)"*, and the platform convention is **never hard DELETE**. The handlers just never matched the contract.

The leftover `service_keys` rows (revoked, but not removed) then block the `DELETE FROM identities`. Note migration `006` *declares* `service_keys.identity_id ON DELETE CASCADE` — but existing deployments carry a **non-cascading** FK: the table predates the cascade and `CREATE TABLE IF NOT EXISTS` never re-applied it. So a migration that re-declares the cascade wouldn't help existing DBs. **Soft delete sidesteps the drift entirely.**

## Fix

Both DELETE endpoints now **deactivate** the identity instead of removing it:
- `AgentService.DeleteAgent` and the `deleteIdentityOp` handler route through new `IdentityService.DeactivateIdentity` (flip `status → deactivated` via the shared `UpdateIdentity` path), which sweeps linked API keys, cascade-revokes active credentials, and emits the retirement CAE signal. The row is **retained** (audit trail preserved); no hard DELETE is issued, so the `service_keys` FK is never touched.
- `DeactivateIdentity` is **idempotent**: an already-deactivated identity is a no-op success (so a repeat DELETE doesn't trip `UpdateIdentity`'s transition guard with a spurious 400); a missing identity surfaces as **404**.
- The hard-delete is **renamed `DeleteIdentity` → `PurgeIdentity`** and reserved for the registration rollback (purge a half-created identity). That rollback stays safe against the FK because `CreateKey` persists its row **last** — a failure never leaves a service key behind. (Internal method; authn consumes zeroid over HTTP + the public `Server`/`domain` packages, so there's no downstream churn.)

## Tests (integration, testcontainers Postgres)

- **`TestDeleteAgent_WithServiceKey_SoftDeletes`** — the authn#109 regression: register an agent (with a key) → `DELETE /agents/registry/{id}` → 200, identity **retained as `deactivated`**, credentials revoked, repeat DELETE idempotent.
- Strengthened `TestDeleteIdentity` / `TestDeleteIdentityRunsCleanup` to assert the identity is **retained-deactivated** (not removed) after DELETE — these previously passed only because a fresh testcontainer DB *has* the cascade, masking the production drift.

Full integration suite green; `golangci-lint` 0 issues.

## Downstream validation

Per the zeroid release convention, validated **highflame-authn** against this branch via a local `replace` directive: authn **builds and its full test suite passes**. authn only imports zeroid's root + `domain` packages (deletes go over HTTP), so the internal rename is invisible to it.

Follow-up after release: bump `zeroid` in highflame-authn to the new tag and close authn#109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)