### PR TITLE
fix: cascade revocation reachability, proof-token replay race, attestation expiry

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -169,12 +169,23 @@ jobs:
         with:
           node-version: ${{ env.NODE_VER }}
 
-      - name: Run Go tests in tests/
+      # Unit tests live next to their packages (pkg/dpop, pkg/authjwt,
+      # internal/service, domain, config) and were previously not run in CI
+      # at all — only ./tests/... was. Run them with the race detector
+      # (which requires cgo) to cover the concurrency-sensitive surfaces.
+      - name: Run Go unit tests (race detector)
         env:
-          CGO_ENABLED: 0
+          CGO_ENABLED: 1
         shell: bash
         run: |-
-          go test ./tests/... -v -count=1 -timeout=120s
+          go test $(go list ./... | grep -v '/tests') -race -count=1 -timeout=300s
+
+      - name: Run Go integration tests in tests/
+        env:
+          CGO_ENABLED: 1
+        shell: bash
+        run: |-
+          go test ./tests/... -v -race -count=1 -timeout=600s
 
       - name: Install Python SDK smoke dependencies
         shell: bash

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -581,16 +581,24 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 	// policy constraint set (delegation depth ceiling, required trust
 	// level, allowed grant types, max TTL) is enforced inside
 	// IssueCredential against actor.IdentityPolicyID.
+	//
+	// CredentialExpiresAt clamps the child's exp to the subject_token's:
+	// a delegated credential must never outlive its parent. Without this
+	// bound, an exchange near the end of the parent's lifetime mints a
+	// child that survives the parent's expiry — and once the parent row
+	// expires, the cascade-revocation walk can no longer reach the child
+	// (the traversal anchors on live ancestry).
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:          actorIdentity,
-		IdentityPolicyID:  actorPolicy.ID,
-		Scopes:            scopes,
-		GrantType:         domain.GrantTypeTokenExchange,
-		DelegatedBy:       delegatedBy,
-		ParentJTI:         subjectJTI,
-		DelegationDepth:   parentDepth + 1,
-		MissionID:         missionID,
-		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
+		Identity:            actorIdentity,
+		IdentityPolicyID:    actorPolicy.ID,
+		Scopes:              scopes,
+		GrantType:           domain.GrantTypeTokenExchange,
+		DelegatedBy:         delegatedBy,
+		ParentJTI:           subjectJTI,
+		DelegationDepth:     parentDepth + 1,
+		MissionID:           missionID,
+		DPoPKeyThumbprint:   req.DPoPKeyThumbprint,
+		CredentialExpiresAt: &subjectCred.ExpiresAt,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/proof.go
+++ b/internal/service/proof.go
@@ -113,18 +113,18 @@ func (s *ProofService) VerifyProofToken(ctx context.Context, tokenStr, expectedA
 
 	jti, _ := parsed.JwtID()
 
-	// Check if already used (single-use enforcement).
-	pt, err := s.proofRepo.GetByJTI(ctx, jti)
+	// Single-use enforcement: claim the token via the conditional UPDATE in
+	// MarkUsed. Zero rows claimed means another verification got there first
+	// (or the JTI was never issued) — both are replays from this caller's
+	// perspective. A read-then-check here would race: two concurrent
+	// verifications of the same WPT could both observe is_used = FALSE and
+	// both succeed.
+	affected, err := s.proofRepo.MarkUsed(ctx, jti)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lookup proof token: %w", err)
-	}
-	if pt.IsUsed {
-		return nil, ErrNonceReplayed
-	}
-
-	// Mark as used atomically.
-	if err := s.proofRepo.MarkUsed(ctx, jti); err != nil {
 		return nil, fmt.Errorf("failed to mark proof token as used: %w", err)
+	}
+	if affected == 0 {
+		return nil, ErrNonceReplayed
 	}
 
 	return parsed, nil

--- a/internal/service/proof.go
+++ b/internal/service/proof.go
@@ -111,7 +111,14 @@ func (s *ProofService) VerifyProofToken(ctx context.Context, tokenStr, expectedA
 		return nil, fmt.Errorf("proof token validation failed: %w", err)
 	}
 
+	// A WPT without a jti cannot participate in single-use enforcement —
+	// reject it as malformed rather than letting the empty string fall
+	// through to MarkUsed, where the inevitable zero-row claim would
+	// surface as a misleading ErrNonceReplayed.
 	jti, _ := parsed.JwtID()
+	if jti == "" {
+		return nil, fmt.Errorf("proof token validation failed: missing jti claim")
+	}
 
 	// Single-use enforcement: claim the token via the conditional UPDATE in
 	// MarkUsed. Zero rows claimed means another verification got there first

--- a/internal/store/postgres/attestation.go
+++ b/internal/store/postgres/attestation.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/uptrace/bun"
 
@@ -81,6 +82,9 @@ func (r *AttestationRepository) GetByIDForUpdate(ctx context.Context, id, accoun
 
 // GetHighestVerifiedLevel returns the highest verified attestation level for an identity.
 // Returns an empty string if no verified attestation exists.
+// An attestation past its expires_at no longer counts, regardless of the
+// is_expired flag — the flag is only flipped by an out-of-band sweep, so the
+// wall-clock predicate is the enforcement that matters at policy-gate time.
 func (r *AttestationRepository) GetHighestVerifiedLevel(ctx context.Context, identityID string) (string, error) {
 	var level string
 	db := dbOrTx(ctx, r.db)
@@ -90,6 +94,7 @@ func (r *AttestationRepository) GetHighestVerifiedLevel(ctx context.Context, ide
 		Where("identity_id = ?", identityID).
 		Where("is_verified = TRUE").
 		Where("is_expired = FALSE").
+		Where("(expires_at IS NULL OR expires_at > ?)", time.Now()).
 		OrderExpr(`CASE level
 			WHEN 'hardware' THEN 3
 			WHEN 'platform' THEN 2

--- a/internal/store/postgres/proof.go
+++ b/internal/store/postgres/proof.go
@@ -29,19 +29,28 @@ func (r *ProofRepository) Create(ctx context.Context, pt *domain.ProofToken) err
 	return nil
 }
 
-// MarkUsed sets is_used = TRUE and records used_at for the token with the given JTI.
-func (r *ProofRepository) MarkUsed(ctx context.Context, jti string) error {
+// MarkUsed sets is_used = TRUE and records used_at for the token with the
+// given JTI, returning the number of rows claimed. The conditional UPDATE is
+// the single-use enforcement point: 0 rows means another verification already
+// claimed the token (or the JTI is unknown), and the caller must treat that
+// as a replay. A separate read-then-check is not sufficient — two concurrent
+// verifications can both observe is_used = FALSE.
+func (r *ProofRepository) MarkUsed(ctx context.Context, jti string) (int64, error) {
 	now := time.Now()
-	_, err := r.db.NewUpdate().
+	res, err := r.db.NewUpdate().
 		TableExpr("proof_tokens").
 		Set("is_used = TRUE, used_at = ?", now).
 		Where("jti = ?", jti).
 		Where("is_used = FALSE").
 		Exec(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to mark proof token as used: %w", err)
+		return 0, fmt.Errorf("failed to mark proof token as used: %w", err)
 	}
-	return nil
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read proof token claim result: %w", err)
+	}
+	return affected, nil
 }
 
 // GetByJTI retrieves a proof token by its JWT ID.

--- a/internal/store/postgres/proof.go
+++ b/internal/store/postgres/proof.go
@@ -38,7 +38,7 @@ func (r *ProofRepository) Create(ctx context.Context, pt *domain.ProofToken) err
 func (r *ProofRepository) MarkUsed(ctx context.Context, jti string) (int64, error) {
 	now := time.Now()
 	res, err := r.db.NewUpdate().
-		TableExpr("proof_tokens").
+		Model((*domain.ProofToken)(nil)).
 		Set("is_used = TRUE, used_at = ?", now).
 		Where("jti = ?", jti).
 		Where("is_used = FALSE").

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -51,6 +51,13 @@ type CleanupWorker struct {
 // The identity-expiry sweep is wired separately via SetIdentityExpirer
 // after IdentityService is constructed.
 func NewCleanupWorker(db *bun.DB, backchannelRepo *postgres.BackchannelRequestRepository, interval, credRetention time.Duration) *CleanupWorker {
+	// A negative retention would make now.Add(-credRetention) a FUTURE
+	// cutoff and the worker would delete unexpired credentials. Clamp to
+	// zero so a misconfigured max TTL degrades to delete-at-expiry, never
+	// delete-before-expiry.
+	if credRetention < 0 {
+		credRetention = 0
+	}
 	return &CleanupWorker{db: db, backchannelRepo: backchannelRepo, interval: interval, credRetention: credRetention}
 }
 

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -30,16 +30,28 @@ type CleanupWorker struct {
 	backchannelRepo *postgres.BackchannelRequestRepository
 	expirer         IdentityExpirer
 	interval        time.Duration
+	credRetention   time.Duration
 }
 
 // NewCleanupWorker creates a cleanup worker with the given tick interval.
 // backchannelRepo is required so the worker can flip expired CIBA requests
 // to status='expired' (so an in-flight poll sees expired_token before the
 // row is reaped) and then delete the resolved rows.
+//
+// credRetention is how long expired issued_credentials rows are retained
+// before deletion. Expired rows are not just garbage: their parent_jti
+// edges are the path the cascade-revocation walk takes to reach still-live
+// delegated descendants. Deleting a parent row at the moment of expiry
+// severs that edge and strands any child that outlives it. token_exchange
+// now clamps child expiry to the parent's, so retaining for the max token
+// TTL guarantees every edge survives as long as any descendant could —
+// including legacy chains issued before the clamp. Callers pass the
+// configured token max TTL.
+//
 // The identity-expiry sweep is wired separately via SetIdentityExpirer
 // after IdentityService is constructed.
-func NewCleanupWorker(db *bun.DB, backchannelRepo *postgres.BackchannelRequestRepository, interval time.Duration) *CleanupWorker {
-	return &CleanupWorker{db: db, backchannelRepo: backchannelRepo, interval: interval}
+func NewCleanupWorker(db *bun.DB, backchannelRepo *postgres.BackchannelRequestRepository, interval, credRetention time.Duration) *CleanupWorker {
+	return &CleanupWorker{db: db, backchannelRepo: backchannelRepo, interval: interval, credRetention: credRetention}
 }
 
 // SetIdentityExpirer installs the identity-expiry sweep callback. Nil
@@ -74,10 +86,13 @@ func (w *CleanupWorker) Run(ctx context.Context) {
 func (w *CleanupWorker) RunOnce(ctx context.Context) {
 	now := time.Now()
 
-	// Delete all expired credentials regardless of revocation status.
+	// Delete expired credentials regardless of revocation status, but only
+	// after the retention window: parent_jti edges on expired rows are still
+	// needed by the cascade-revocation walk to reach live descendants (see
+	// NewCleanupWorker).
 	credRes, err := w.db.NewDelete().
 		TableExpr("issued_credentials").
-		Where("expires_at < ?", now).
+		Where("expires_at < ?", now.Add(-w.credRetention)).
 		Exec(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Cleanup: failed to delete expired credentials")

--- a/migrations/031_cascade_walk_dead_intermediates.down.sql
+++ b/migrations/031_cascade_walk_dead_intermediates.down.sql
@@ -1,0 +1,94 @@
+-- 031_cascade_walk_dead_intermediates.down.sql
+-- Restores the migration-029 function bodies (liveness filters in the
+-- recursive traversal legs). Same return type, so CREATE OR REPLACE suffices.
+-- Note: rolling back reintroduces the dead-intermediate reachability hole
+-- this migration fixed — live descendants of expired/revoked intermediates
+-- become unreachable by the cascade again.
+
+CREATE OR REPLACE FUNCTION revoke_credentials_cascade(
+    p_identity_id UUID,
+    p_revoked_at  TIMESTAMPTZ,
+    p_reason      TEXT
+) RETURNS TABLE(
+    jti         VARCHAR(255),
+    identity_id UUID,
+    account_id  VARCHAR(255),
+    project_id  VARCHAR(255),
+    expires_at  TIMESTAMPTZ
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE chain(id, jti, depth) AS (
+        SELECT ic.id, ic.jti, 0
+        FROM issued_credentials ic
+        WHERE ic.identity_id = p_identity_id
+          AND ic.is_revoked  = FALSE
+          AND ic.expires_at  > p_revoked_at
+        UNION ALL
+        SELECT ic.id, ic.jti, chain.depth + 1
+        FROM issued_credentials ic
+        JOIN chain ON ic.parent_jti = chain.jti
+        WHERE ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+          AND chain.depth   < 50
+    )
+    CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+    , revoked AS (
+        UPDATE issued_credentials ic
+        SET is_revoked    = TRUE,
+            revoked_at    = p_revoked_at,
+            revoke_reason = p_reason
+        WHERE ic.id IN (SELECT c.id FROM chain c WHERE NOT c.is_cycle)
+          AND ic.is_revoked = FALSE
+        RETURNING ic.jti, ic.identity_id, ic.account_id, ic.project_id, ic.expires_at
+    )
+    SELECT r.jti, r.identity_id, r.account_id, r.project_id, r.expires_at
+    FROM revoked r;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION revoke_credential_cascade(
+    p_id         UUID,
+    p_account_id TEXT,
+    p_project_id TEXT,
+    p_revoked_at TIMESTAMPTZ,
+    p_reason     TEXT
+) RETURNS TABLE(
+    jti         VARCHAR(255),
+    identity_id UUID,
+    account_id  VARCHAR(255),
+    project_id  VARCHAR(255),
+    expires_at  TIMESTAMPTZ
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE chain(id, jti, depth) AS (
+        SELECT ic.id, ic.jti, 0
+        FROM issued_credentials ic
+        WHERE ic.id         = p_id
+          AND ic.account_id = p_account_id
+          AND ic.project_id = p_project_id
+          AND ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+        UNION ALL
+        SELECT ic.id, ic.jti, chain.depth + 1
+        FROM issued_credentials ic
+        JOIN chain ON ic.parent_jti = chain.jti
+        WHERE ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+          AND chain.depth   < 50
+    )
+    CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+    , revoked AS (
+        UPDATE issued_credentials ic
+        SET is_revoked    = TRUE,
+            revoked_at    = p_revoked_at,
+            revoke_reason = p_reason
+        WHERE ic.id IN (SELECT c.id FROM chain c WHERE NOT c.is_cycle)
+          AND ic.is_revoked = FALSE
+        RETURNING ic.jti, ic.identity_id, ic.account_id, ic.project_id, ic.expires_at
+    )
+    SELECT r.jti, r.identity_id, r.account_id, r.project_id, r.expires_at
+    FROM revoked r;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/031_cascade_walk_dead_intermediates.up.sql
+++ b/migrations/031_cascade_walk_dead_intermediates.up.sql
@@ -1,0 +1,113 @@
+-- 031_cascade_walk_dead_intermediates.up.sql
+-- Fixes a reachability hole in the cascade-revocation functions (007/029):
+-- the recursive traversal legs required every visited node to be live
+-- (is_revoked = FALSE AND expires_at > p_revoked_at), so an expired or
+-- already-revoked INTERMEDIATE credential stopped the walk and its still-live
+-- descendants were never revoked.
+--
+-- Concrete failure: orchestrator token A delegates to child B late in A's
+-- lifetime; A expires; A's identity is then revoked. The walk anchored on A
+-- (or on the identity) finds A dead, never reaches B, and B stays valid for
+-- its full remaining TTL despite its entire ancestry being revoked.
+--
+-- The fix moves the liveness filters out of the traversal: the chain CTE now
+-- walks ALL parent_jti edges (cycle guard + depth cap unchanged), and the
+-- final UPDATE alone decides which visited rows actually flip — only rows
+-- that are not yet revoked and not yet expired. Returned-set semantics are
+-- unchanged: callers still receive exactly the credentials that were live
+-- and are now revoked, so the RevocationNotifier fan-out stays accurate and
+-- already-dead rows generate no events.
+--
+-- The anchor legs likewise drop the liveness filters so a dead anchor's live
+-- descendants are reachable (RFC 7009 revoke on an expired parent must still
+-- kill the family).
+--
+-- Companion application-level changes (same release):
+--   * token_exchange clamps child exp to the parent credential's expiry, so
+--     dead-intermediate chains stop being produced going forward.
+--   * the cleanup worker retains expired credential rows for a grace window
+--     so parent_jti edges survive long enough for any late cascade to walk.
+--
+-- Return type is unchanged from 029, so CREATE OR REPLACE suffices.
+
+CREATE OR REPLACE FUNCTION revoke_credentials_cascade(
+    p_identity_id UUID,
+    p_revoked_at  TIMESTAMPTZ,
+    p_reason      TEXT
+) RETURNS TABLE(
+    jti         VARCHAR(255),
+    identity_id UUID,
+    account_id  VARCHAR(255),
+    project_id  VARCHAR(255),
+    expires_at  TIMESTAMPTZ
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE chain(id, jti, depth) AS (
+        SELECT ic.id, ic.jti, 0
+        FROM issued_credentials ic
+        WHERE ic.identity_id = p_identity_id
+        UNION ALL
+        SELECT ic.id, ic.jti, chain.depth + 1
+        FROM issued_credentials ic
+        JOIN chain ON ic.parent_jti = chain.jti
+        WHERE chain.depth < 50
+    )
+    CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+    , revoked AS (
+        UPDATE issued_credentials ic
+        SET is_revoked    = TRUE,
+            revoked_at    = p_revoked_at,
+            revoke_reason = p_reason
+        WHERE ic.id IN (SELECT c.id FROM chain c WHERE NOT c.is_cycle)
+          AND ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+        RETURNING ic.jti, ic.identity_id, ic.account_id, ic.project_id, ic.expires_at
+    )
+    SELECT r.jti, r.identity_id, r.account_id, r.project_id, r.expires_at
+    FROM revoked r;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION revoke_credential_cascade(
+    p_id         UUID,
+    p_account_id TEXT,
+    p_project_id TEXT,
+    p_revoked_at TIMESTAMPTZ,
+    p_reason     TEXT
+) RETURNS TABLE(
+    jti         VARCHAR(255),
+    identity_id UUID,
+    account_id  VARCHAR(255),
+    project_id  VARCHAR(255),
+    expires_at  TIMESTAMPTZ
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE chain(id, jti, depth) AS (
+        SELECT ic.id, ic.jti, 0
+        FROM issued_credentials ic
+        WHERE ic.id         = p_id
+          AND ic.account_id = p_account_id
+          AND ic.project_id = p_project_id
+        UNION ALL
+        SELECT ic.id, ic.jti, chain.depth + 1
+        FROM issued_credentials ic
+        JOIN chain ON ic.parent_jti = chain.jti
+        WHERE chain.depth < 50
+    )
+    CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+    , revoked AS (
+        UPDATE issued_credentials ic
+        SET is_revoked    = TRUE,
+            revoked_at    = p_revoked_at,
+            revoke_reason = p_reason
+        WHERE ic.id IN (SELECT c.id FROM chain c WHERE NOT c.is_cycle)
+          AND ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+        RETURNING ic.jti, ic.identity_id, ic.account_id, ic.project_id, ic.expires_at
+    )
+    SELECT r.jti, r.identity_id, r.account_id, r.project_id, r.expires_at
+    FROM revoked r;
+END;
+$$ LANGUAGE plpgsql;

--- a/server.go
+++ b/server.go
@@ -410,7 +410,7 @@ func NewServer(cfg Config) (*Server, error) {
 		jwksSvc:              jwksSvc,
 		refreshTokenSvc:      refreshTokenSvc,
 		revocationDispatcher: revocationDispatcher,
-		cleanupWorker:        worker.NewCleanupWorker(db, backchannelRepo, time.Hour),
+		cleanupWorker:        worker.NewCleanupWorker(db, backchannelRepo, time.Hour, time.Duration(cfg.Token.MaxTTL)*time.Second),
 		adminAuthState:       authState,
 		globalMWState:        globalMW,
 		http: &http.Server{

--- a/tests/integration/cascade_reachability_test.go
+++ b/tests/integration/cascade_reachability_test.go
@@ -36,13 +36,18 @@ import (
 )
 
 // tokenClaims extracts jti and exp from a token without verifying the
-// signature — fine for tests; the server signed it moments ago.
-func tokenClaims(t *testing.T, tokenStr string) (jti string, exp time.Time) {
+// signature — fine for tests; the server signed it moments ago. Fails fast
+// if either claim is absent: callers use jti to drive DB updates and exp in
+// assertions, and an empty/zero value would produce misleading results.
+func tokenClaims(t *testing.T, tokenStr string) (string, time.Time) {
 	t.Helper()
 	parsed, err := jwt.ParseInsecure([]byte(tokenStr))
 	require.NoError(t, err)
-	jti, _ = parsed.JwtID()
-	exp, _ = parsed.Expiration()
+	jti, ok := parsed.JwtID()
+	require.True(t, ok, "token missing jti claim")
+	require.NotEmpty(t, jti)
+	exp, ok := parsed.Expiration()
+	require.True(t, ok, "token missing exp claim")
 	return jti, exp
 }
 

--- a/tests/integration/cascade_reachability_test.go
+++ b/tests/integration/cascade_reachability_test.go
@@ -179,7 +179,15 @@ func TestCascadeRevocationFromIdentityWithExpiredAnchor(t *testing.T) {
 	require.Equal(t, http.StatusCreated, signalResp.StatusCode)
 	_ = signalResp.Body.Close()
 
-	time.Sleep(100 * time.Millisecond)
+	// Signal-triggered revocation is asynchronous; poll instead of a fixed
+	// sleep so the test converges fast locally and tolerates CI load. The
+	// loop stays in the test goroutine because introspect uses require
+	// (FailNow must not be called from a polling goroutine, which rules
+	// out assert.Eventually here).
+	deadline := time.Now().Add(2 * time.Second)
+	for introspect(t, depth1Token)["active"].(bool) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	assert.False(t, introspect(t, depth1Token)["active"].(bool),
 		"delegated child must be revoked even though the anchor credential expired before the signal fired")

--- a/tests/integration/cascade_reachability_test.go
+++ b/tests/integration/cascade_reachability_test.go
@@ -1,0 +1,359 @@
+// Regression suite for the cascade-revocation reachability fixes.
+//
+// The bug cluster: (1) token_exchange issued delegated children with no
+// expiry bound from the parent, so children routinely outlived their
+// parents; (2) the cascade-revocation SQL (migrations 007/029) required
+// every node in the recursive walk to be live, so an expired or revoked
+// INTERMEDIATE stopped traversal and its still-live descendants were never
+// revoked; (3) the cleanup worker hard-deleted expired credential rows
+// immediately, severing the parent_jti edges the walk depends on.
+//
+// Fixes under test:
+//   - tokenExchange passes CredentialExpiresAt = subject credential expiry
+//     (child exp clamped to parent).
+//   - Migration 031 moves the liveness filters from the traversal legs to
+//     the final UPDATE, so the walk passes through dead intermediates.
+//
+// This file also pins two adjacent single-fix regressions from the same
+// review: WIMSE proof-token single-use under concurrency (atomic claim in
+// MarkUsed) and attestation-expiry enforcement in GetHighestVerifiedLevel.
+
+package integration_test
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// tokenClaims extracts jti and exp from a token without verifying the
+// signature — fine for tests; the server signed it moments ago.
+func tokenClaims(t *testing.T, tokenStr string) (jti string, exp time.Time) {
+	t.Helper()
+	parsed, err := jwt.ParseInsecure([]byte(tokenStr))
+	require.NoError(t, err)
+	jti, _ = parsed.JwtID()
+	exp, _ = parsed.Expiration()
+	return jti, exp
+}
+
+// setCredentialExpiryInDB rewrites the issued_credentials row's expires_at
+// directly, simulating a credential whose DB lifetime has been shortened
+// (or has lapsed) after issuance.
+func setCredentialExpiryInDB(t *testing.T, jti string, expiresAt time.Time) {
+	t.Helper()
+	res, err := testDB.NewUpdate().
+		TableExpr("issued_credentials").
+		Set("expires_at = ?", expiresAt.UTC()).
+		Where("jti = ?", jti).
+		Exec(context.Background())
+	require.NoError(t, err, "setCredentialExpiryInDB: direct UPDATE failed")
+	n, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n, "setCredentialExpiryInDB: expected exactly one row for jti %s", jti)
+}
+
+// mintOrchestratorToken registers an identity + confidential client and
+// returns a client_credentials access token for it, plus the identity.
+func mintOrchestratorToken(t *testing.T, prefix string) (string, identityResp) {
+	t.Helper()
+	ext := uid(prefix)
+	identity := registerIdentity(t, ext, []string{"data:read"})
+	client := registerOAuthClient(t, ext, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	token, _ := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, token)
+	return token, identity
+}
+
+// exchangeForSubAgent runs an RFC 8693 token exchange from subjectToken to a
+// freshly registered sub-agent and returns the delegated token.
+func exchangeForSubAgent(t *testing.T, subjectToken, prefix string) string {
+	t.Helper()
+	subKey := generateKey(t)
+	subIdentity := registerIdentity(t, uid(prefix), []string{"data:read"}, ecPublicKeyPEM(t, subKey))
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": subjectToken,
+		"actor_token":   buildAssertion(t, subKey, subIdentity.WIMSEURI),
+		"scope":         "data:read",
+	}, nil)
+	body := decode(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "token exchange failed: %v", body)
+	token, _ := body["access_token"].(string)
+	require.NotEmpty(t, token)
+	return token
+}
+
+// TestTokenExchangeChildClampedToParentExpiry pins the invariant that a
+// delegated credential never outlives the subject credential it was
+// exchanged from. Without the clamp, an exchange late in the parent's
+// lifetime mints a child with the full default TTL — and once the parent
+// expires, the revocation cascade loses its only path to the child.
+func TestTokenExchangeChildClampedToParentExpiry(t *testing.T) {
+	orchToken, _ := mintOrchestratorToken(t, "clamp-orch")
+	orchJTI, _ := tokenClaims(t, orchToken)
+
+	// Shorten the parent's remaining lifetime to 45s. The parent JWT's own
+	// exp claim is untouched (still far in the future), so the subject_token
+	// still validates — only the credential row's authority window shrinks.
+	parentExpiry := time.Now().Add(45 * time.Second)
+	setCredentialExpiryInDB(t, orchJTI, parentExpiry)
+
+	childToken := exchangeForSubAgent(t, orchToken, "clamp-sub")
+	_, childExp := tokenClaims(t, childToken)
+
+	assert.LessOrEqual(t, childExp.Unix(), parentExpiry.Unix()+2,
+		"delegated child exp (%s) must not outlive parent credential expiry (%s); slack 2s",
+		childExp.UTC(), parentExpiry.UTC())
+}
+
+// TestCascadeRevocationWalksThroughExpiredIntermediate pins the migration
+// 031 traversal fix on the credential-anchored cascade (RFC 7009 revoke):
+// revoking the root must reach a live grandchild even when the credential
+// between them has already expired.
+func TestCascadeRevocationWalksThroughExpiredIntermediate(t *testing.T) {
+	orchToken, _ := mintOrchestratorToken(t, "walk-orch")
+	depth1Token := exchangeForSubAgent(t, orchToken, "walk-sub1")
+	depth2Token := exchangeForSubAgent(t, depth1Token, "walk-sub2")
+
+	require.True(t, introspect(t, orchToken)["active"].(bool))
+	require.True(t, introspect(t, depth1Token)["active"].(bool))
+	require.True(t, introspect(t, depth2Token)["active"].(bool))
+
+	// Kill the intermediate by expiry (not revocation): its row stays in the
+	// DB but is no longer live. Pre-031, the recursive walk refused to pass
+	// through it and the grandchild survived the root's revocation.
+	depth1JTI, _ := tokenClaims(t, depth1Token)
+	setCredentialExpiryInDB(t, depth1JTI, time.Now().Add(-time.Minute))
+
+	resp := post(t, "/oauth2/token/revoke", map[string]any{"token": orchToken}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	assert.False(t, introspect(t, orchToken)["active"].(bool),
+		"root token must be inactive after revoke")
+	assert.False(t, introspect(t, depth2Token)["active"].(bool),
+		"grandchild must be revoked even though the intermediate credential expired before the cascade ran")
+}
+
+// TestCascadeRevocationFromIdentityWithExpiredAnchor pins the migration 031
+// anchor fix on the identity-anchored cascade (CAE signals / deactivation):
+// a critical signal against an identity whose own credential has already
+// expired must still revoke that credential's live delegated children.
+func TestCascadeRevocationFromIdentityWithExpiredAnchor(t *testing.T) {
+	orchToken, orchIdentity := mintOrchestratorToken(t, "anchor-orch")
+	depth1Token := exchangeForSubAgent(t, orchToken, "anchor-sub1")
+	require.True(t, introspect(t, depth1Token)["active"].(bool))
+
+	// Expire the anchor credential. Pre-031, the anchor leg's liveness
+	// filter matched zero rows, the walk never started, and the child kept
+	// working despite a CRITICAL signal against its delegator.
+	orchJTI, _ := tokenClaims(t, orchToken)
+	setCredentialExpiryInDB(t, orchJTI, time.Now().Add(-time.Minute))
+
+	signalResp := post(t, adminPath("/signals/ingest"), map[string]any{
+		"identity_id": orchIdentity.ID,
+		"signal_type": "anomalous_behavior",
+		"severity":    "critical",
+		"source":      "integration-test",
+		"payload":     map[string]any{"reason": "expired-anchor cascade regression"},
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, signalResp.StatusCode)
+	_ = signalResp.Body.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	assert.False(t, introspect(t, depth1Token)["active"].(bool),
+		"delegated child must be revoked even though the anchor credential expired before the signal fired")
+}
+
+// TestProofTokenSingleUseUnderConcurrency pins the atomic-claim fix in
+// ProofRepository.MarkUsed: N concurrent verifications of the same WPT must
+// yield exactly one success. The previous read-then-mark sequence let every
+// concurrent caller observe is_used = FALSE and all succeed.
+func TestProofTokenSingleUseUnderConcurrency(t *testing.T) {
+	agentKey := generateKey(t)
+	ext := uid("proof-race")
+	identity := registerIdentity(t, ext, []string{"data:read"}, ecPublicKeyPEM(t, agentKey))
+
+	tokResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    buildAssertion(t, agentKey, identity.WIMSEURI),
+		"scope":      "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, tokResp.StatusCode)
+	accessTok, _ := decode(t, tokResp)["access_token"].(string)
+
+	const audience = "https://target.example.com"
+	proofResp := post(t, adminPath("/proof/generate"), map[string]any{
+		"identity_id": identity.ID,
+		"audience":    audience,
+		"nonce":       "race-nonce-" + ext,
+	}, map[string]string{"Authorization": "Bearer " + accessTok})
+	proofBody := decode(t, proofResp)
+	require.Equal(t, http.StatusOK, proofResp.StatusCode, "proof generation failed: %v", proofBody)
+	proofToken, _ := proofBody["proof_token"].(string)
+	require.NotEmpty(t, proofToken)
+
+	// Pre-build one request per goroutine (requests are single-use), then
+	// fire them all at once. Assertions stay in the test goroutine —
+	// require.* must not run inside the workers.
+	const workers = 12
+	requests := make([]*http.Request, workers)
+	for i := range requests {
+		requests[i] = newRequest(t, http.MethodPost, adminPath("/proof/verify"), map[string]any{
+			"proof_token": proofToken,
+			"audience":    audience,
+		}, adminHeaders())
+	}
+
+	statuses := make([]int, workers)
+	errs := make([]error, workers)
+	var start, done sync.WaitGroup
+	start.Add(1)
+	done.Add(workers)
+	for i := range requests {
+		go func(i int) {
+			defer done.Done()
+			start.Wait() // line up all workers before releasing
+			resp, err := http.DefaultClient.Do(requests[i])
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			statuses[i] = resp.StatusCode
+			_ = resp.Body.Close()
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	successes := 0
+	for i := range statuses {
+		require.NoError(t, errs[i])
+		switch statuses[i] {
+		case http.StatusOK:
+			successes++
+		case http.StatusUnauthorized:
+			// expected for every loser
+		default:
+			t.Fatalf("unexpected status %d from concurrent proof verification", statuses[i])
+		}
+	}
+	assert.Equal(t, 1, successes,
+		"exactly one of %d concurrent verifications of the same proof token may succeed", workers)
+}
+
+// TestExpiredAttestationNoLongerSatisfiesPolicy pins the wall-clock
+// expires_at predicate in GetHighestVerifiedLevel: an attestation past its
+// expiry must stop satisfying a policy's required_attestation gate, even
+// though no sweep has flipped is_expired.
+//
+// The verified attestation record is inserted directly via testDB rather
+// than through /attestation/submit + /verify: this test pins the READ path
+// (the policy gate's level query), and going through the verifier would
+// couple it to whatever AttestationPolicy earlier tests left on the shared
+// tenant. The inserted row is exactly what a successful verification
+// writes: is_verified = TRUE, is_expired = FALSE, expires_at set.
+func TestExpiredAttestationNoLongerSatisfiesPolicy(t *testing.T) {
+	ext := uid("attest-expiry")
+	policyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("attest-expiry-policy"),
+		"allowed_grant_types":  []string{"client_credentials"},
+		"required_attestation": "software",
+		"max_ttl_seconds":      3600,
+	}, adminHeaders())
+	identityID := registerIdentityWithPolicy(t, ext, policyID, "", []string{"data:read"}, adminHeaders())
+	client := registerOAuthClient(t, ext, []string{"data:read"})
+
+	mint := func() *http.Response {
+		return post(t, "/oauth2/token", map[string]any{
+			"grant_type":    "client_credentials",
+			"client_id":     client.ClientID,
+			"client_secret": client.ClientSecret,
+			"account_id":    testAccountID,
+			"project_id":    testProjectID,
+			"scope":         "data:read",
+		}, nil)
+	}
+
+	// No attestation yet → policy gate must refuse.
+	resp := mint()
+	require.NotEqual(t, http.StatusOK, resp.StatusCode,
+		"policy requires software attestation; issuance without one must fail")
+	_ = resp.Body.Close()
+
+	// Insert a verified software attestation with a future expiry — the
+	// exact row state a successful verification leaves behind.
+	now := time.Now().UTC()
+	futureExpiry := now.Add(time.Hour)
+	record := &domain.AttestationRecord{
+		ID:         uuid.New().String(),
+		IdentityID: identityID,
+		AccountID:  testAccountID,
+		ProjectID:  testProjectID,
+		Level:      domain.AttestationLevelSoftware,
+		ProofType:  domain.ProofTypeOIDCToken,
+		ProofValue: "test-proof",
+		ProofHash:  "test-proof-hash",
+		VerifiedAt: &now,
+		IsVerified: true,
+		ExpiresAt:  &futureExpiry,
+		CreatedAt:  now,
+	}
+	_, err := testDB.NewInsert().Model(record).Exec(context.Background())
+	require.NoError(t, err, "failed to insert verified attestation record")
+
+	// Read back through the same predicates the policy gate uses, so a
+	// failure here localizes to the insert rather than the gate.
+	var insertedLevel string
+	err = testDB.NewSelect().
+		TableExpr("attestation_records").
+		ColumnExpr("level").
+		Where("identity_id = ?", identityID).
+		Where("is_verified = TRUE").
+		Scan(context.Background(), &insertedLevel)
+	require.NoError(t, err, "inserted attestation record not found")
+	require.Equal(t, "software", insertedLevel)
+
+	// With a fresh verified attestation the gate opens.
+	resp = mint()
+	mintBody := decode(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"verified attestation must satisfy the policy gate: %v", mintBody)
+
+	// Lapse the attestation by wall clock only — is_expired stays FALSE,
+	// exactly the state the old query treated as still-valid forever.
+	res, err := testDB.NewUpdate().
+		TableExpr("attestation_records").
+		Set("expires_at = ?", time.Now().Add(-time.Hour).UTC()).
+		Where("identity_id = ?", identityID).
+		Exec(context.Background())
+	require.NoError(t, err)
+	n, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, n, int64(1), "expected to lapse at least one attestation record")
+
+	resp = mint()
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode,
+		"an attestation past expires_at must no longer satisfy required_attestation")
+	_ = resp.Body.Close()
+}


### PR DESCRIPTION
## Summary

Fixes the bug that lets delegated tokens survive ancestor revocation, a TOCTOU race in WIMSE proof-token single-use enforcement, and attestation expiry never being enforced. Also closes the CI gap where unit tests never ran on PRs.

## 1. Cascade revocation couldn't reach live descendants of dead intermediates

Three interacting facts produced the hole:

1. `tokenExchange` issued delegated children with no expiry bound from the parent — an exchange late in the parent's lifetime minted a child that outlived it.
2. The recursive CTEs in `revoke_credential_cascade` / `revoke_credentials_cascade` required every traversed node to be live (`is_revoked = FALSE AND expires_at > p_revoked_at`), so an expired or already-revoked **intermediate** stopped the walk and its still-live descendants were never revoked. Revoking an already-expired credential returned zero rows — callers saw "nothing to revoke".
3. The cleanup worker hard-deleted expired credential rows immediately, severing the `parent_jti` edges the walk depends on.

**Scenario:** orchestrator token A expires at T; at T−10s it delegates to sub-agent token B (1h TTL). At T+5m the orchestrator's identity is revoked — B stayed valid for ~55 more minutes despite its entire ancestry being dead.

**Fixes (coordinated):**
- `tokenExchange` passes `CredentialExpiresAt = subjectCred.ExpiresAt` so children are clamped to their parent's remaining lifetime (the clamp infrastructure already existed for the api_key grant).
- Migration 031 moves the liveness filters from the traversal legs to the final `UPDATE` — the walk passes through dead nodes; returned-set semantics are unchanged (only live rows flip, so RevocationNotifier fan-out stays accurate).
- The cleanup worker retains expired `issued_credentials` rows for `token.max_ttl` before deletion, guaranteeing edges survive as long as any descendant could be alive — including legacy chains issued before the clamp.

## 2. WIMSE proof-token single-use was a check-then-act race

`VerifyProofToken` read `is_used`, then called `MarkUsed`, which ran a conditional `UPDATE` but discarded `RowsAffected` — two concurrent presentations of the same WPT both verified. `MarkUsed` now returns rows affected and zero is treated as `ErrNonceReplayed` (the same atomic-claim pattern already used by CIBA `MarkIssued` and refresh-token rotation).

## 3. Attestation expiry was never enforced

`attestation_records.expires_at` was written but nothing read it: the level query only filtered `is_expired = FALSE`, and no code ever flips that flag — a lapsed attestation satisfied `required_attestation` policy gates forever. `GetHighestVerifiedLevel` now requires `expires_at IS NULL OR expires_at > now()`.

## 4. CI: unit tests + race detector

The PR check only ran `go test ./tests/...` — `pkg/dpop`, `pkg/authjwt`, service, domain, and config unit tests never executed in CI, and nothing ran with `-race`. The workflow now runs the full unit-test set and both unit + integration tests under the race detector.

## Tests

New regression suite in `tests/integration/cascade_reachability_test.go`:
- delegated child exp clamped to parent credential expiry
- credential-anchored cascade revokes a grandchild through an expired intermediate
- identity-anchored cascade (CAE signal) works from an expired anchor credential
- 12 concurrent verifications of one WPT yield exactly one success
- a wall-clock-lapsed attestation (with `is_expired` still FALSE) stops satisfying the policy gate

All four behavioral tests were verified to **fail with the fixes reverted** and pass with them. Full suite: 421 integration + 201 unit tests green under `-race` locally.

## Migration notes

031 uses `CREATE OR REPLACE` (return type unchanged from 029) — no lock hazard, no table rewrite, instantly reversible; the down restores the 029 bodies verbatim.