### PR TITLE
fix: accept any port on loopback redirect URIs per RFC 8252 §7.3

### DIFF
--- a/internal/service/authcode_issue_test.go
+++ b/internal/service/authcode_issue_test.go
@@ -269,8 +269,23 @@ func TestRedirectURIAllowed(t *testing.T) {
 		{"exact match localhost", "http://localhost:17580/callback", true},
 		{"127.0.0.1 ↔ localhost equiv", "http://127.0.0.1:17580/callback", true},
 		{"exact match https", "https://app.example.com/oauth/callback", true},
-		{"wrong port", "http://localhost:17581/callback", false},
-		{"wrong path", "http://localhost:17580/other", false},
+
+		// RFC 8252 §7.3: any port is accepted on a loopback redirect, because
+		// the native/CLI app binds an ephemeral OS-assigned port.
+		{"loopback different port", "http://localhost:17581/callback", true},
+		{"loopback ephemeral high port", "http://localhost:54321/callback", true},
+		{"loopback 127.0.0.1 different port", "http://127.0.0.1:49999/callback", true},
+		{"loopback no port", "http://localhost/callback", true},
+
+		// Only the port floats — scheme / path / host / extras must still match.
+		{"loopback wrong path", "http://localhost:17580/other", false},
+		{"loopback wrong scheme", "https://localhost:17580/callback", false},
+		{"loopback with userinfo rejected", "http://evil@127.0.0.1:17580/callback", false},
+		{"loopback with query rejected", "http://localhost:17580/callback?x=1", false},
+		{"loopback look-alike host", "http://127.0.0.1.evil.com:17580/callback", false},
+
+		// Non-loopback hosts get NO port leniency — exact match only.
+		{"non-loopback different port", "https://app.example.com:9443/oauth/callback", false},
 		{"wrong host", "https://attacker.example.com/oauth/callback", false},
 		{"unregistered scheme", "http://app.example.com/oauth/callback", false},
 		{"empty candidate", "", false},

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -1178,18 +1179,69 @@ func (s *OAuthService) IssueAuthCode(ctx context.Context, req IssueAuthCodeReque
 	return signed, nil
 }
 
-// redirectURIAllowed reports whether candidate matches any of the
-// registered URIs under loopback normalization (RFC 8252 §7.3). Used by
-// IssueAuthCode at /oauth2/authorize time AND by authorizationCode at
-// /oauth2/token time so both ends apply the same allow-list rule.
+// redirectURIAllowed reports whether candidate matches one of the client's
+// registered redirect URIs. Used by IssueAuthCode at /oauth2/authorize time.
+//
+// Non-loopback URIs must match exactly (after normalizeLoopback's 127.0.0.1 ↔
+// localhost equivalence). LOOPBACK URIs are matched with the PORT IGNORED:
+// RFC 8252 §7.3 requires the authorization server to "allow any port to be
+// specified at the time of the request for loopback IP redirect URIs", because
+// a native / CLI app binds an ephemeral, OS-assigned port for its callback
+// listener and cannot reserve a fixed one in advance. So for a loopback
+// candidate we accept it when some registered loopback URI shares the same
+// scheme, host (treating 127.0.0.1, localhost and ::1 as equivalent), path and
+// query — only the port floats; userinfo and fragments are rejected.
+//
+// This is safe: the loopback interface is reachable only from the same host, so
+// no remote attacker can stand up a listener to intercept the redirect, and
+// PKCE binds the code to the verifier regardless. Without it, the embedded
+// Overwatch/ramparts Guardian (which listens on an ephemeral loopback port)
+// is rejected here even though its redirect is a legitimate loopback callback.
 func redirectURIAllowed(candidate string, registered []string) bool {
 	normCand := normalizeLoopback(candidate)
+
+	cu, cerr := url.Parse(candidate)
+	candLoopback := cerr == nil && isLoopbackHost(cu.Hostname())
+
 	for _, r := range registered {
 		if normalizeLoopback(r) == normCand {
 			return true
 		}
+
+		if !candLoopback {
+			continue
+		}
+
+		ru, rerr := url.Parse(r)
+		if rerr != nil || !isLoopbackHost(ru.Hostname()) {
+			continue
+		}
+
+		// Loopback: match everything but the port. Reject userinfo /
+		// fragments — registered redirect URIs carry neither, and the old
+		// Studio-side regex anchored them out too.
+		if cu.User == nil && cu.Fragment == "" &&
+			cu.Scheme == ru.Scheme && cu.Path == ru.Path && cu.RawQuery == ru.RawQuery {
+			return true
+		}
 	}
+
 	return false
+}
+
+// isLoopbackHost reports whether host is one of the canonical loopback forms a
+// native/CLI redirect URI uses, for RFC 8252 §7.3 port-agnostic matching. We
+// treat 127.0.0.1, localhost and ::1 as equivalent (the seed config registers
+// the 127.0.0.1 and localhost variants). Anything else — including a
+// look-alike like "127.0.0.1.evil.com" — is not loopback and falls through to
+// exact matching.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "127.0.0.1", "localhost", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 // authorizationCode handles the PKCE authorization code grant (RFC 6749 section 4.1).


### PR DESCRIPTION
Fixes the Overwatch PKCE failure: `redirect_uri is not in the client's registered list`.

## Root cause

The embedded Overwatch/ramparts **Guardian binds an ephemeral, OS-assigned loopback port** for its OAuth callback (`packages/guardian/src/module.ts` → `new GuardianHttpServer(config.httpPort || 0)` → port `0`). The redirect_uri it sends is therefore `http://127.0.0.1:<ephemeral>/oauth/callback`. `redirectURIAllowed` did an **exact-match including the port** against the fixed `overwatch-cli` seed list (`17580–17584`), so the ephemeral port was rejected.

This regressed when PKCE redirect validation **moved from Studio to AuthN**. Studio's `isValidRedirectUri` validated with a regex — `/^http:\/\/(127\.0\.0\.1|localhost):\d{4,5}\/oauth\/callback$/` — that accepts **any 4–5 digit loopback port**, so the ephemeral port passed pre-migration. AuthN's exact-match allow-list did not. (The regression test never caught it because it pinned a registered port, `127.0.0.1:17580`.)

## Fix

For **loopback** candidates (`127.0.0.1` / `localhost` / `::1`), match on scheme + host + path + query and **ignore the port**, per **RFC 8252 §7.3** (*"the authorization server MUST allow any port ... for loopback IP redirect URIs"*). Non-loopback URIs keep exact matching — no port leniency. Userinfo and fragments are rejected, and a look-alike like `127.0.0.1.evil.com` is not loopback, so the envelope matches the old anchored Studio regex.

The token-exchange identity check (RFC 6749 §4.1.3, `/oauth2/token`) is **unchanged** — it still compares the two client-supplied redirect_uris exactly, so the code stays bound to the specific ephemeral port issued at authorize time.

## Security

Reviewed by `security-reviewer` — **CLEAN, no bypass**. Empirically verified rejection of decimal/hex/octal IP encodings, `::ffff:127.0.0.1`, `evil@127.0.0.1`, `127.0.0.1@evil.com`, `127.0.0.1.evil.com`, trailing-dot, fragment/query injection, and backslash hosts; non-loopback hosts get zero port leniency; the emitted `Location` is built from the validated loopback candidate so a code can only ever reach a same-host listener (and PKCE binds it to the verifier regardless).

## Tests

`TestRedirectURIAllowed` gains loopback any-port cases (different / ephemeral / no port) plus negative guards (wrong path/scheme, userinfo, query, look-alike host, and non-loopback ports get **no** leniency). Service unit + OAuth integration tests green; lint 0 issues.

Paired with: highflame-regression#99 (de-fangs the masking test to use a non-registered loopback port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)