### PR TITLE
fix: security-review backlog — endpoint/grant client auth, policy ceiling, CIBA, SSRF, sweeps, config hardening

### DIFF
--- a/config.go
+++ b/config.go
@@ -80,6 +80,24 @@ type AttestationConfig struct {
 	// should set ZEROID_ALLOW_UNSAFE_DEV_STUB=false. The OIDC verifier
 	// (the only real verifier shipped) is unaffected by this flag.
 	AllowUnsafeDevStub bool `koanf:"allow_unsafe_dev_stub"`
+
+	// AllowPrivateIssuerEndpoints relaxes the SSRF guard the OIDC
+	// attestation verifier applies to a proof's issuer endpoint (the URL
+	// it fetches OIDC discovery + JWKS from). Default false
+	// (production-safe).
+	//
+	// When false, the verifier rejects issuer endpoints that resolve to
+	// private, loopback, link-local, multicast, CGN, or unspecified IP
+	// ranges so an attacker-controlled proof can't make the server fetch
+	// internal URLs (SSRF).
+	//
+	// When true, that guard is disabled. Use ONLY in single-tenant
+	// test/dev deployments whose attestation issuer is itself on
+	// localhost / a private network. Production MUST keep this false.
+	//
+	// NOTE: this flag is the config surface only — the OIDC verifier in
+	// the attestation subsystem (server-side) must read it to take effect.
+	AllowPrivateIssuerEndpoints bool `koanf:"allow_private_issuer_endpoints"`
 }
 
 // SigningCredsConfig governs workload-attested ephemeral signing
@@ -300,7 +318,59 @@ func (c *Config) Validate() error {
 	if err := validateIssuer(c.Token.Issuer); err != nil {
 		return err
 	}
+
+	// Production-gated hardening. server.env had ZERO readers before this —
+	// it now governs the footgun defaults that are safe in dev but dangerous
+	// in production. The dev defaults stay intact so local/test workflows are
+	// unaffected; these checks only fire when the deployer declares production.
+	if isProductionEnv(c.Server.Env) {
+		// The dev stub accepts ANY submitted proof for image_hash/tpm. Its
+		// default is true (so dev demos work); leaving it on in production
+		// means accept-any attestation. Force an explicit opt-out.
+		if c.Attestation.AllowUnsafeDevStub {
+			return fmt.Errorf("attestation.allow_unsafe_dev_stub must be false in production (server.env=%q): the stub accepts ANY submitted proof for image_hash/tpm — set ZEROID_ALLOW_UNSAFE_DEV_STUB=false", c.Server.Env)
+		}
+		// token.issuer and wimse_domain ship with Highflame's hosted defaults.
+		// A production deploy that forgets to override them silently runs on
+		// Highflame's identity — require an explicit value.
+		if c.Token.Issuer == defaultIssuer {
+			return fmt.Errorf("token.issuer must be set explicitly in production (server.env=%q): it still has the built-in default %q — set ZEROID_ISSUER to this deployment's public URL", c.Server.Env, defaultIssuer)
+		}
+		if c.WIMSEDomain == defaultWIMSEDomain {
+			return fmt.Errorf("wimse_domain must be set explicitly in production (server.env=%q): it still has the built-in default %q — set ZEROID_WIMSE_DOMAIN to this deployment's trust domain", c.Server.Env, defaultWIMSEDomain)
+		}
+	}
+
+	// token.hmac_secret signs/verifies stateless authorization_code JWTs
+	// (HS256). The authorization_code grant is optional, so the secret is not
+	// globally required — but a weak secret is forgeable, so when one IS set
+	// we enforce a floor. 32 bytes matches the HS256 output size.
+	if c.Token.HMACSecret != "" && len(c.Token.HMACSecret) < 32 {
+		return fmt.Errorf("token.hmac_secret must be at least 32 bytes when set, got %d: it signs stateless auth-code JWTs (HS256) and a short secret is forgeable", len(c.Token.HMACSecret))
+	}
+
 	return nil
+}
+
+// defaultIssuer and defaultWIMSEDomain are the built-in dev defaults that the
+// production gate in Validate() rejects when left unchanged. They MUST match
+// the values set in loadDefaults() — kept as named constants so the gate and
+// the default can never drift.
+const (
+	defaultIssuer      = "https://auth.highflame.ai"
+	defaultWIMSEDomain = "highflame.ai"
+)
+
+// isProductionEnv reports whether server.env names a production deployment.
+// Accepts the common spellings ("production", "prod") case-insensitively so a
+// deployer can't accidentally dodge the production gate with "Production".
+func isProductionEnv(env string) bool {
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "production", "prod":
+		return true
+	default:
+		return false
+	}
 }
 
 // validateIssuer enforces RFC 8414 §2's shape constraints on Token.Issuer.
@@ -363,6 +433,18 @@ func rejectRemovedKeys(k *koanf.Koanf) error {
 	}
 	if os.Getenv("ZEROID_BASE_URL") != "" {
 		return fmt.Errorf("ZEROID_BASE_URL has been removed: set ZEROID_ISSUER to the full URL ZeroID is reached at (RFC 8414 §3 anchors discovery on the issuer URL). See CHANGELOG for migration notes")
+	}
+	// telemetry.endpoint / telemetry.insecure were removed when exporter
+	// configuration moved to the standard OTel SDK env vars
+	// (OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_INSECURE). They are no
+	// longer fields on TelemetryConfig, so koanf would silently drop them —
+	// reject loudly so a stale YAML doesn't quietly point telemetry at the
+	// wrong collector.
+	if k.Exists("telemetry.endpoint") {
+		return fmt.Errorf("telemetry.endpoint has been removed: exporter config moved to the OTel SDK env var OTEL_EXPORTER_OTLP_ENDPOINT. Remove it from config and set the env var instead")
+	}
+	if k.Exists("telemetry.insecure") {
+		return fmt.Errorf("telemetry.insecure has been removed: exporter config moved to the OTel SDK env var OTEL_EXPORTER_OTLP_INSECURE. Remove it from config and set the env var instead")
 	}
 	return nil
 }
@@ -436,12 +518,12 @@ func loadDefaults(k *koanf.Koanf) error {
 		// service, not the marketing site). Self-hosted deployments
 		// override via ZEROID_ISSUER or token.issuer in YAML. Local dev
 		// on localhost:8899 should set ZEROID_ISSUER=http://localhost:8899.
-		"token.issuer":      "https://auth.highflame.ai",
+		"token.issuer":      defaultIssuer,
 		"token.default_ttl": 3600,
 		"token.max_ttl":     7776000, // 90 days
 
 		// WIMSE
-		"wimse_domain": "highflame.ai",
+		"wimse_domain": defaultWIMSEDomain,
 
 		// Telemetry
 		"telemetry.enabled":       false,
@@ -456,6 +538,10 @@ func loadDefaults(k *koanf.Koanf) error {
 		// ZEROID_ALLOW_UNSAFE_DEV_STUB=false for deployments that don't
 		// submit those proof types (or once real verifiers land).
 		"attestation.allow_unsafe_dev_stub": true,
+		// SSRF guard on the OIDC verifier's issuer-endpoint fetch. Default
+		// false (production-safe); dev/test deployments whose attestation
+		// issuer is on localhost/a private network opt in.
+		"attestation.allow_private_issuer_endpoints": false,
 
 		// Workload-attested signing credentials. Operational signing
 		// window is short (1h, keys are ephemeral + rotated); the public
@@ -483,9 +569,10 @@ func loadDefaults(k *koanf.Koanf) error {
 func loadEnvVars(k *koanf.Koanf) error {
 	envMapping := map[string]string{
 		// Server
-		"ZEROID_PORT":              "server.port",
-		"ZEROID_ENV":               "server.env",
-		"ZEROID_ADMIN_PATH_PREFIX": "server.admin_path_prefix",
+		"ZEROID_PORT":                    "server.port",
+		"ZEROID_ENV":                     "server.env",
+		"ZEROID_ADMIN_PATH_PREFIX":       "server.admin_path_prefix",
+		"ZEROID_TRUST_FORWARDED_HEADERS": "server.trust_forwarded_headers",
 
 		// Database
 		"ZEROID_DATABASE_URL": "database.url",
@@ -514,12 +601,20 @@ func loadEnvVars(k *koanf.Koanf) error {
 		"ZEROID_ISSUER":                "token.issuer",
 		"ZEROID_TOKEN_TTL_SECONDS":     "token.default_ttl",
 		"ZEROID_MAX_TOKEN_TTL_SECONDS": "token.max_ttl",
+		// HMAC secret signs/verifies stateless authorization_code JWTs (HS256).
+		// A leak forges auth codes; Validate() enforces >= 32 bytes when set.
+		"ZEROID_HMAC_SECRET": "token.hmac_secret",
 
 		// WIMSE
 		"ZEROID_WIMSE_DOMAIN": "wimse_domain",
 
 		// Attestation
-		"ZEROID_ALLOW_UNSAFE_DEV_STUB": "attestation.allow_unsafe_dev_stub",
+		"ZEROID_ALLOW_UNSAFE_DEV_STUB":                      "attestation.allow_unsafe_dev_stub",
+		"ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS": "attestation.allow_private_issuer_endpoints",
+
+		// Backchannel (CIBA) — SSRF guard relaxation for single-tenant
+		// test/dev deployments only. Production MUST leave this false.
+		"ZEROID_BACKCHANNEL_ALLOW_PRIVATE_ENDPOINTS": "backchannel.allow_private_notification_endpoints",
 
 		// Telemetry — OTEL_EXPORTER_OTLP_ENDPOINT and TLS settings are read
 		// directly by the OTel SDK (spec-compliant).
@@ -536,26 +631,47 @@ func loadEnvVars(k *koanf.Koanf) error {
 			continue
 		}
 
+		// Parse errors are returned, not swallowed: a typo'd typed env var
+		// (e.g. ZEROID_ALLOW_UNSAFE_DEV_STUB=flase) must NOT silently retain
+		// the default — for a security flag that means the accept-any
+		// attestation stub stays on. Fail loud at startup instead.
 		switch {
 		case strings.HasSuffix(configPath, ".enabled") ||
-			strings.HasSuffix(configPath, ".allow_unsafe_dev_stub"):
-			if boolVal, err := strconv.ParseBool(value); err == nil {
-				_ = k.Set(configPath, boolVal)
+			strings.HasSuffix(configPath, ".allow_unsafe_dev_stub") ||
+			strings.HasSuffix(configPath, ".trust_forwarded_headers") ||
+			strings.HasSuffix(configPath, ".allow_private_notification_endpoints") ||
+			strings.HasSuffix(configPath, ".allow_private_issuer_endpoints"):
+			boolVal, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("%s=%q: not a valid bool (use true/false)", envVar, value)
+			}
+			if err := k.Set(configPath, boolVal); err != nil {
+				return fmt.Errorf("setting %s from %s: %w", configPath, envVar, err)
 			}
 		case strings.HasSuffix(configPath, ".max_open_conns") ||
 			strings.HasSuffix(configPath, ".max_idle_conns") ||
 			strings.HasSuffix(configPath, ".default_ttl") ||
 			strings.HasSuffix(configPath, ".max_ttl") ||
 			strings.HasSuffix(configPath, ".shutdown_timeout_seconds"):
-			if intVal, err := strconv.Atoi(value); err == nil {
-				_ = k.Set(configPath, intVal)
+			intVal, err := strconv.Atoi(value)
+			if err != nil {
+				return fmt.Errorf("%s=%q: not a valid integer", envVar, value)
+			}
+			if err := k.Set(configPath, intVal); err != nil {
+				return fmt.Errorf("setting %s from %s: %w", configPath, envVar, err)
 			}
 		case strings.HasSuffix(configPath, ".sampling_rate"):
-			if floatVal, err := strconv.ParseFloat(value, 64); err == nil {
-				_ = k.Set(configPath, floatVal)
+			floatVal, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return fmt.Errorf("%s=%q: not a valid float", envVar, value)
+			}
+			if err := k.Set(configPath, floatVal); err != nil {
+				return fmt.Errorf("setting %s from %s: %w", configPath, envVar, err)
 			}
 		default:
-			_ = k.Set(configPath, value)
+			if err := k.Set(configPath, value); err != nil {
+				return fmt.Errorf("setting %s from %s: %w", configPath, envVar, err)
+			}
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -95,8 +95,8 @@ type AttestationConfig struct {
 	// test/dev deployments whose attestation issuer is itself on
 	// localhost / a private network. Production MUST keep this false.
 	//
-	// NOTE: this flag is the config surface only — the OIDC verifier in
-	// the attestation subsystem (server-side) must read it to take effect.
+	// Wired at startup into both the OIDC verifier (fetch-time guard) and
+	// the attestation policy service (write-time URL validation).
 	AllowPrivateIssuerEndpoints bool `koanf:"allow_private_issuer_endpoints"`
 }
 

--- a/config.go
+++ b/config.go
@@ -233,6 +233,26 @@ type TokenConfig struct {
 	// AuthCodeIssuer is the expected issuer claim in auth code JWTs.
 	// Defaults to Token.Issuer when empty.
 	AuthCodeIssuer string `koanf:"auth_code_issuer"`
+
+	// AllowUnauthenticatedTokenInspection controls whether the introspection
+	// (RFC 7662) and revocation (RFC 7009) endpoints accept anonymous callers.
+	//
+	// RFC 7662 §2.1 says the introspection endpoint MUST require some form of
+	// authorization (token-scanning defense); RFC 7009 §2.1 requires client
+	// authentication on revocation. When this is false, ZeroID enforces that:
+	// a caller MUST present client credentials, and an anonymous call is
+	// rejected with invalid_client.
+	//
+	// Default true preserves the accept-and-verify posture (anonymous allowed,
+	// presented credentials still verified) for the standalone, network-
+	// isolated deployment model and local development. Validate() REJECTS true
+	// when server.env is production, so production deployments are strict
+	// (spec-compliant) by default and must consciously keep this false — the
+	// same production-gate pattern as AllowUnsafeDevStub and the default
+	// issuer. A production deployment that genuinely relies on network
+	// isolation should authenticate these endpoints at its own edge
+	// (Server.Use) rather than serving them unauthenticated from ZeroID.
+	AllowUnauthenticatedTokenInspection bool `koanf:"allow_unauthenticated_token_inspection"`
 }
 
 // TelemetryConfig holds OpenTelemetry settings.
@@ -338,6 +358,14 @@ func (c *Config) Validate() error {
 		}
 		if c.WIMSEDomain == defaultWIMSEDomain {
 			return fmt.Errorf("wimse_domain must be set explicitly in production (server.env=%q): it still has the built-in default %q — set ZEROID_WIMSE_DOMAIN to this deployment's trust domain", c.Server.Env, defaultWIMSEDomain)
+		}
+		// Introspection (RFC 7662 §2.1) and revocation (RFC 7009 §2.1) MUST
+		// require caller authorization. The default leaves them accept-and-
+		// verify (anonymous allowed) for the standalone/dev model; production
+		// must not serve an unauthenticated token-scanning / force-revoke
+		// surface. Force the explicit opt-out.
+		if c.Token.AllowUnauthenticatedTokenInspection {
+			return fmt.Errorf("token.allow_unauthenticated_token_inspection must be false in production (server.env=%q): RFC 7662 §2.1 / RFC 7009 §2.1 require caller authentication on introspection/revocation — set ZEROID_ALLOW_UNAUTHENTICATED_TOKEN_INSPECTION=false (authenticate these endpoints at your edge if you rely on network isolation)", c.Server.Env)
 		}
 	}
 
@@ -521,6 +549,9 @@ func loadDefaults(k *koanf.Koanf) error {
 		"token.issuer":      defaultIssuer,
 		"token.default_ttl": 3600,
 		"token.max_ttl":     7776000, // 90 days
+		// Accept-and-verify on introspect/revoke by default (dev/standalone).
+		// Validate() forces this false in production (RFC 7662/7009).
+		"token.allow_unauthenticated_token_inspection": true,
 
 		// WIMSE
 		"wimse_domain": defaultWIMSEDomain,
@@ -604,6 +635,9 @@ func loadEnvVars(k *koanf.Koanf) error {
 		// HMAC secret signs/verifies stateless authorization_code JWTs (HS256).
 		// A leak forges auth codes; Validate() enforces >= 32 bytes when set.
 		"ZEROID_HMAC_SECRET": "token.hmac_secret",
+		// Strict client auth on introspection/revocation (RFC 7662/7009).
+		// Default true (accept-and-verify); Validate() forces false in production.
+		"ZEROID_ALLOW_UNAUTHENTICATED_TOKEN_INSPECTION": "token.allow_unauthenticated_token_inspection",
 
 		// WIMSE
 		"ZEROID_WIMSE_DOMAIN": "wimse_domain",
@@ -640,7 +674,8 @@ func loadEnvVars(k *koanf.Koanf) error {
 			strings.HasSuffix(configPath, ".allow_unsafe_dev_stub") ||
 			strings.HasSuffix(configPath, ".trust_forwarded_headers") ||
 			strings.HasSuffix(configPath, ".allow_private_notification_endpoints") ||
-			strings.HasSuffix(configPath, ".allow_private_issuer_endpoints"):
+			strings.HasSuffix(configPath, ".allow_private_issuer_endpoints") ||
+			strings.HasSuffix(configPath, ".allow_unauthenticated_token_inspection"):
 			boolVal, err := strconv.ParseBool(value)
 			if err != nil {
 				return fmt.Errorf("%s=%q: not a valid bool (use true/false)", envVar, value)

--- a/config_test.go
+++ b/config_test.go
@@ -132,6 +132,7 @@ func TestLoadEnvVarsBadTypedValues(t *testing.T) {
 		{"bad_bool_trust_fwd", "ZEROID_TRUST_FORWARDED_HEADERS", "yepp", "not a valid bool"},
 		{"bad_bool_backchannel", "ZEROID_BACKCHANNEL_ALLOW_PRIVATE_ENDPOINTS", "maybe", "not a valid bool"},
 		{"bad_bool_private_issuer", "ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS", "nah", "not a valid bool"},
+		{"bad_bool_unauth_inspect", "ZEROID_ALLOW_UNAUTHENTICATED_TOKEN_INSPECTION", "nope", "not a valid bool"},
 		{"bad_int_ttl", "ZEROID_TOKEN_TTL_SECONDS", "soon", "not a valid integer"},
 		{"bad_float_sampling", "OTEL_TRACES_SAMPLER_ARG", "lots", "not a valid float"},
 	}
@@ -157,10 +158,14 @@ func TestLoadEnvVarsGoodTypedValues(t *testing.T) {
 	t.Setenv("ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS", "true")
 	t.Setenv("ZEROID_HMAC_SECRET", "this-is-a-sufficiently-long-secret-key")
 	t.Setenv("ZEROID_ALLOW_UNSAFE_DEV_STUB", "false")
+	t.Setenv("ZEROID_ALLOW_UNAUTHENTICATED_TOKEN_INSPECTION", "false")
 
 	cfg, err := LoadConfig("")
 	if err != nil {
 		t.Fatalf("LoadConfig with valid env vars failed: %v", err)
+	}
+	if cfg.Token.AllowUnauthenticatedTokenInspection {
+		t.Error("ZEROID_ALLOW_UNAUTHENTICATED_TOKEN_INSPECTION=false did not reach token config")
 	}
 	if !cfg.Server.TrustForwardedHeaders {
 		t.Error("ZEROID_TRUST_FORWARDED_HEADERS=true did not reach server.trust_forwarded_headers")
@@ -272,6 +277,30 @@ func TestValidateProductionGate(t *testing.T) {
 		cfg.WIMSEDomain = "acme.example"
 		if err := cfg.Validate(); err != nil {
 			t.Fatalf("production with explicit safe values must pass: %v", err)
+		}
+	})
+
+	t.Run("production_rejects_unauthenticated_inspection", func(t *testing.T) {
+		// RFC 7662 §2.1 / RFC 7009 §2.1: production must not serve an
+		// unauthenticated introspection/revocation surface.
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "production"
+		cfg.Attestation.AllowUnsafeDevStub = false
+		cfg.Token.Issuer = "https://auth.acme.example"
+		cfg.WIMSEDomain = "acme.example"
+		cfg.Token.AllowUnauthenticatedTokenInspection = true
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "allow_unauthenticated_token_inspection must be false in production") {
+			t.Fatalf("production + unauthenticated token inspection must be rejected, got: %v", err)
+		}
+	})
+
+	t.Run("dev_allows_unauthenticated_inspection", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "development"
+		cfg.Token.AllowUnauthenticatedTokenInspection = true
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("dev must allow unauthenticated token inspection: %v", err)
 		}
 	})
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,8 @@
 package zeroid
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -79,6 +81,226 @@ func TestValidateIssuer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// writeTestKeys creates throwaway private/public key files so Validate()'s
+// os.Stat checks pass. The contents don't matter — Validate only stats them.
+func writeTestKeys(t *testing.T) (priv, pub string) {
+	t.Helper()
+	dir := t.TempDir()
+	priv = filepath.Join(dir, "private.pem")
+	pub = filepath.Join(dir, "public.pem")
+	for _, p := range []string{priv, pub} {
+		if err := os.WriteFile(p, []byte("test-key"), 0o600); err != nil {
+			t.Fatalf("writing test key %s: %v", p, err)
+		}
+	}
+	return priv, pub
+}
+
+// baseValidConfig returns a Config that passes Validate() in development.
+// Tests mutate one field to exercise a single rejection branch.
+func baseValidConfig(t *testing.T) Config {
+	t.Helper()
+	priv, pub := writeTestKeys(t)
+	return Config{
+		Server: ServerConfig{Port: "8899", Env: "development"},
+		Database: DatabaseConfig{
+			URL:          "postgres://u@localhost:5432/db",
+			MaxOpenConns: 25,
+			MaxIdleConns: 5,
+		},
+		Keys:        KeysConfig{PrivateKeyPath: priv, PublicKeyPath: pub},
+		Token:       TokenConfig{Issuer: "https://auth.example.com"},
+		WIMSEDomain: "example.com",
+		Attestation: AttestationConfig{AllowUnsafeDevStub: true},
+	}
+}
+
+// TestLoadEnvVarsBadTypedValues pins finding #1: a typo'd typed env var must
+// fail loudly at startup, not silently retain the default. Before the fix the
+// parse error was swallowed and ZEROID_ALLOW_UNSAFE_DEV_STUB=flase left the
+// accept-any attestation stub ON.
+func TestLoadEnvVarsBadTypedValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		envVar  string
+		value   string
+		wantErr string
+	}{
+		{"bad_bool_dev_stub", "ZEROID_ALLOW_UNSAFE_DEV_STUB", "flase", "not a valid bool"},
+		{"bad_bool_trust_fwd", "ZEROID_TRUST_FORWARDED_HEADERS", "yepp", "not a valid bool"},
+		{"bad_bool_backchannel", "ZEROID_BACKCHANNEL_ALLOW_PRIVATE_ENDPOINTS", "maybe", "not a valid bool"},
+		{"bad_bool_private_issuer", "ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS", "nah", "not a valid bool"},
+		{"bad_int_ttl", "ZEROID_TOKEN_TTL_SECONDS", "soon", "not a valid integer"},
+		{"bad_float_sampling", "OTEL_TRACES_SAMPLER_ARG", "lots", "not a valid float"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(tc.envVar, tc.value)
+			_, err := LoadConfig("")
+			if err == nil {
+				t.Fatalf("expected LoadConfig to fail on %s=%q, got nil", tc.envVar, tc.value)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q must mention %q so operators can act on it", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoadEnvVarsGoodTypedValues confirms the corrected parser still accepts
+// valid values and that the new env mappings actually reach the struct.
+func TestLoadEnvVarsGoodTypedValues(t *testing.T) {
+	t.Setenv("ZEROID_TRUST_FORWARDED_HEADERS", "true")
+	t.Setenv("ZEROID_BACKCHANNEL_ALLOW_PRIVATE_ENDPOINTS", "true")
+	t.Setenv("ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS", "true")
+	t.Setenv("ZEROID_HMAC_SECRET", "this-is-a-sufficiently-long-secret-key")
+	t.Setenv("ZEROID_ALLOW_UNSAFE_DEV_STUB", "false")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig with valid env vars failed: %v", err)
+	}
+	if !cfg.Server.TrustForwardedHeaders {
+		t.Error("ZEROID_TRUST_FORWARDED_HEADERS=true did not reach server.trust_forwarded_headers")
+	}
+	if !cfg.Backchannel.AllowPrivateNotificationEndpoints {
+		t.Error("ZEROID_BACKCHANNEL_ALLOW_PRIVATE_ENDPOINTS=true did not reach backchannel")
+	}
+	if !cfg.Attestation.AllowPrivateIssuerEndpoints {
+		t.Error("ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS=true did not reach attestation")
+	}
+	if cfg.Token.HMACSecret != "this-is-a-sufficiently-long-secret-key" {
+		t.Errorf("ZEROID_HMAC_SECRET did not reach token.hmac_secret, got %q", cfg.Token.HMACSecret)
+	}
+	if cfg.Attestation.AllowUnsafeDevStub {
+		t.Error("ZEROID_ALLOW_UNSAFE_DEV_STUB=false did not turn off the dev stub")
+	}
+}
+
+// TestRejectRemovedTelemetryKeys pins finding #6: stale telemetry.endpoint /
+// telemetry.insecure keys must fail loudly rather than be silently dropped.
+func TestRejectRemovedTelemetryKeys(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{"endpoint", "telemetry:\n  endpoint: \"localhost:4317\"\n", "telemetry.endpoint has been removed"},
+		{"insecure", "telemetry:\n  insecure: true\n", "telemetry.insecure has been removed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "zeroid.yaml")
+			if err := os.WriteFile(path, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("writing test yaml: %v", err)
+			}
+			_, err := LoadConfig(path)
+			if err == nil {
+				t.Fatalf("expected LoadConfig to reject %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q must mention %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateProductionGate pins findings #2 and #3: the production gate on
+// server.env rejects the unsafe dev stub and the unchanged default
+// issuer / wimse_domain, while dev leaves all three alone.
+func TestValidateProductionGate(t *testing.T) {
+	t.Run("dev_allows_stub_and_defaults", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "development"
+		cfg.Attestation.AllowUnsafeDevStub = true
+		cfg.Token.Issuer = defaultIssuer
+		cfg.WIMSEDomain = defaultWIMSEDomain
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("dev config must pass with stub on and default issuer/domain: %v", err)
+		}
+	})
+
+	t.Run("production_rejects_unsafe_stub", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "production"
+		cfg.Attestation.AllowUnsafeDevStub = true
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "allow_unsafe_dev_stub must be false in production") {
+			t.Fatalf("production + unsafe stub must be rejected, got: %v", err)
+		}
+	})
+
+	t.Run("production_case_insensitive", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "Production"
+		cfg.Attestation.AllowUnsafeDevStub = true
+		if err := cfg.Validate(); err == nil {
+			t.Fatal("\"Production\" must still trip the production gate")
+		}
+	})
+
+	t.Run("production_rejects_default_issuer", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "production"
+		cfg.Attestation.AllowUnsafeDevStub = false
+		cfg.Token.Issuer = defaultIssuer
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "token.issuer must be set explicitly in production") {
+			t.Fatalf("production + default issuer must be rejected, got: %v", err)
+		}
+	})
+
+	t.Run("production_rejects_default_wimse_domain", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "production"
+		cfg.Attestation.AllowUnsafeDevStub = false
+		cfg.WIMSEDomain = defaultWIMSEDomain
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "wimse_domain must be set explicitly in production") {
+			t.Fatalf("production + default wimse_domain must be rejected, got: %v", err)
+		}
+	})
+
+	t.Run("production_passes_with_explicit_values", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Server.Env = "production"
+		cfg.Attestation.AllowUnsafeDevStub = false
+		cfg.Token.Issuer = "https://auth.acme.example"
+		cfg.WIMSEDomain = "acme.example"
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("production with explicit safe values must pass: %v", err)
+		}
+	})
+}
+
+// TestValidateHMACSecret pins finding #4: hmac_secret is optional, but when
+// set must be at least 32 bytes.
+func TestValidateHMACSecret(t *testing.T) {
+	t.Run("empty_ok", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Token.HMACSecret = ""
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("empty hmac_secret must be allowed: %v", err)
+		}
+	})
+	t.Run("short_rejected", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Token.HMACSecret = "too-short"
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "hmac_secret must be at least 32 bytes") {
+			t.Fatalf("short hmac_secret must be rejected, got: %v", err)
+		}
+	})
+	t.Run("long_enough_ok", func(t *testing.T) {
+		cfg := baseValidConfig(t)
+		cfg.Token.HMACSecret = strings.Repeat("a", 32)
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("32-byte hmac_secret must be allowed: %v", err)
+		}
+	})
 }
 
 func TestValidateWIMSEDomain(t *testing.T) {

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -90,10 +90,11 @@ func NewOIDCVerifier(httpClient *http.Client) *OIDCVerifier {
 // It is the seam through which a dev/test deployment opts out of the guard;
 // production must leave it false. Returns the verifier for chaining.
 //
-// NOTE FOR INTEGRATORS: there is currently no config flag wiring this from
-// server startup. To gate it on operator config, add an attestation config
-// field (see report in the closing PR) and call SetAllowPrivate in
-// server.go's verifier construction. Until then the guard is always on.
+// Wired from operator config: server.go passes
+// cfg.Attestation.AllowPrivateIssuerEndpoints (env
+// ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS, default false) into both
+// this verifier and the PolicyService, so the write-time and verify-time
+// guards agree. The guard is on unless an operator explicitly opts out.
 func (v *OIDCVerifier) SetAllowPrivate(allow bool) *OIDCVerifier {
 	v.allowPrivate = allow
 	return v

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -476,28 +476,41 @@ func ssrfGuardedTransport(allowPrivate func() bool) *http.Transport {
 	base := http.DefaultTransport.(*http.Transport).Clone()
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
 	base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		if !allowPrivate() {
-			host, _, err := net.SplitHostPort(addr)
-			if err != nil {
-				host = addr
+		if allowPrivate() {
+			return dialer.DialContext(ctx, network, addr)
+		}
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			host, port = addr, ""
+		}
+		// IP-literal host: validate and dial it directly.
+		if ip := net.ParseIP(host); ip != nil {
+			if isBlockedIP(ip) {
+				return nil, ErrPrivateAttestationEndpoint
 			}
-			if ip := net.ParseIP(host); ip != nil {
-				if isBlockedIP(ip) {
-					return nil, ErrPrivateAttestationEndpoint
-				}
-			} else {
-				// addr carries an IP literal only when the URL host was one
-				// (handled above). For hostnames, re-resolve here so a DNS
-				// rebind between the pre-flight check and this dial is still
-				// caught. The dialer below performs its own resolution, so a
-				// sub-millisecond rebind window remains — accepted residual
-				// risk for a host-based guard.
-				if err := resolveAndCheckHost(ctx, host); err != nil {
-					return nil, err
-				}
+			return dialer.DialContext(ctx, network, addr)
+		}
+		// Hostname: resolve ONCE, validate every answer, then dial a
+		// validated IP literal — not the hostname — so the kernel connects to
+		// exactly the address we checked. Re-resolving and dialing the
+		// hostname again (letting net.Dialer resolve a third time) would leave
+		// a DNS-rebinding window between the check and the connect; pinning the
+		// dial to the validated IP closes it. TLS still verifies against the
+		// original hostname because the Transport sets ServerName from the URL,
+		// not from the dial address.
+		ips, err := lookupIPs(ctx, host)
+		if err != nil {
+			return nil, fmt.Errorf("attestation issuer host resolution failed: %w", err)
+		}
+		if len(ips) == 0 {
+			return nil, ErrPrivateAttestationEndpoint
+		}
+		for _, ip := range ips {
+			if isBlockedIP(ip) {
+				return nil, ErrPrivateAttestationEndpoint
 			}
 		}
-		return dialer.DialContext(ctx, network, addr)
+		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
 	}
 	return base
 }

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -486,9 +486,12 @@ func ssrfGuardedTransport(allowPrivate func() bool) *http.Transport {
 					return nil, ErrPrivateAttestationEndpoint
 				}
 			} else {
-				// Resolver may hand back an IP literal as addr after a CGI
-				// rewrite, but for hostnames re-resolve here so a rebind
-				// between pre-flight check and dial is still caught.
+				// addr carries an IP literal only when the URL host was one
+				// (handled above). For hostnames, re-resolve here so a DNS
+				// rebind between the pre-flight check and this dial is still
+				// caught. The dialer below performs its own resolution, so a
+				// sub-millisecond rebind window remains — accepted residual
+				// risk for a host-based guard.
 				if err := resolveAndCheckHost(ctx, host); err != nil {
 					return nil, err
 				}

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -3,10 +3,13 @@ package attestation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -43,20 +46,57 @@ type OIDCVerifier struct {
 	cache    *jwksCache
 	http     *http.Client
 	cacheTTL time.Duration
+
+	// allowPrivate disables the SSRF blocklist on issuer / jwks_uri hosts.
+	// Production default is false: both the discovery GET and the JWKS GET
+	// resolve their target host and reject if ANY resolved IP falls in a
+	// private / loopback / link-local / metadata / CGN / multicast /
+	// unspecified range, re-checked at dial time as DNS-rebinding defence.
+	// Set to true ONLY in test/dev contexts that point issuers at loopback
+	// (httptest.NewServer, http://localhost:port). See SetAllowPrivate.
+	allowPrivate bool
 }
 
 // NewOIDCVerifier creates a verifier with a shared JWKS cache. httpClient
 // is used for both OIDC discovery and JWKS fetches; passing a custom one
 // is useful in tests (httptest.NewServer has no DNS).
+//
+// SSRF guard: when httpClient is nil, the verifier builds a hardened client
+// whose dialer rejects connections to private / reserved IP ranges. When a
+// custom client is supplied (tests), the caller owns transport behaviour —
+// but the pre-fetch host resolution check in discoverJWKSURL / fetchJWKS
+// still applies unless allowPrivate is set via SetAllowPrivate.
+//
+// allowPrivate defaults to false (production-safe). A tenant-configured
+// issuer that resolves to an internal address is rejected before any byte
+// leaves this process. To run against loopback fixtures, call
+// v.SetAllowPrivate(true) after construction.
 func NewOIDCVerifier(httpClient *http.Client) *OIDCVerifier {
-	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
-	}
-	return &OIDCVerifier{
+	v := &OIDCVerifier{
 		cache:    newJWKSCache(),
-		http:     httpClient,
 		cacheTTL: 1 * time.Hour,
 	}
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: ssrfGuardedTransport(func() bool { return v.allowPrivate }),
+		}
+	}
+	v.http = httpClient
+	return v
+}
+
+// SetAllowPrivate toggles the SSRF blocklist on issuer / jwks_uri hosts.
+// It is the seam through which a dev/test deployment opts out of the guard;
+// production must leave it false. Returns the verifier for chaining.
+//
+// NOTE FOR INTEGRATORS: there is currently no config flag wiring this from
+// server startup. To gate it on operator config, add an attestation config
+// field (see report in the closing PR) and call SetAllowPrivate in
+// server.go's verifier construction. Until then the guard is always on.
+func (v *OIDCVerifier) SetAllowPrivate(allow bool) *OIDCVerifier {
+	v.allowPrivate = allow
+	return v
 }
 
 // ProofType reports oidc_token. One OIDCVerifier per registry.
@@ -97,8 +137,10 @@ func (v *OIDCVerifier) Verify(ctx context.Context, record *domain.AttestationRec
 		return nil, fmt.Errorf("oidc verifier: issuer not in allowlist: %s", issuerClaim)
 	}
 
-	// Step 3: resolve JWKS (cached).
-	keySet, err := v.cache.get(ctx, v.http, matchedIssuer.URL, v.cacheTTL)
+	// Step 3: resolve JWKS (cached). The cache fetch path runs the SSRF
+	// blocklist on both the issuer host (discovery GET) and the
+	// discovery-provided jwks_uri host (JWKS GET) before any network call.
+	keySet, err := v.cache.get(ctx, v.http, matchedIssuer.URL, v.cacheTTL, v.allowPrivate)
 	if err != nil {
 		return nil, fmt.Errorf("oidc verifier: JWKS fetch failed: %w", err)
 	}
@@ -221,7 +263,7 @@ func newJWKSCache() *jwksCache {
 // when the entry is absent or stale. The two-phase locking pattern (map
 // mutex for entry lookup, then entry mutex for fetch) ensures cross-issuer
 // lookups don't serialize on a single slow upstream.
-func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL string, ttl time.Duration) (jwk.Set, error) {
+func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL string, ttl time.Duration, allowPrivate bool) (jwk.Set, error) {
 	c.mu.Lock()
 	entry, ok := c.entries[issuerURL]
 	if !ok {
@@ -237,7 +279,7 @@ func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL 
 		return entry.keys, nil
 	}
 
-	jwksURL, err := discoverJWKSURL(ctx, httpClient, issuerURL)
+	jwksURL, err := discoverJWKSURL(ctx, httpClient, issuerURL, allowPrivate)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +289,7 @@ func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL 
 	// them into a Set. Bound the body at maxDiscoveryDocBytes for the same
 	// reason we do on the discovery endpoint — defend against an issuer
 	// streaming attacker-chosen volumes into our process.
-	keySet, err := fetchJWKS(ctx, httpClient, jwksURL)
+	keySet, err := fetchJWKS(ctx, httpClient, jwksURL, allowPrivate)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +301,13 @@ func (c *jwksCache) get(ctx context.Context, httpClient *http.Client, issuerURL 
 
 // fetchJWKS performs a bounded HTTP GET against jwksURL and parses the
 // response as a jwk.Set. Replaces the v2 jwk.Fetch helper that v4 removed.
-func fetchJWKS(ctx context.Context, httpClient *http.Client, jwksURL string) (jwk.Set, error) {
+func fetchJWKS(ctx context.Context, httpClient *http.Client, jwksURL string, allowPrivate bool) (jwk.Set, error) {
+	// SSRF guard: the jwks_uri came from the (untrusted) discovery document
+	// and may point at a different host than the issuer — resolve and block
+	// internal targets before connecting. Re-checked at dial time too.
+	if err := assertURLHostAllowed(ctx, jwksURL, allowPrivate); err != nil {
+		return nil, fmt.Errorf("jwks_uri %s: %w", jwksURL, err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build JWKS request: %w", err)
@@ -292,8 +340,15 @@ func fetchJWKS(ctx context.Context, httpClient *http.Client, jwksURL string) (jw
 // the issuer URL used to fetch it — otherwise a DNS-hijacked or MITM'd
 // discovery endpoint could redirect jwks_uri at attacker-controlled keys
 // while pretending to serve the trusted issuer's metadata.
-func discoverJWKSURL(ctx context.Context, httpClient *http.Client, issuerURL string) (string, error) {
+func discoverJWKSURL(ctx context.Context, httpClient *http.Client, issuerURL string, allowPrivate bool) (string, error) {
 	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+	// SSRF guard: resolve the issuer host and block internal targets before
+	// the discovery GET. A tenant with policy-write access could otherwise
+	// point the issuer at 169.254.169.254 (cloud metadata) or an RFC 1918
+	// service for blind SSRF / port probing. Re-checked at dial time too.
+	if err := assertURLHostAllowed(ctx, discoveryURL, allowPrivate); err != nil {
+		return "", fmt.Errorf("issuer %s: %w", issuerURL, err)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("build discovery request: %w", err)
@@ -328,4 +383,173 @@ func discoverJWKSURL(ctx context.Context, httpClient *http.Client, issuerURL str
 		return "", fmt.Errorf("discovery doc issuer mismatch: got %q, want %q", doc.Issuer, issuerURL)
 	}
 	return doc.JWKSURI, nil
+}
+
+// ── SSRF guard ────────────────────────────────────────────────────────────
+//
+// OIDC issuer URLs and the jwks_uri inside their discovery documents are
+// tenant-controlled and fetched server-side at verify time. Without a guard,
+// a tenant with policy-write access (or a stolen admin token) could point an
+// issuer at 169.254.169.254 (cloud metadata), an RFC 1918 service, or any
+// internal port — turning /attestation/verify into a blind-SSRF / internal
+// port-probe primitive. The discovery-provided jwks_uri can also redirect the
+// second fetch to a different internal host.
+//
+// Defence (mirrors the CIBA notification guard in internal/service):
+//  1. Before each GET, resolve the target host and reject if ANY resolved IP
+//     is in a blocked range (DNS-rebinding defence — a hostname mixing public
+//     and private answers is treated as hostile).
+//  2. The default HTTP client's dialer re-checks the actually-dialed IP, so a
+//     hostname that flips its answer between the pre-flight resolve and the
+//     dial (TOCTOU rebind) is still refused at connect time.
+
+// dnsLookupTimeout caps each resolve so a slow/hanging DNS server cannot stall
+// a verify call indefinitely. Well above typical resolver latency.
+const dnsLookupTimeout = 2 * time.Second
+
+// ErrPrivateAttestationEndpoint is the sentinel returned when an issuer or
+// jwks_uri host resolves to a private / loopback / link-local / metadata /
+// CGN / multicast / unspecified address. Callers can errors.Is on it. The
+// error deliberately does NOT echo the resolved IP — leaking our internal DNS
+// view is not a useful diagnostic and could expose split-horizon topology.
+var ErrPrivateAttestationEndpoint = errors.New("attestation issuer/jwks_uri resolves to a private or reserved address")
+
+// assertURLHostAllowed parses rawURL and runs the SSRF blocklist on its host.
+// allowPrivate short-circuits the check for dev/test (loopback fixtures).
+func assertURLHostAllowed(ctx context.Context, rawURL string, allowPrivate bool) error {
+	if allowPrivate {
+		return nil
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("malformed URL: %w", err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("URL has no host")
+	}
+	return resolveAndCheckHost(ctx, host)
+}
+
+// resolveAndCheckHost performs a timeout-bounded DNS lookup for host and
+// rejects if ANY returned IP is blocked. Pure-IP hosts resolve to a single
+// literal entry, so direct IP-as-host issuers (https://10.0.0.5/) are covered.
+func resolveAndCheckHost(ctx context.Context, host string) error {
+	lookupCtx, cancel := context.WithTimeout(ctx, dnsLookupTimeout)
+	defer cancel()
+	ips, err := lookupIPs(lookupCtx, host)
+	if err != nil {
+		return fmt.Errorf("host %q does not resolve: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("host %q returned no IPs", host)
+	}
+	for _, ip := range ips {
+		if isBlockedIP(ip) {
+			return ErrPrivateAttestationEndpoint
+		}
+	}
+	return nil
+}
+
+// lookupIPs is a package-level var so tests can inject a stubbed resolver
+// without touching real DNS. Production uses LookupIPAddr which honours the
+// supplied context (net.LookupIP does not), so dnsLookupTimeout actually binds.
+var lookupIPs = func(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, len(addrs))
+	for i, a := range addrs {
+		ips[i] = a.IP
+	}
+	return ips, nil
+}
+
+// ssrfGuardedTransport wraps http.DefaultTransport with a dialer that rejects
+// any connection whose resolved IP is blocked. allowPrivate is read through a
+// func so the verifier's flag can be flipped after the transport is built.
+// This is the dial-time half of the DNS-rebinding defence.
+func ssrfGuardedTransport(allowPrivate func() bool) *http.Transport {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	base.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if !allowPrivate() {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				host = addr
+			}
+			if ip := net.ParseIP(host); ip != nil {
+				if isBlockedIP(ip) {
+					return nil, ErrPrivateAttestationEndpoint
+				}
+			} else {
+				// Resolver may hand back an IP literal as addr after a CGI
+				// rewrite, but for hostnames re-resolve here so a rebind
+				// between pre-flight check and dial is still caught.
+				if err := resolveAndCheckHost(ctx, host); err != nil {
+					return nil, err
+				}
+			}
+		}
+		return dialer.DialContext(ctx, network, addr)
+	}
+	return base
+}
+
+// isBlockedIP returns true for any IP that must never be a verify-time fetch
+// target. Mirrors the CIBA notification guard's blocklist:
+//
+// Via stdlib helpers:
+//   - RFC 1918 IPv4 private + RFC 4193 IPv6 ULA (fc00::/7, incl. Azure IMDS
+//     fd00:ec2::254) — net.IP.IsPrivate
+//   - Loopback (127/8, ::1) — net.IP.IsLoopback
+//   - Link-local unicast (169.254/16, fe80::/10, incl. AWS/GCP IMDS
+//     169.254.169.254) — net.IP.IsLinkLocalUnicast
+//   - Multicast (224/4, ff00::/8) — net.IP.IsMulticast
+//   - Unspecified (0.0.0.0, ::) — net.IP.IsUnspecified
+//
+// Manual ranges not exposed by stdlib:
+//   - RFC 1122 "this network" (0.0.0.0/8)
+//   - RFC 6598 Carrier-Grade NAT (100.64.0.0/10)
+//   - RFC 5737 documentation (192.0.2/24, 198.51.100/24, 203.0.113/24)
+//   - RFC 2544 benchmarking (198.18.0.0/15)
+//   - RFC 1112 / RFC 6890 reserved (240.0.0.0/4)
+func isBlockedIP(ip net.IP) bool {
+	if ip.IsPrivate() ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() {
+		return true
+	}
+	v4 := ip.To4()
+	if v4 == nil {
+		return false
+	}
+	switch {
+	case v4[0] == 0:
+		// RFC 1122 "this network": 0.0.0.0/8
+		return true
+	case v4[0] == 100 && v4[1]&0xC0 == 0x40:
+		// RFC 6598 CGN: 100.64.0.0/10
+		return true
+	case v4[0] == 192 && v4[1] == 0 && v4[2] == 2:
+		// RFC 5737 TEST-NET-1: 192.0.2.0/24
+		return true
+	case v4[0] == 198 && v4[1] == 51 && v4[2] == 100:
+		// RFC 5737 TEST-NET-2: 198.51.100.0/24
+		return true
+	case v4[0] == 203 && v4[1] == 0 && v4[2] == 113:
+		// RFC 5737 TEST-NET-3: 203.0.113.0/24
+		return true
+	case v4[0] == 198 && v4[1]&0xFE == 18:
+		// RFC 2544 benchmarking: 198.18.0.0/15
+		return true
+	case v4[0]&0xF0 == 0xF0:
+		// RFC 1112 / RFC 6890 reserved: 240.0.0.0/4
+		return true
+	}
+	return false
 }

--- a/internal/attestation/oidc_ssrf_test.go
+++ b/internal/attestation/oidc_ssrf_test.go
@@ -1,0 +1,234 @@
+package attestation
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSSRFIsBlockedIP exercises the IP classifier directly. This is the
+// load-bearing primitive: every fetch-time guard funnels through it, so a
+// gap here is a gap in the whole SSRF defence.
+func TestSSRFIsBlockedIP(t *testing.T) {
+	cases := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		// Cloud metadata — the headline target.
+		{"aws_gcp_imds_link_local", "169.254.169.254", true},
+		{"azure_imds_ula_v6", "fd00:ec2::254", true},
+		// RFC 1918 private.
+		{"private_10", "10.1.2.3", true},
+		{"private_172", "172.16.5.5", true},
+		{"private_192", "192.168.1.1", true},
+		// Loopback.
+		{"loopback_v4", "127.0.0.1", true},
+		{"loopback_v6", "::1", true},
+		// IPv6 ULA + link-local.
+		{"ula_v6", "fc00::1", true},
+		{"link_local_v6", "fe80::1", true},
+		// Other reserved ranges.
+		{"this_network", "0.0.0.0", true},
+		{"this_network_8", "0.1.2.3", true},
+		{"cgn", "100.64.0.1", true},
+		{"test_net_1", "192.0.2.5", true},
+		{"test_net_2", "198.51.100.5", true},
+		{"test_net_3", "203.0.113.5", true},
+		{"benchmarking", "198.18.0.1", true},
+		{"reserved_class_e", "240.0.0.1", true},
+		{"multicast_v4", "224.0.0.1", true},
+		{"multicast_v6", "ff02::1", true},
+		// Public addresses must pass.
+		{"public_v4", "8.8.8.8", false},
+		{"public_v4_github", "140.82.121.4", false},
+		{"public_v6", "2606:4700:4700::1111", false},
+		// Just outside CGN (100.128/9 is public).
+		{"public_just_outside_cgn", "100.128.0.1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ip := net.ParseIP(tc.ip)
+			if ip == nil {
+				t.Fatalf("bad test IP %q", tc.ip)
+			}
+			if got := isBlockedIP(ip); got != tc.blocked {
+				t.Errorf("isBlockedIP(%s) = %v, want %v", tc.ip, got, tc.blocked)
+			}
+		})
+	}
+}
+
+// withStubbedResolver swaps the package-level lookupIPs for the duration of a
+// test, restoring it afterwards. The stub maps every host to fixedIPs, which
+// lets the fetch-level tests drive issuer/jwks_uri hosts to chosen addresses
+// without real DNS.
+func withStubbedResolver(t *testing.T, fixedIPs []net.IP) {
+	t.Helper()
+	orig := lookupIPs
+	t.Cleanup(func() { lookupIPs = orig })
+	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
+		return fixedIPs, nil
+	}
+}
+
+// TestSSRFDiscoveryRejectsInternalIssuer proves the issuer host is resolved
+// and rejected BEFORE the discovery GET fires — the server must never be
+// reachable for an issuer that resolves to an internal address.
+func TestSSRFDiscoveryRejectsInternalIssuer(t *testing.T) {
+	internalRanges := map[string]string{
+		"metadata":    "169.254.169.254",
+		"rfc1918":     "10.0.0.5",
+		"loopback":    "127.0.0.1",
+		"cgn":         "100.64.0.1",
+		"unspecified": "0.0.0.0",
+	}
+	for name, ipStr := range internalRanges {
+		t.Run(name, func(t *testing.T) {
+			withStubbedResolver(t, []net.IP{net.ParseIP(ipStr)})
+
+			// A transport that records whether any GET reached the network.
+			var hits int32
+			rt := &recordingTransport{onRoundTrip: func() { atomic.AddInt32(&hits, 1) }}
+			client := &http.Client{Transport: rt, Timeout: 5 * time.Second}
+
+			_, err := discoverJWKSURL(context.Background(), client, "https://issuer.example.com", false)
+			if err == nil {
+				t.Fatalf("expected rejection for internal issuer %s", ipStr)
+			}
+			if !errors.Is(err, ErrPrivateAttestationEndpoint) {
+				t.Fatalf("expected ErrPrivateAttestationEndpoint, got %v", err)
+			}
+			if got := atomic.LoadInt32(&hits); got != 0 {
+				t.Fatalf("discovery GET fired %d times for blocked issuer — must be 0", got)
+			}
+		})
+	}
+}
+
+// TestSSRFJWKSRejectsInternalRedirect proves a discovery doc whose jwks_uri
+// points at an internal host is rejected before the JWKS GET — the second
+// fetch is independently guarded.
+func TestSSRFJWKSRejectsInternalRedirect(t *testing.T) {
+	withStubbedResolver(t, []net.IP{net.ParseIP("169.254.169.254")})
+
+	var hits int32
+	rt := &recordingTransport{onRoundTrip: func() { atomic.AddInt32(&hits, 1) }}
+	client := &http.Client{Transport: rt, Timeout: 5 * time.Second}
+
+	_, err := fetchJWKS(context.Background(), client, "https://metadata.internal/jwks.json", false)
+	if err == nil {
+		t.Fatal("expected rejection for internal jwks_uri")
+	}
+	if !errors.Is(err, ErrPrivateAttestationEndpoint) {
+		t.Fatalf("expected ErrPrivateAttestationEndpoint, got %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("JWKS GET fired %d times for blocked jwks_uri — must be 0", got)
+	}
+}
+
+// TestSSRFPublicIssuerAllowed proves the guard does NOT block a public issuer:
+// the full discovery → jwks_uri resolution succeeds end to end against an
+// httptest server when the resolver hands back a public IP and the same
+// server answers both GETs.
+func TestSSRFPublicIssuerAllowed(t *testing.T) {
+	var jwksHits int32
+	var issuerURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/.well-known/openid-configuration"):
+			w.Header().Set("Content-Type", "application/json")
+			// Echo the issuer URL we fetched with so the RFC 8414 §3.3
+			// issuer-match check passes; point jwks_uri at the same server.
+			_, _ = w.Write([]byte(`{"issuer":"` + issuerURL + `","jwks_uri":"` + issuerURL + `/jwks"}`))
+		case strings.HasSuffix(r.URL.Path, "/jwks"):
+			atomic.AddInt32(&jwksHits, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"keys":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	issuerURL = srv.URL
+
+	// Resolve every host to a public IP so the guard permits the fetch, but
+	// route the actual HTTP through the httptest server's real client.
+	withStubbedResolver(t, []net.IP{net.ParseIP("93.184.216.34")}) // public IP
+
+	jwksURL, err := discoverJWKSURL(context.Background(), srv.Client(), issuerURL, false)
+	if err != nil {
+		t.Fatalf("public issuer discovery rejected unexpectedly: %v", err)
+	}
+	if jwksURL == "" {
+		t.Fatal("expected a jwks_uri from discovery")
+	}
+	if _, err := fetchJWKS(context.Background(), srv.Client(), jwksURL, false); err != nil {
+		t.Fatalf("public jwks fetch rejected unexpectedly: %v", err)
+	}
+	if atomic.LoadInt32(&jwksHits) != 1 {
+		t.Fatalf("expected exactly one JWKS GET, got %d", jwksHits)
+	}
+}
+
+// TestSSRFAllowPrivateBypassesGuard proves the dev/test escape hatch: when
+// allowPrivate is true, an internal host is NOT pre-checked, so loopback
+// fixtures (httptest, http://localhost) keep working.
+func TestSSRFAllowPrivateBypassesGuard(t *testing.T) {
+	// Resolver would map to loopback, but allowPrivate=true skips resolution
+	// entirely — assertURLHostAllowed must return nil without consulting it.
+	called := false
+	orig := lookupIPs
+	t.Cleanup(func() { lookupIPs = orig })
+	lookupIPs = func(_ context.Context, _ string) ([]net.IP, error) {
+		called = true
+		return []net.IP{net.ParseIP("127.0.0.1")}, nil
+	}
+
+	if err := assertURLHostAllowed(context.Background(), "http://localhost:8080/x", true); err != nil {
+		t.Fatalf("allowPrivate should bypass the guard, got %v", err)
+	}
+	if called {
+		t.Fatal("resolver must not be consulted when allowPrivate is true")
+	}
+}
+
+// TestSSRFGuardedTransportDialBlock proves the dial-time half of the defence:
+// a connection to an IP-literal address in a blocked range is refused at the
+// transport layer, catching DNS-rebind between the pre-flight resolve and the
+// actual dial.
+func TestSSRFGuardedTransportDialBlock(t *testing.T) {
+	allowPrivate := false
+	tr := ssrfGuardedTransport(func() bool { return allowPrivate })
+	_, err := tr.DialContext(context.Background(), "tcp", "169.254.169.254:80")
+	if !errors.Is(err, ErrPrivateAttestationEndpoint) {
+		t.Fatalf("dial to metadata IP should be blocked, got %v", err)
+	}
+
+	// With allowPrivate flipped on, the dialer no longer blocks the IP — it
+	// proceeds to a real dial (which fails to connect, not with our sentinel).
+	allowPrivate = true
+	_, err = tr.DialContext(context.Background(), "tcp", "127.0.0.1:0")
+	if errors.Is(err, ErrPrivateAttestationEndpoint) {
+		t.Fatalf("allowPrivate should not block dial with our sentinel, got %v", err)
+	}
+}
+
+// recordingTransport fails every request after invoking onRoundTrip, so tests
+// can assert whether the network was reached. The guard must reject before
+// RoundTrip is ever called.
+type recordingTransport struct {
+	onRoundTrip func()
+}
+
+func (rt *recordingTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	rt.onRoundTrip()
+	return nil, errors.New("recordingTransport: network must not be reached")
+}

--- a/internal/attestation/policy.go
+++ b/internal/attestation/policy.go
@@ -154,8 +154,12 @@ func validatePolicyConfig(pt domain.ProofType, cfg json.RawMessage, allowPrivate
 			// previously always on, meaning production accepted plaintext
 			// loopback issuers. Production deployments leave allowPrivate
 			// false and only https issuers validate.
-			if u.Scheme != "https" && !(allowPrivate && isLoopbackHost(u.Host)) {
-				return fmt.Errorf("invalid oidc_token config: issuer[%d].url must use https (got %q)", i, u.Scheme)
+			if u.Scheme != "https" {
+				// Plain HTTP is only permitted for loopback issuers, and only
+				// when the dev/test carve-out (allowPrivate) is enabled.
+				if !allowPrivate || !isLoopbackHost(u.Host) {
+					return fmt.Errorf("invalid oidc_token config: issuer[%d].url must use https (got %q)", i, u.Scheme)
+				}
 			}
 		}
 	case domain.ProofTypeImageHash, domain.ProofTypeTPM:

--- a/internal/attestation/policy.go
+++ b/internal/attestation/policy.go
@@ -32,13 +32,31 @@ var ErrInvalidPolicy = errors.New("invalid attestation policy")
 type PolicyService struct {
 	repo      *postgres.AttestationPolicyRepository
 	verifiers *Registry
+
+	// allowPrivate carves out the loopback/private-issuer exception at
+	// write time (an issuer URL like http://localhost:8080/ over plaintext).
+	// Default false (production-safe): only https issuers pass validation,
+	// matching the verifier's runtime SSRF guard. Set true ONLY in dev/test
+	// via SetAllowPrivate. Must track the verifier's allowPrivate flag — see
+	// the integrator note on OIDCVerifier.SetAllowPrivate.
+	allowPrivate bool
 }
 
 // NewPolicyService creates a new policy service. The verifier registry
 // is required so UpsertPolicy can reject policies for proof types that
-// have no verifier wired.
+// have no verifier wired. allowPrivate defaults to false; see
+// SetAllowPrivate to opt into the dev/test loopback carve-out.
 func NewPolicyService(repo *postgres.AttestationPolicyRepository, verifiers *Registry) *PolicyService {
 	return &PolicyService{repo: repo, verifiers: verifiers}
+}
+
+// SetAllowPrivate toggles whether non-https loopback issuer URLs are accepted
+// at policy write time. Production must leave it false. Pair it with
+// OIDCVerifier.SetAllowPrivate so write-time validation and verify-time
+// fetching agree. Returns the service for chaining.
+func (s *PolicyService) SetAllowPrivate(allow bool) *PolicyService {
+	s.allowPrivate = allow
+	return s
 }
 
 // UpsertPolicyRequest captures the payload accepted by the admin API.
@@ -75,7 +93,7 @@ func (s *PolicyService) UpsertPolicy(ctx context.Context, req UpsertPolicyReques
 	// Validate the per-proof-type config shape up front so bad configs can't
 	// sit in the DB until a /verify call finally trips on them. Catches
 	// typos, wrong types, missing issuer URLs, etc. at write time.
-	if err := validatePolicyConfig(req.ProofType, req.Config); err != nil {
+	if err := validatePolicyConfig(req.ProofType, req.Config, s.allowPrivate); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidPolicy, err)
 	}
 
@@ -104,7 +122,12 @@ func (s *PolicyService) UpsertPolicy(ctx context.Context, req UpsertPolicyReques
 // Parsing the JSONB into its typed Go struct catches the obvious "this will
 // never verify successfully" cases (missing issuer list, non-https issuer
 // URL, malformed URL, etc.) before the config reaches the verifier.
-func validatePolicyConfig(pt domain.ProofType, cfg json.RawMessage) error {
+//
+// allowPrivate gates the non-https loopback carve-out: when false (production
+// default) every issuer URL must be https, matching the verifier's runtime
+// SSRF guard. The previous unconditional carve-out let http://localhost
+// issuers persist in production.
+func validatePolicyConfig(pt domain.ProofType, cfg json.RawMessage, allowPrivate bool) error {
 	switch pt {
 	case domain.ProofTypeOIDCToken:
 		var oidc domain.OIDCPolicyConfig
@@ -124,11 +147,14 @@ func validatePolicyConfig(pt domain.ProofType, cfg json.RawMessage) error {
 			}
 			// OIDC discovery is unauthenticated — if we'd fetch jwks_uri
 			// over plain HTTP, a DNS or network attacker could substitute
-			// their own keys and forge any workload identity. Require TLS
-			// except for loopback addresses, which are safe to serve over
-			// HTTP because traffic never leaves the machine — useful for
-			// local dev and httptest-based integration tests.
-			if u.Scheme != "https" && !isLoopbackHost(u.Host) {
+			// their own keys and forge any workload identity. Require TLS.
+			//
+			// The loopback-over-HTTP carve-out (http://localhost) is now
+			// gated behind allowPrivate: it's a dev/test convenience and was
+			// previously always on, meaning production accepted plaintext
+			// loopback issuers. Production deployments leave allowPrivate
+			// false and only https issuers validate.
+			if u.Scheme != "https" && !(allowPrivate && isLoopbackHost(u.Host)) {
 				return fmt.Errorf("invalid oidc_token config: issuer[%d].url must use https (got %q)", i, u.Scheme)
 			}
 		}

--- a/internal/handler/credential.go
+++ b/internal/handler/credential.go
@@ -137,11 +137,12 @@ func (a *API) issueCredentialOp(ctx context.Context, input *IssueCredentialInput
 	}
 
 	accessToken, cred, err := a.credSvc.IssueCredential(ctx, service.IssueRequest{
-		Identity:  identity,
-		Scopes:    input.Body.Scopes,
-		TTL:       input.Body.TTL,
-		GrantType: grantType,
-		Audience:  input.Body.Audience,
+		Identity:              identity,
+		Scopes:                input.Body.Scopes,
+		TTL:                   input.Body.TTL,
+		GrantType:             grantType,
+		Audience:              input.Body.Audience,
+		ResolveIdentityPolicy: true,
 	})
 	if err != nil {
 		log.Error().Err(err).Str("identity_id", input.Body.IdentityID).Msg("failed to issue credential")

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -2,9 +2,12 @@ package handler
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/rs/zerolog/log"
@@ -111,35 +114,48 @@ func extractOAuthError(err error) (code, description string, status int) {
 }
 
 type IntrospectInput struct {
-	Body struct {
+	// Authorization carries OPTIONAL client_secret_basic credentials
+	// (RFC 6749 §2.3.1: `Basic base64(urlencode(id):urlencode(secret))`).
+	// Body client_id/client_secret remain the client_secret_post path; a
+	// request using both methods at once is rejected per RFC 6749 §2.3.
+	Authorization string `header:"Authorization" doc:"Optional HTTP Basic client authentication (client_secret_basic)"`
+	Body          struct {
 		Token string `json:"token" required:"true" minLength:"1" doc:"JWT to introspect"`
 		// ClientID / ClientSecret are OPTIONAL client credentials (RFC 7662 §2.1
 		// authorization). When supplied they are verified (accept-and-verify
 		// posture); a bad secret is rejected with invalid_client. When omitted
 		// the endpoint preserves the internal/network-isolated access path.
-		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth)"`
-		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth)"`
+		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth, client_secret_post)"`
+		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth, client_secret_post)"`
 	}
 }
 
 type IntrospectOutput struct {
 	Status int
-	Body   any // dynamic shape per RFC 7662; oauthErrorBody on client-auth failure
+	// WWWAuthenticate is set on 401 only when the failed attempt used the
+	// Authorization header (RFC 6749 §5.2: MUST echo the scheme back).
+	WWWAuthenticate string `header:"WWW-Authenticate"`
+	Body            any    // dynamic shape per RFC 7662; oauthErrorBody on client-auth failure
 }
 
 type OAuthRevokeInput struct {
-	Body struct {
+	// Authorization — same optional client_secret_basic support as
+	// IntrospectInput (RFC 7009 §2.1 client authorization).
+	Authorization string `header:"Authorization" doc:"Optional HTTP Basic client authentication (client_secret_basic)"`
+	Body          struct {
 		Token string `json:"token" required:"true" minLength:"1" doc:"JWT to revoke"`
 		// ClientID / ClientSecret are OPTIONAL client credentials (RFC 7009 §2.1
 		// authorization). Same accept-and-verify posture as introspection.
-		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth)"`
-		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth)"`
+		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth, client_secret_post)"`
+		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth, client_secret_post)"`
 	}
 }
 
 type OAuthRevokeOutput struct {
 	Status int
-	Body   struct {
+	// WWWAuthenticate — see IntrospectOutput.
+	WWWAuthenticate string `header:"WWW-Authenticate"`
+	Body            struct {
 		Revoked bool `json:"revoked"`
 		// Error / ErrorDescription are populated only when presented client
 		// credentials fail verification (invalid_client). On every other path
@@ -147,6 +163,48 @@ type OAuthRevokeOutput struct {
 		Error            string `json:"error,omitempty"`
 		ErrorDescription string `json:"error_description,omitempty"`
 	}
+}
+
+// basicAuthChallenge is the WWW-Authenticate value returned when a Basic
+// client-auth attempt fails (RFC 6749 §5.2).
+const basicAuthChallenge = `Basic realm="zeroid", charset="UTF-8"`
+
+// resolveInspectionClientAuth merges the two supported client authentication
+// methods on the introspection/revocation endpoints: client_secret_basic
+// (Authorization header) and client_secret_post (body fields). Returns the
+// effective credentials plus whether the Basic header was the source (drives
+// the RFC 6749 §5.2 WWW-Authenticate echo on failure).
+//
+// Per RFC 6749 §2.3 a client MUST NOT use more than one method in a single
+// request — presenting both is rejected as invalid_request. Non-Basic
+// Authorization schemes are ignored (treated as not presented) so bearer
+// headers from generic middleware don't break the anonymous internal path.
+// Credentials inside Basic are form-urlencoded per RFC 6749 §2.3.1.
+func resolveInspectionClientAuth(authorization, bodyClientID, bodyClientSecret string) (clientID, clientSecret string, viaBasic bool, err error) {
+	badRequest := func(desc string) *service.OAuthError {
+		return &service.OAuthError{Code: oautherror.InvalidRequest, Description: desc, HTTPStatus: http.StatusBadRequest}
+	}
+	const prefix = "Basic "
+	if len(authorization) < len(prefix) || !strings.EqualFold(authorization[:len(prefix)], prefix) {
+		return bodyClientID, bodyClientSecret, false, nil
+	}
+	if bodyClientID != "" || bodyClientSecret != "" {
+		return "", "", true, badRequest("only one client authentication method may be used per request (RFC 6749 §2.3)")
+	}
+	raw, decErr := base64.StdEncoding.DecodeString(strings.TrimSpace(authorization[len(prefix):]))
+	if decErr != nil {
+		return "", "", true, badRequest("malformed Basic authorization header")
+	}
+	id, secret, ok := strings.Cut(string(raw), ":")
+	if !ok {
+		return "", "", true, badRequest("malformed Basic authorization header")
+	}
+	id, idErr := url.QueryUnescape(id)
+	secret, secErr := url.QueryUnescape(secret)
+	if idErr != nil || secErr != nil {
+		return "", "", true, badRequest("malformed Basic authorization header")
+	}
+	return id, secret, true, nil
 }
 
 // ── OAuth routes ─────────────────────────────────────────────────────────────
@@ -343,12 +401,21 @@ func (a *API) tokenOp(ctx context.Context, input *TokenInput) (*TokenOutput, err
 }
 
 func (a *API) introspectOp(ctx context.Context, input *IntrospectInput) (*IntrospectOutput, error) {
-	// Accept-and-verify client auth (RFC 7662 §2.1). When credentials are
+	// Accept-and-verify client auth (RFC 7662 §2.1) via client_secret_basic
+	// (Authorization header) or client_secret_post (body). When credentials are
 	// presented they MUST verify; a bad secret is rejected with invalid_client.
 	// When absent, the existing internal/tenant-header access path is preserved.
-	if err := a.oauthSvc.VerifyPresentedClientAuth(ctx, input.Body.ClientID, input.Body.ClientSecret); err != nil {
+	clientID, clientSecret, viaBasic, err := resolveInspectionClientAuth(input.Authorization, input.Body.ClientID, input.Body.ClientSecret)
+	if err == nil {
+		err = a.oauthSvc.VerifyPresentedClientAuth(ctx, clientID, clientSecret)
+	}
+	if err != nil {
 		code, desc, status := extractOAuthError(err)
-		return &IntrospectOutput{Status: status, Body: oauthErrorBody{Error: code, ErrorDescription: desc}}, nil
+		out := &IntrospectOutput{Status: status, Body: oauthErrorBody{Error: code, ErrorDescription: desc}}
+		if viaBasic && status == http.StatusUnauthorized {
+			out.WWWAuthenticate = basicAuthChallenge
+		}
+		return out, nil
 	}
 
 	result, err := a.oauthSvc.Introspect(ctx, input.Body.Token)
@@ -360,11 +427,16 @@ func (a *API) introspectOp(ctx context.Context, input *IntrospectInput) (*Intros
 }
 
 func (a *API) revokeOp(ctx context.Context, input *OAuthRevokeInput) (*OAuthRevokeOutput, error) {
-	// Accept-and-verify client auth (RFC 7009 §2.1). A presented-but-wrong
+	// Accept-and-verify client auth (RFC 7009 §2.1) via client_secret_basic
+	// (Authorization header) or client_secret_post (body). A presented-but-wrong
 	// secret is rejected with invalid_client; otherwise the RFC 7009 §2.2
 	// "always 200" contract holds (including for unknown/already-revoked tokens
 	// and anonymous internal-path callers).
-	if err := a.oauthSvc.VerifyPresentedClientAuth(ctx, input.Body.ClientID, input.Body.ClientSecret); err != nil {
+	clientID, clientSecret, viaBasic, err := resolveInspectionClientAuth(input.Authorization, input.Body.ClientID, input.Body.ClientSecret)
+	if err == nil {
+		err = a.oauthSvc.VerifyPresentedClientAuth(ctx, clientID, clientSecret)
+	}
+	if err != nil {
 		code, desc, status := extractOAuthError(err)
 		out := &OAuthRevokeOutput{Status: status}
 		// Use the error's own code, not a hardcoded invalid_client — an
@@ -372,6 +444,9 @@ func (a *API) revokeOp(ctx context.Context, input *OAuthRevokeInput) (*OAuthRevo
 		// labelled as a client authentication failure.
 		out.Body.Error = code
 		out.Body.ErrorDescription = desc
+		if viaBasic && status == http.StatusUnauthorized {
+			out.WWWAuthenticate = basicAuthChallenge
+		}
 		return out, nil
 	}
 

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -365,9 +365,12 @@ func (a *API) revokeOp(ctx context.Context, input *OAuthRevokeInput) (*OAuthRevo
 	// "always 200" contract holds (including for unknown/already-revoked tokens
 	// and anonymous internal-path callers).
 	if err := a.oauthSvc.VerifyPresentedClientAuth(ctx, input.Body.ClientID, input.Body.ClientSecret); err != nil {
-		_, desc, status := extractOAuthError(err)
+		code, desc, status := extractOAuthError(err)
 		out := &OAuthRevokeOutput{Status: status}
-		out.Body.Error = oautherror.InvalidClient
+		// Use the error's own code, not a hardcoded invalid_client — an
+		// operational failure maps to a 500/server_error and must not be
+		// labelled as a client authentication failure.
+		out.Body.Error = code
 		out.Body.ErrorDescription = desc
 		return out, nil
 	}

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -113,22 +113,39 @@ func extractOAuthError(err error) (code, description string, status int) {
 type IntrospectInput struct {
 	Body struct {
 		Token string `json:"token" required:"true" minLength:"1" doc:"JWT to introspect"`
+		// ClientID / ClientSecret are OPTIONAL client credentials (RFC 7662 §2.1
+		// authorization). When supplied they are verified (accept-and-verify
+		// posture); a bad secret is rejected with invalid_client. When omitted
+		// the endpoint preserves the internal/network-isolated access path.
+		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth)"`
+		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth)"`
 	}
 }
 
 type IntrospectOutput struct {
-	Body any // dynamic shape per RFC 7662
+	Status int
+	Body   any // dynamic shape per RFC 7662; oauthErrorBody on client-auth failure
 }
 
 type OAuthRevokeInput struct {
 	Body struct {
 		Token string `json:"token" required:"true" minLength:"1" doc:"JWT to revoke"`
+		// ClientID / ClientSecret are OPTIONAL client credentials (RFC 7009 §2.1
+		// authorization). Same accept-and-verify posture as introspection.
+		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth)"`
+		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth)"`
 	}
 }
 
 type OAuthRevokeOutput struct {
-	Body struct {
+	Status int
+	Body   struct {
 		Revoked bool `json:"revoked"`
+		// Error / ErrorDescription are populated only when presented client
+		// credentials fail verification (invalid_client). On every other path
+		// the RFC 7009 §2.2 "always 200" contract holds.
+		Error            string `json:"error,omitempty"`
+		ErrorDescription string `json:"error_description,omitempty"`
 	}
 }
 
@@ -326,17 +343,37 @@ func (a *API) tokenOp(ctx context.Context, input *TokenInput) (*TokenOutput, err
 }
 
 func (a *API) introspectOp(ctx context.Context, input *IntrospectInput) (*IntrospectOutput, error) {
-	result, err := a.oauthSvc.Introspect(ctx, input.Body.Token)
-	if err != nil {
-		return &IntrospectOutput{Body: map[string]any{"active": false}}, nil
+	// Accept-and-verify client auth (RFC 7662 §2.1). When credentials are
+	// presented they MUST verify; a bad secret is rejected with invalid_client.
+	// When absent, the existing internal/tenant-header access path is preserved.
+	if err := a.oauthSvc.VerifyPresentedClientAuth(ctx, input.Body.ClientID, input.Body.ClientSecret); err != nil {
+		code, desc, status := extractOAuthError(err)
+		return &IntrospectOutput{Status: status, Body: oauthErrorBody{Error: code, ErrorDescription: desc}}, nil
 	}
 
-	return &IntrospectOutput{Body: result}, nil
+	result, err := a.oauthSvc.Introspect(ctx, input.Body.Token)
+	if err != nil {
+		return &IntrospectOutput{Status: http.StatusOK, Body: map[string]any{"active": false}}, nil
+	}
+
+	return &IntrospectOutput{Status: http.StatusOK, Body: result}, nil
 }
 
 func (a *API) revokeOp(ctx context.Context, input *OAuthRevokeInput) (*OAuthRevokeOutput, error) {
+	// Accept-and-verify client auth (RFC 7009 §2.1). A presented-but-wrong
+	// secret is rejected with invalid_client; otherwise the RFC 7009 §2.2
+	// "always 200" contract holds (including for unknown/already-revoked tokens
+	// and anonymous internal-path callers).
+	if err := a.oauthSvc.VerifyPresentedClientAuth(ctx, input.Body.ClientID, input.Body.ClientSecret); err != nil {
+		_, desc, status := extractOAuthError(err)
+		out := &OAuthRevokeOutput{Status: status}
+		out.Body.Error = oautherror.InvalidClient
+		out.Body.ErrorDescription = desc
+		return out, nil
+	}
+
 	_ = a.oauthSvc.Revoke(ctx, input.Body.Token)
-	out := &OAuthRevokeOutput{}
+	out := &OAuthRevokeOutput{Status: http.StatusOK}
 	out.Body.Revoked = true
 	return out, nil
 }

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -388,6 +388,7 @@ func (a *API) revokeOp(ctx context.Context, input *OAuthRevokeInput) (*OAuthRevo
 type BcAuthorizeInput struct {
 	Body struct {
 		ClientID                string `json:"client_id" required:"true" doc:"OAuth client initiating the backchannel request"`
+		ClientSecret            string `json:"client_secret,omitempty" doc:"Client secret — REQUIRED for confidential clients (OpenID CIBA Core §7.1); omitted for public clients"`
 		AccountID               string `json:"account_id" required:"true" doc:"Tenant account ID"`
 		ProjectID               string `json:"project_id" required:"true" doc:"Tenant project ID"`
 		LoginHint               string `json:"login_hint,omitempty" doc:"User identifier (email, phone, user_id). Required IF group_hint is not supplied."`
@@ -426,6 +427,7 @@ func (a *API) bcAuthorizeOp(ctx context.Context, input *BcAuthorizeInput) (*BcAu
 	}
 	out, err := a.backchannelSvc.CreateAuthRequest(ctx, service.CreateAuthRequestInput{
 		ClientID:                input.Body.ClientID,
+		ClientSecret:            input.Body.ClientSecret,
 		AccountID:               input.Body.AccountID,
 		ProjectID:               input.Body.ProjectID,
 		LoginHint:               input.Body.LoginHint,

--- a/internal/handler/wellknown.go
+++ b/internal/handler/wellknown.go
@@ -125,10 +125,15 @@ func (a *API) oauthMetadataOp(_ context.Context, _ *struct{}) (*OAuthMetadataOut
 			"api_key",
 			"urn:openid:params:grant-type:ciba",
 		},
-		"jwks_uri":                 a.issuer + "/.well-known/jwks.json",
-		"introspection_endpoint":   a.issuer + "/oauth2/token/introspect",
-		"revocation_endpoint":      a.issuer + "/oauth2/token/revoke",
-		"response_types_supported": []string{"token"},
+		"jwks_uri":               a.issuer + "/.well-known/jwks.json",
+		"introspection_endpoint": a.issuer + "/oauth2/token/introspect",
+		"revocation_endpoint":    a.issuer + "/oauth2/token/revoke",
+		// RFC 8414 — client auth methods accepted by the introspection and
+		// revocation endpoints (client_secret_basic via Authorization header,
+		// client_secret_post via body fields).
+		"introspection_endpoint_auth_methods_supported": []string{"client_secret_post", "client_secret_basic"},
+		"revocation_endpoint_auth_methods_supported":    []string{"client_secret_post", "client_secret_basic"},
+		"response_types_supported":                      []string{"token"},
 		"token_endpoint_auth_signing_alg_values_supported": []string{"ES256", "RS256"},
 
 		// RFC 7591 dynamic client registration.

--- a/internal/handler/wellknown.go
+++ b/internal/handler/wellknown.go
@@ -131,9 +131,9 @@ func (a *API) oauthMetadataOp(_ context.Context, _ *struct{}) (*OAuthMetadataOut
 		// RFC 8414 — client auth methods accepted by the introspection and
 		// revocation endpoints (client_secret_basic via Authorization header,
 		// client_secret_post via body fields).
-		"introspection_endpoint_auth_methods_supported": []string{"client_secret_post", "client_secret_basic"},
-		"revocation_endpoint_auth_methods_supported":    []string{"client_secret_post", "client_secret_basic"},
-		"response_types_supported":                      []string{"token"},
+		"introspection_endpoint_auth_methods_supported":    []string{"client_secret_post", "client_secret_basic"},
+		"revocation_endpoint_auth_methods_supported":       []string{"client_secret_post", "client_secret_basic"},
+		"response_types_supported":                         []string{"token"},
 		"token_endpoint_auth_signing_alg_values_supported": []string{"ES256", "RS256"},
 
 		// RFC 7591 dynamic client registration.

--- a/internal/service/attestation.go
+++ b/internal/service/attestation.go
@@ -271,8 +271,9 @@ func (s *AttestationService) VerifyAttestation(ctx context.Context, id, accountI
 		}
 
 		issued, issuedCred, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-			Identity:  identity,
-			GrantType: domain.GrantTypeClientCredentials,
+			Identity:              identity,
+			GrantType:             domain.GrantTypeClientCredentials,
+			ResolveIdentityPolicy: true,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to issue post-attestation credential: %w", err)

--- a/internal/service/backchannel.go
+++ b/internal/service/backchannel.go
@@ -274,10 +274,19 @@ func (s *BackchannelService) SetPingDispatchSync(sync bool) {
 
 // CreateAuthRequest input for POST /oauth2/bc-authorize.
 type CreateAuthRequestInput struct {
-	ClientID  string
-	AccountID string
-	ProjectID string
-	LoginHint string
+	ClientID string
+	// ClientSecret authenticates the initiating client at bc-authorize.
+	// REQUIRED when the resolved client is confidential — bc-authorize fires
+	// the deployer's notifier (SMS/push prompts to a real end user), so an
+	// unauthenticated caller must not be able to spam approval prompts at
+	// arbitrary users using a confidential client's identity. Public clients
+	// (CIBA Core §7.1 permits them) carry no secret and may remain
+	// unauthenticated here; the trust anchor for token issuance is still the
+	// user's approval, not the client credential. Empty for public clients.
+	ClientSecret string
+	AccountID    string
+	ProjectID    string
+	LoginHint    string
 	// GroupHint is the CIBA extension parameter for role/group-targeted
 	// approval. Opaque to zeroid; the deployer's BackchannelNotifier
 	// owns interpretation (e.g. AuthN treats "highflame:role:finance_lead"
@@ -353,13 +362,45 @@ func (s *BackchannelService) CreateAuthRequest(ctx context.Context, in CreateAut
 		)
 	}
 
-	// Validate client exists in the tenant scope. We don't enforce a
-	// client_secret check here: CIBA Core §7.1 allows public clients to
-	// initiate the flow, and the trust anchor for token issuance is the
-	// user's approval, not the client credential.
+	// Resolve the client. GetClientByClientID intentionally returns any
+	// client (public or confidential) WITHOUT an is_active filter (the
+	// underlying repo GetByClientID skips the check — tracked as a follow-up;
+	// see the explicit IsActive guard below), so we re-derive activeness here.
 	client, err := s.oauthClientSvc.GetClientByClientID(ctx, in.ClientID)
 	if err != nil {
 		return nil, oauthBadRequestCause(oautherror.InvalidClient, fmt.Sprintf("unknown client %s", in.ClientID), err)
+	}
+
+	// Reject deactivated clients explicitly. GetClientByClientID does not
+	// filter on is_active (unlike GetPublicClient / VerifyClientSecret, which
+	// both do), so without this guard a deactivated client could still drive
+	// CIBA. Use the same opaque invalid_client surface as "unknown client" so
+	// we don't leak the activeness state of a client_id.
+	if !client.IsActive {
+		return nil, oauthBadRequest(oautherror.InvalidClient, fmt.Sprintf("unknown client %s", in.ClientID))
+	}
+
+	// Authenticate confidential clients. CIBA Core §7.1 permits public clients
+	// to initiate the flow unauthenticated — the trust anchor for token
+	// issuance is the user's approval, not the client credential — but a
+	// CONFIDENTIAL client registered a secret precisely so it can be
+	// authenticated. bc-authorize fires the deployer's notifier (real SMS/push
+	// approval prompts to an end user), so allowing an unauthenticated party to
+	// initiate against a confidential client lets them spam prompts at
+	// arbitrary users under that client's identity. Require + verify the
+	// client_secret when the client is confidential. A client is confidential
+	// if it declares so or carries a stored secret hash (belt-and-suspenders).
+	if client.ClientType == "confidential" || client.ClientSecret != "" {
+		if in.ClientSecret == "" {
+			return nil, oauthBadRequest(oautherror.InvalidClient, "client_secret is required for a confidential client")
+		}
+		// VerifyClientSecret re-loads by client_id, re-checks is_active, and
+		// compares the bcrypt hash. On any failure surface the opaque
+		// invalid_client so we don't distinguish "wrong secret" from
+		// "unknown/deactivated client".
+		if _, verr := s.oauthClientSvc.VerifyClientSecret(ctx, in.ClientID, in.ClientSecret); verr != nil {
+			return nil, oauthBadRequestCause(oautherror.InvalidClient, "client authentication failed", verr)
+		}
 	}
 
 	// Determine notification mode. CIBA Core §10 makes the delivery mode a
@@ -629,6 +670,17 @@ func (s *BackchannelService) Redeem(ctx context.Context, in RedeemInput) (*domai
 	if in.AuthReqID == "" {
 		return nil, oauthBadRequest(oautherror.InvalidGrant, "auth_req_id is required for grant_type=urn:openid:params:grant-type:ciba")
 	}
+	// Fail closed on the ownership check. CIBA Core §11 binds an auth_req_id to
+	// the client that initiated it; the polling client MUST identify itself so
+	// we can confirm ownership. The previous comparison was skipped entirely
+	// when in.ClientID was empty, so a polling caller that simply omitted
+	// client_id could redeem ANY approved auth_req_id it learned. Require a
+	// non-empty client_id on the redemption path and always compare it to the
+	// row — empty or mismatched both yield the same opaque "not issued to this
+	// client" error so we don't leak which auth_req_ids exist.
+	if in.ClientID == "" {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "auth_req_id was not issued to this client")
+	}
 	row, err := s.repo.GetByAuthReqID(ctx, in.AuthReqID)
 	if err != nil {
 		if errors.Is(err, postgres.ErrBackchannelRequestNotFound) {
@@ -636,7 +688,7 @@ func (s *BackchannelService) Redeem(ctx context.Context, in RedeemInput) (*domai
 		}
 		return nil, oauthServerError("failed to load backchannel auth request", err)
 	}
-	if in.ClientID != "" && row.ClientID != in.ClientID {
+	if row.ClientID != in.ClientID {
 		// Mismatch means a different client is polling — refuse without leaking detail.
 		return nil, oauthBadRequest(oautherror.InvalidGrant, "auth_req_id was not issued to this client")
 	}
@@ -651,6 +703,19 @@ func (s *BackchannelService) Redeem(ctx context.Context, in RedeemInput) (*domai
 	now := time.Now()
 	if now.After(row.ExpiresAt) && row.Status == domain.BackchannelStatusPending {
 		// Race against the sweep: surface expired_token immediately.
+		return nil, oauthBadRequest(oautherror.ExpiredToken, "the backchannel authentication request has expired")
+	}
+	// An APPROVED row that has outlived both its own expires_at and the
+	// post-approval grace window must NOT mint a token. Without this an
+	// approved-but-unredeemed auth_req_id was redeemable forever (the PENDING
+	// guard above never fired for it and DeleteExpired used to retain approved
+	// rows indefinitely), so a leaked months-old handle still issued a token.
+	// Surface expired_token, matching the PENDING-row treatment. The MarkIssued
+	// guard enforces the same bound atomically at the DB layer; this check
+	// surfaces the right error code before we attempt the claim.
+	if row.Status == domain.BackchannelStatusApproved &&
+		now.After(row.ExpiresAt) &&
+		now.After(approvalRedemptionDeadline(row)) {
 		return nil, oauthBadRequest(oautherror.ExpiredToken, "the backchannel authentication request has expired")
 	}
 
@@ -706,7 +771,12 @@ func (s *BackchannelService) issueTokenForApprovedRow(ctx context.Context, row *
 	// initiate a new bc-authorize. That's preferable to silently minting two
 	// tokens — the failure is loud (HTTP 500) and the client's
 	// retry-with-new-auth-req-id path handles it cleanly.
-	affected, mErr := s.repo.MarkIssued(ctx, row.AuthReqID)
+	// Pass time.Now() as the issuance cutoff. MarkIssued's WHERE clause
+	// additionally rejects an approved row that has outlived both expires_at
+	// and the post-approval grace window — the atomic DB-layer counterpart to
+	// the expired_token pre-check in Redeem. A row that lost that race (or any
+	// concurrent second redemption) yields affected=0 and is rejected below.
+	affected, mErr := s.repo.MarkIssued(ctx, row.AuthReqID, time.Now())
 	if mErr != nil {
 		log.Error().Err(mErr).Str("auth_req_id", row.AuthReqID).Msg("failed to mark backchannel request issued")
 		return nil, oauthServerError("failed to commit issuance state", mErr)
@@ -1120,6 +1190,22 @@ func (s *BackchannelService) postCallback(ctx context.Context, row *domain.Backc
 		return
 	}
 	deliver()
+}
+
+// approvalRedemptionDeadline returns the latest instant at which an APPROVED
+// row may still be redeemed via the grace window: approved_at +
+// postgres.ApprovedRedemptionGrace. Falls back to created_at when approved_at
+// is somehow unset (defensive — an approved row always has approved_at
+// stamped). Redeem combines this with expires_at: a row is redeemable while it
+// is within EITHER its own expires_at OR this grace deadline. This mirrors the
+// SQL guard in postgres.MarkIssued so the service-side expired_token decision
+// and the atomic DB-side claim agree.
+func approvalRedemptionDeadline(row *domain.BackchannelAuthRequest) time.Time {
+	base := row.CreatedAt
+	if row.ApprovedAt != nil {
+		base = *row.ApprovedAt
+	}
+	return base.Add(postgres.ApprovedRedemptionGrace)
 }
 
 // mintAuthReqID returns a 32-byte URL-safe random handle. 256 bits of entropy

--- a/internal/service/backchannel.go
+++ b/internal/service/backchannel.go
@@ -656,6 +656,11 @@ func (s *BackchannelService) dispatchResolution(ctx context.Context, row *domain
 type RedeemInput struct {
 	AuthReqID string
 	ClientID  string
+	// ClientSecret authenticates a confidential client at the token endpoint
+	// (OpenID CIBA Core §10.2: token requests follow standard OAuth client-
+	// authentication rules, same as refresh_token/authorization_code). Empty
+	// for public clients.
+	ClientSecret string
 	// DPoPKeyThumbprint forwards the proof key thumbprint from the token
 	// endpoint so a CIBA-redeemed token can still be DPoP-bound (RFC 9449).
 	// Non-empty when the polling /oauth2/token call carried a valid DPoP
@@ -681,6 +686,32 @@ func (s *BackchannelService) Redeem(ctx context.Context, in RedeemInput) (*domai
 	if in.ClientID == "" {
 		return nil, oauthBadRequest(oautherror.InvalidGrant, "auth_req_id was not issued to this client")
 	}
+
+	// Authenticate confidential clients at redemption (CIBA Core §10.2: the
+	// token request follows standard OAuth client-authentication rules, the
+	// same posture as the refresh_token/authorization_code grants). The
+	// initiation side (bc-authorize) already enforces this; without the
+	// symmetric check here a leaked auth_req_id alone would mint the token for
+	// a confidential client, defeating the defense-in-depth the secret
+	// provides. Runs BEFORE the row lookup so an unauthenticated caller learns
+	// nothing about which auth_req_ids exist. Same confidentiality test and
+	// opaque invalid_client surface as bc-authorize. An unresolvable client_id
+	// falls through — CIBA rows are only created for registered clients, so
+	// the row ownership check below rejects it with the usual opaque error.
+	if client, cerr := s.oauthClientSvc.GetClientByClientID(ctx, in.ClientID); cerr == nil {
+		if !client.IsActive {
+			return nil, oauthBadRequest(oautherror.InvalidClient, fmt.Sprintf("unknown client %s", in.ClientID))
+		}
+		if client.ClientType == "confidential" || client.ClientSecret != "" {
+			if in.ClientSecret == "" {
+				return nil, oauthBadRequest(oautherror.InvalidClient, "client_secret is required for a confidential client")
+			}
+			if _, verr := s.oauthClientSvc.VerifyClientSecret(ctx, in.ClientID, in.ClientSecret); verr != nil {
+				return nil, oauthBadRequestCause(oautherror.InvalidClient, "client authentication failed", verr)
+			}
+		}
+	}
+
 	row, err := s.repo.GetByAuthReqID(ctx, in.AuthReqID)
 	if err != nil {
 		if errors.Is(err, postgres.ErrBackchannelRequestNotFound) {

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -270,16 +270,43 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 		}
 
 		// Identity policy — governance ceiling.
-		if req.IdentityPolicyID != "" {
-			policy, err := s.policySvc.GetPolicy(ctx, req.IdentityPolicyID, req.Identity.AccountID, req.Identity.ProjectID)
+		//
+		// Callers on the OAuth grant paths resolve the identity's policy
+		// themselves (via IdentityService.ResolveCredentialPolicy) and pass
+		// its ID in IdentityPolicyID. But three other issuance paths —
+		// RotateCredential, the admin issue handler, and post-attestation
+		// verification — historically left IdentityPolicyID empty, which
+		// turned this "authoritative chokepoint" into a no-op for them and
+		// let a since-tightened ceiling be bypassed.
+		//
+		// To make the chokepoint authoritative regardless of caller, resolve
+		// the policy here when none was supplied, mirroring
+		// ResolveCredentialPolicy exactly: prefer the identity's own
+		// CredentialPolicyID, otherwise fall back to the tenant default
+		// (EnsureDefaultPolicy). That fallback always yields a policy, so an
+		// identity that "has no policy configured" still issues — it's
+		// governed by the tenant default rather than being rejected. Callers
+		// that DO pass IdentityPolicyID keep using exactly that policy; we
+		// never re-resolve or override an explicit ID.
+		identityPolicyID := req.IdentityPolicyID
+		if identityPolicyID == "" {
+			resolved, err := s.resolveIdentityPolicyID(ctx, req.Identity)
 			if err != nil {
-				return nil, nil, fmt.Errorf("identity credential policy %s not found: %w", req.IdentityPolicyID, err)
+				return nil, nil, fmt.Errorf("failed to resolve identity credential policy: %w", err)
+			}
+			identityPolicyID = resolved
+		}
+
+		if identityPolicyID != "" {
+			policy, err := s.policySvc.GetPolicy(ctx, identityPolicyID, req.Identity.AccountID, req.Identity.ProjectID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("identity credential policy %s not found: %w", identityPolicyID, err)
 			}
 			if err := s.policySvc.EnforcePolicy(ctx, policy, enforceReq); err != nil {
 				log.Warn().
 					Err(err).
 					Str("identity_id", req.Identity.ID).
-					Str("policy_id", req.IdentityPolicyID).
+					Str("policy_id", identityPolicyID).
 					Str("policy_layer", "identity").
 					Msg("Identity policy enforcement denied issuance")
 				return nil, nil, err
@@ -288,8 +315,10 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 
 		// API key policy — per-credential restriction. Checked only when a
 		// distinct policy is supplied; if the API key inherits the identity
-		// policy we skip the redundant enforcement.
-		if req.CredentialPolicyID != "" && req.CredentialPolicyID != req.IdentityPolicyID {
+		// policy we skip the redundant enforcement. Compared against the
+		// resolved identity policy (not the raw request field) so the skip
+		// still fires when the identity policy was resolved at this layer.
+		if req.CredentialPolicyID != "" && req.CredentialPolicyID != identityPolicyID {
 			policy, err := s.policySvc.GetPolicy(ctx, req.CredentialPolicyID, req.Identity.AccountID, req.Identity.ProjectID)
 			if err != nil {
 				return nil, nil, fmt.Errorf("credential policy %s not found: %w", req.CredentialPolicyID, err)
@@ -585,6 +614,37 @@ func (s *CredentialService) dispatchRevocations(ctx context.Context, revoked []p
 		})
 	}
 	s.revocationDispatcher.Dispatch(ctx, events)
+}
+
+// resolveIdentityPolicyID returns the ID of the credential policy that
+// governs this identity, to be used as the authority ceiling at the issuance
+// chokepoint when the caller didn't supply one explicitly.
+//
+// It mirrors IdentityService.ResolveCredentialPolicy: prefer the identity's
+// own CredentialPolicyID, otherwise fall back to the tenant default
+// (EnsureDefaultPolicy, which creates one on first use). The chokepoint owns
+// this resolution so every issuance path is governed even when its caller
+// forgot to resolve and pass IdentityPolicyID. CredentialService already holds
+// policySvc, so this introduces no new dependency and no import cycle (the
+// OAuth-side resolver lives on IdentityService, which depends on
+// CredentialService — reaching the other way would cycle).
+//
+// EnsureDefaultPolicy always returns a policy, so this never produces an
+// "unrestricted, no policy" outcome for a tenant that simply never configured
+// one — that tenant is governed by the permissive default policy, matching the
+// OAuth grant paths exactly.
+func (s *CredentialService) resolveIdentityPolicyID(ctx context.Context, identity *domain.Identity) (string, error) {
+	if s.policySvc == nil || identity == nil {
+		return "", nil
+	}
+	if identity.CredentialPolicyID != "" {
+		return identity.CredentialPolicyID, nil
+	}
+	policy, err := s.policySvc.EnsureDefaultPolicy(ctx, identity.AccountID, identity.ProjectID)
+	if err != nil {
+		return "", err
+	}
+	return policy.ID, nil
 }
 
 // RotateCredential revokes an existing credential and immediately issues a new one for the same identity.

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -117,6 +117,17 @@ type IssueRequest struct {
 	// cnf.jkt claim binding the token to that key, and token_type is returned
 	// as "DPoP" instead of "Bearer" (RFC 9449 §6.1).
 	DPoPKeyThumbprint string
+	// ResolveIdentityPolicy asks IssueCredential to resolve and enforce the
+	// identity's policy when IdentityPolicyID is empty. The OAuth grant paths
+	// resolve the policy themselves (and only for grants gated at the identity
+	// layer — authorization_code/refresh_token/CIBA tokens minted for a client
+	// with no linked identity are deliberately governed by the client, not an
+	// identity policy). The three issuance paths that historically bypassed the
+	// ceiling — RotateCredential, the admin issue handler, and post-attestation
+	// verification — set this so the chokepoint resolves the identity's policy
+	// (own CredentialPolicyID, else tenant default) and enforces it. Leaving it
+	// false preserves the prior behavior for every other caller.
+	ResolveIdentityPolicy bool
 }
 
 // ErrScopesNotAllowed is returned when one or more requested scopes are not in the identity's AllowedScopes list.
@@ -273,23 +284,23 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 		//
 		// Callers on the OAuth grant paths resolve the identity's policy
 		// themselves (via IdentityService.ResolveCredentialPolicy) and pass
-		// its ID in IdentityPolicyID. But three other issuance paths —
-		// RotateCredential, the admin issue handler, and post-attestation
-		// verification — historically left IdentityPolicyID empty, which
-		// turned this "authoritative chokepoint" into a no-op for them and
-		// let a since-tightened ceiling be bypassed.
-		//
-		// To make the chokepoint authoritative regardless of caller, resolve
-		// the policy here when none was supplied, mirroring
-		// ResolveCredentialPolicy exactly: prefer the identity's own
-		// CredentialPolicyID, otherwise fall back to the tenant default
-		// (EnsureDefaultPolicy). That fallback always yields a policy, so an
-		// identity that "has no policy configured" still issues — it's
-		// governed by the tenant default rather than being rejected. Callers
-		// that DO pass IdentityPolicyID keep using exactly that policy; we
-		// never re-resolve or override an explicit ID.
+		// its ID in IdentityPolicyID — and only do so for grants gated at the
+		// identity layer. Three other issuance paths — RotateCredential, the
+		// admin issue handler, and post-attestation verification — historically
+		// left IdentityPolicyID empty, which turned this "authoritative
+		// chokepoint" into a no-op for them and let a since-tightened ceiling be
+		// bypassed. They now set ResolveIdentityPolicy so the chokepoint
+		// resolves the governing policy when none was supplied, mirroring
+		// ResolveCredentialPolicy: prefer the identity's own CredentialPolicyID,
+		// else the tenant default (EnsureDefaultPolicy, which always yields a
+		// policy so a tenant that never configured one is governed by the
+		// default rather than rejected). Callers that pass IdentityPolicyID keep
+		// using exactly that policy; we never re-resolve or override it. Callers
+		// that neither pass an ID nor opt in are unaffected — preserving the
+		// client-gated behavior of authorization_code/refresh_token/CIBA tokens
+		// minted for clients with no linked identity.
 		identityPolicyID := req.IdentityPolicyID
-		if identityPolicyID == "" {
+		if identityPolicyID == "" && req.ResolveIdentityPolicy {
 			resolved, err := s.resolveIdentityPolicyID(ctx, req.Identity)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to resolve identity credential policy: %w", err)
@@ -668,10 +679,11 @@ func (s *CredentialService) RotateCredential(ctx context.Context, credID, accoun
 
 	// Issue a new one with the same parameters.
 	return s.IssueCredential(ctx, IssueRequest{
-		Identity:  identity,
-		Scopes:    old.Scopes,
-		TTL:       old.TTLSeconds,
-		GrantType: old.GrantType,
+		Identity:              identity,
+		Scopes:                old.Scopes,
+		TTL:                   old.TTLSeconds,
+		GrantType:             old.GrantType,
+		ResolveIdentityPolicy: true,
 	})
 }
 

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -259,6 +259,18 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 		return nil, oauthBadRequest(oautherror.UnauthorizedClient, "client not authorized for client_credentials grant")
 	}
 
+	// A client_credentials client registered with zero scopes can mint
+	// NOTHING — there is no human or delegation chain to fall back to here,
+	// so the client's registered scope set IS the entire authority ceiling.
+	// intersectScopes treats an empty allow-list as "no restriction" (RFC 6749
+	// §3.3 default) which is correct for the chained api_key/jwt_bearer/
+	// token_exchange paths (they have a separate identity/policy ceiling), but
+	// for client_credentials it would let a scope-less client echo arbitrary
+	// requested scopes. Deny outright instead of calling the shared helper.
+	if len(client.Scopes) == 0 {
+		return nil, oauthBadRequest(oautherror.InvalidScope, "client is registered with no scopes and cannot be granted any")
+	}
+
 	// Parse and intersect requested scopes with the client's allowed scopes.
 	scopes := intersectScopes(parseScopeString(req.Scope), client.Scopes)
 
@@ -1282,11 +1294,24 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 	}
 
 	// Look up the client in the registry — this is the authoritative check.
-	// GetPublicClient verifies the client is active and registered; no secret
-	// is required because PKCE provides the proof of possession.
-	oauthClient, err := s.oauthClientSvc.GetPublicClient(ctx, req.ClientID)
+	// Resolve ANY client (public or confidential): an authorization_code client
+	// may be either. GetPublicClient filters to client_type='public', so a
+	// confidential code client would otherwise fail to resolve. Re-establish
+	// the active-client gate that GetPublicClient enforced.
+	oauthClient, err := s.oauthClientSvc.GetClientByClientID(ctx, req.ClientID)
 	if err != nil {
 		return nil, oauthUnauthorized("unknown or inactive client_id", err)
+	}
+	if !oauthClient.IsActive {
+		return nil, oauthUnauthorized("unknown or inactive client_id", nil)
+	}
+
+	// RFC 6749 §2.3/§10.4: a confidential client MUST authenticate with its
+	// client_secret even on the PKCE authorization_code path — PKCE proves
+	// possession of the code, the secret proves the client's identity (defense
+	// in depth). Public PKCE clients carry no secret and pass through unchanged.
+	if err := s.verifyConfidentialClientAuth(ctx, oauthClient, req.ClientID, req.ClientSecret); err != nil {
+		return nil, err
 	}
 
 	// Verify the client is authorised to use the authorization_code grant.
@@ -1475,11 +1500,17 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 		return nil, oauthServerError("refresh tokens not configured", nil)
 	}
 
-	// Look up client to get per-client TTL settings.
+	// Look up client to get per-client TTL settings AND to enforce client
+	// authentication. A confidential client MUST present its client_secret on
+	// the refresh_token grant (RFC 6749 §6/§10.4); a public client proves
+	// possession with the refresh-token string alone and carries no secret.
 	var accessTTL, refreshTokenTTL int
 	if oauthClient, err := s.oauthClientSvc.GetClientByClientID(ctx, req.ClientID); err == nil {
 		accessTTL = oauthClient.AccessTokenTTL
 		refreshTokenTTL = oauthClient.RefreshTokenTTL
+		if err := s.verifyConfidentialClientAuth(ctx, oauthClient, req.ClientID, req.ClientSecret); err != nil {
+			return nil, err
+		}
 	} else {
 		log.Warn().Err(err).Str("client_id", req.ClientID).Msg("failed to get oauth client for TTL override, using defaults")
 	}
@@ -1488,6 +1519,65 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 		accessTTL = defaultAccessTokenTTLWithRefresh
 	}
 
+	// Pre-rotation validation (HIGH — session-bricking fix). The gates that can
+	// reject a request for an OTHERWISE-VALID token (client_id binding, identity
+	// status/expiry, policy resolution) now run AGAINST A NON-CONSUMING PEEK of
+	// the token, BEFORE RotateRefreshToken commits the claim. If a gate fails
+	// the token stays active, so the client can retry once the transient
+	// condition clears — a wrong client_id, a temporarily suspended identity, or
+	// a DB blip during policy resolution no longer revokes the family
+	// permanently (RFC 6749 §10.4). Previously these ran AFTER rotation: the
+	// successor was discarded on error, the client retried with the now-revoked
+	// old token, and reuse detection nuked the whole session.
+	//
+	// A failed peek means the token is NOT active (expired, revoked, or
+	// unknown). We deliberately DO NOT reject here — instead we fall through to
+	// RotateRefreshToken, whose claim path distinguishes the reuse grace window
+	// from a genuine RFC 6749 §10.4 replay (and revokes the family on the
+	// latter). Short-circuiting on the peek would silence reuse detection.
+	var (
+		identity         *domain.Identity
+		identityPolicyID string
+	)
+	if peeked, peekErr := s.refreshTokenSvc.PeekRefreshToken(ctx, req.RefreshTokenStr); peekErr == nil {
+		// client_id binding check (RFC 6749 §10.4) — done on the peek so a
+		// mismatch does not consume the token.
+		if peeked.ClientID != req.ClientID {
+			return nil, oauthBadRequest(oautherror.InvalidGrant, "client_id mismatch")
+		}
+
+		// Identity gate. The link came from the OAuth client at
+		// authorization_code time and was persisted on the refresh_token row.
+		// When present, the linked identity's status + expires_at gate
+		// refresh-grant issuance the same way they gate every other grant.
+		// Resolved here (before rotation) so a suspended/expired identity
+		// rejects the request without burning the token.
+		if peeked.IdentityID != nil && *peeked.IdentityID != "" {
+			linked, err := s.identitySvc.repo.GetByID(ctx, *peeked.IdentityID, peeked.AccountID, peeked.ProjectID)
+			if err != nil {
+				return nil, oauthBadRequestCause(oautherror.InvalidGrant, "refresh token references unknown identity", err)
+			}
+			if !linked.Status.IsUsable() {
+				return nil, oauthBadRequest(oautherror.InvalidGrant, "identity is suspended or deactivated")
+			}
+			if linked.IsExpired() {
+				return nil, oauthBadRequest(oautherror.InvalidGrant, "identity_expired")
+			}
+			identity = linked
+			policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, linked)
+			if err != nil {
+				return nil, oauthServerError("failed to resolve identity credential policy", err)
+			}
+			identityPolicyID = policy.ID
+		}
+	}
+
+	// Pre-rotation gates passed (or the token was already inactive — in which
+	// case rotation's claim path returns the right error / fires reuse
+	// detection). NOW consume the token and mint the successor. The remaining
+	// failure surface (IssueCredential) is the only post-claim step; if it fails
+	// the successor was already inserted in the rotation transaction, so the
+	// client's retry trips the grace window rather than reuse detection.
 	oldToken, newRT, err := s.refreshTokenSvc.RotateRefreshToken(ctx, req.RefreshTokenStr, refreshTokenTTL, req.DPoPKeyThumbprint)
 	if err != nil {
 		// A DPoP binding mismatch is a proof failure, not an invalid refresh
@@ -1500,39 +1590,38 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 		return nil, oauthBadRequestCause(oautherror.InvalidGrant, "invalid or expired refresh token", err)
 	}
 
-	if oldToken.ClientID != req.ClientID {
-		return nil, oauthBadRequest(oautherror.InvalidGrant, "client_id mismatch")
-	}
-
-	// Identity gate. The link came from the OAuth client at authorization_code
-	// time and was persisted on the refresh_token row. When present, the
-	// linked identity's status + expires_at gate refresh-grant issuance the
-	// same way they gate every other grant. When absent, this is a human
-	// session with no identity row to check and we fall through to the
-	// synthetic carrier.
-	identity := &domain.Identity{
-		AccountID: oldToken.AccountID,
-		ProjectID: oldToken.ProjectID,
-		Status:    domain.IdentityStatusActive,
-	}
-	var identityPolicyID string
-	if oldToken.IdentityID != nil && *oldToken.IdentityID != "" {
-		linked, err := s.identitySvc.repo.GetByID(ctx, *oldToken.IdentityID, oldToken.AccountID, oldToken.ProjectID)
-		if err != nil {
-			return nil, oauthBadRequestCause(oautherror.InvalidGrant, "refresh token references unknown identity", err)
+	// The peek-time identity resolution is the authoritative one. If the peek
+	// missed (rare: a benign race where the row activated between peek and
+	// claim) re-run the identity gate against the freshly claimed row so the
+	// gate is never skipped — the post-claim failure window here is acceptable
+	// because it only triggers on that race, and a gate failure now lands the
+	// caller in the grace window (successor already minted) rather than a
+	// permanent family revocation. A human session (no IdentityID) falls
+	// through to a synthetic carrier with no policy to resolve.
+	if identity == nil {
+		identity = &domain.Identity{
+			AccountID: oldToken.AccountID,
+			ProjectID: oldToken.ProjectID,
+			Status:    domain.IdentityStatusActive,
 		}
-		if !linked.Status.IsUsable() {
-			return nil, oauthBadRequest(oautherror.InvalidGrant, "identity is suspended or deactivated")
+		if oldToken.IdentityID != nil && *oldToken.IdentityID != "" {
+			linked, err := s.identitySvc.repo.GetByID(ctx, *oldToken.IdentityID, oldToken.AccountID, oldToken.ProjectID)
+			if err != nil {
+				return nil, oauthBadRequestCause(oautherror.InvalidGrant, "refresh token references unknown identity", err)
+			}
+			if !linked.Status.IsUsable() {
+				return nil, oauthBadRequest(oautherror.InvalidGrant, "identity is suspended or deactivated")
+			}
+			if linked.IsExpired() {
+				return nil, oauthBadRequest(oautherror.InvalidGrant, "identity_expired")
+			}
+			identity = linked
+			policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, linked)
+			if err != nil {
+				return nil, oauthServerError("failed to resolve identity credential policy", err)
+			}
+			identityPolicyID = policy.ID
 		}
-		if linked.IsExpired() {
-			return nil, oauthBadRequest(oautherror.InvalidGrant, "identity_expired")
-		}
-		identity = linked
-		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, linked)
-		if err != nil {
-			return nil, oauthServerError("failed to resolve identity credential policy", err)
-		}
-		identityPolicyID = policy.ID
 	}
 
 	// Inherit scopes from the original refresh token. Without this the
@@ -1706,6 +1795,70 @@ func (s *OAuthService) parseWIMSEURI(wimseURI string) (accountID, projectID stri
 		return "", "", fmt.Errorf("malformed WIMSE URI: expected spiffe://%s/{account}/{project}/{identity_type}/{id}", s.wimseDomain)
 	}
 	return parts[0], parts[1], nil
+}
+
+// verifyConfidentialClientAuth enforces RFC 6749 §2.3 / §10.4 client
+// authentication for an already-resolved OAuth client. When the client is
+// CONFIDENTIAL it MUST present and prove its client_secret before any grant
+// proceeds; a missing or wrong secret is rejected with invalid_client (HTTP
+// 401). PUBLIC clients carry no secret and pass through unchanged — they prove
+// possession by other means (PKCE on authorization_code, the refresh-token
+// string itself on refresh_token).
+//
+// VerifyClientSecret re-fetches the client by client_id and bcrypt-compares the
+// secret; the caller passes the already-resolved client purely to read its
+// ClientType. The re-fetch is intentional — VerifyClientSecret owns the
+// constant-time comparison and the active-client gate.
+func (s *OAuthService) verifyConfidentialClientAuth(ctx context.Context, client *domain.OAuthClient, clientID, clientSecret string) error {
+	if client == nil || client.ClientType != "confidential" {
+		return nil
+	}
+	if clientSecret == "" {
+		return oauthUnauthorized("client_secret is required for confidential clients", nil)
+	}
+	if _, err := s.oauthClientSvc.VerifyClientSecret(ctx, clientID, clientSecret); err != nil {
+		if errors.Is(err, ErrOAuthClientNotFound) || errors.Is(err, ErrInvalidClientSecret) {
+			return oauthUnauthorized("invalid client credentials", err)
+		}
+		return oauthUnauthorized("client verification failed", err)
+	}
+	return nil
+}
+
+// VerifyPresentedClientAuth implements the "accept-and-verify" client-auth
+// posture for the introspection (RFC 7662) and revocation (RFC 7009)
+// endpoints, which sit on the unauthenticated public group in this standalone
+// server. When a caller presents client credentials (client_id +
+// client_secret) they are VERIFIED and a bad secret is rejected with
+// invalid_client (HTTP 401). When NO client credentials are presented the call
+// is left to the existing internal/network-isolated path (tenant-header access,
+// service-to-service) — ZeroID does not hard-reject unauthenticated callers
+// here because that would break the standalone deployment model and the
+// established tenant-header access pattern.
+//
+// Returns nil when no credentials were presented OR when presented credentials
+// verify. Returns an *OAuthError (invalid_client / 401) when a client_secret is
+// presented but does not verify, or when only one half of the credential pair
+// is supplied (a malformed authentication attempt, not an anonymous call).
+func (s *OAuthService) VerifyPresentedClientAuth(ctx context.Context, clientID, clientSecret string) error {
+	// Anonymous call — neither half presented. Preserve existing internal-path
+	// behavior; the caller falls through to the unauthenticated flow.
+	if clientID == "" && clientSecret == "" {
+		return nil
+	}
+	// A half-supplied credential pair is a malformed authentication attempt
+	// (RFC 6749 §2.3.1: both client_id and client_secret are required for
+	// client_secret_post). Reject rather than silently treating it as anonymous.
+	if clientID == "" || clientSecret == "" {
+		return oauthUnauthorized("client_id and client_secret must both be supplied", nil)
+	}
+	if _, err := s.oauthClientSvc.VerifyClientSecret(ctx, clientID, clientSecret); err != nil {
+		if errors.Is(err, ErrOAuthClientNotFound) || errors.Is(err, ErrInvalidClientSecret) {
+			return oauthUnauthorized("invalid client credentials", err)
+		}
+		return oauthUnauthorized("client verification failed", err)
+	}
+	return nil
 }
 
 // parseScopeString splits a space-delimited scope string into a slice.

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -1512,14 +1512,18 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 			return nil, err
 		}
 	} else if req.ClientID != "" {
-		// A client_id was named but the client can't be resolved (deleted, or a
-		// transient lookup error). Fail closed: proceeding here would skip
-		// verifyConfidentialClientAuth entirely, letting a confidential client
-		// refresh with no secret after its registration is gone. The client_id
-		// binding check below also rejects any client_id that doesn't match the
-		// token's bound client, so a token genuinely issued without a client
-		// (req.ClientID == "") still refreshes via the no-op branch.
-		return nil, oauthBadRequest(oautherror.InvalidClient, "client_id does not resolve to a registered client")
+		// A client_id was named but the client can't be resolved. Fail closed:
+		// proceeding here would skip verifyConfidentialClientAuth entirely,
+		// letting a confidential client refresh with no secret after its
+		// registration is gone. The client_id binding check below also rejects
+		// any client_id that doesn't match the token's bound client, so a token
+		// genuinely issued without a client (req.ClientID == "") still refreshes
+		// via the no-op branch. A genuine "unknown client" is invalid_client; an
+		// operational lookup error is a server fault, not the client's.
+		if errors.Is(err, ErrOAuthClientNotFound) {
+			return nil, oauthBadRequest(oautherror.InvalidClient, "client_id does not resolve to a registered client")
+		}
+		return nil, oauthServerError("failed to resolve client for refresh grant", err)
 	}
 
 	if accessTTL <= 0 {
@@ -1827,7 +1831,9 @@ func (s *OAuthService) verifyConfidentialClientAuth(ctx context.Context, client 
 		if errors.Is(err, ErrOAuthClientNotFound) || errors.Is(err, ErrInvalidClientSecret) {
 			return oauthUnauthorized("invalid client credentials", err)
 		}
-		return oauthUnauthorized("client verification failed", err)
+		// An unexpected (operational) error is a server fault, not a client
+		// authentication failure — don't mislead the client with a 401.
+		return oauthServerError("client verification failed", err)
 	}
 	return nil
 }
@@ -1843,27 +1849,44 @@ func (s *OAuthService) verifyConfidentialClientAuth(ctx context.Context, client 
 // here because that would break the standalone deployment model and the
 // established tenant-header access pattern.
 //
-// Returns nil when no credentials were presented OR when presented credentials
-// verify. Returns an *OAuthError (invalid_client / 401) when a client_secret is
-// presented but does not verify, or when only one half of the credential pair
-// is supplied (a malformed authentication attempt, not an anonymous call).
+// Returns nil when no credentials were presented, when a registered PUBLIC
+// client presents just its client_id, or when a confidential client's
+// client_id + client_secret verify. Returns an *OAuthError (invalid_client /
+// 401) when a presented secret does not verify, when only a client_secret is
+// supplied without a client_id, or when a client_id without a secret does not
+// resolve to a public client. Operational failures surface as 500.
 func (s *OAuthService) VerifyPresentedClientAuth(ctx context.Context, clientID, clientSecret string) error {
 	// Anonymous call — neither half presented. Preserve existing internal-path
 	// behavior; the caller falls through to the unauthenticated flow.
 	if clientID == "" && clientSecret == "" {
 		return nil
 	}
-	// A half-supplied credential pair is a malformed authentication attempt
-	// (RFC 6749 §2.3.1: both client_id and client_secret are required for
-	// client_secret_post). Reject rather than silently treating it as anonymous.
-	if clientID == "" || clientSecret == "" {
-		return oauthUnauthorized("client_id and client_secret must both be supplied", nil)
+	// A client_secret with no client_id is a malformed attempt — there is no
+	// client to authenticate. Reject rather than treat it as anonymous.
+	if clientID == "" {
+		return oauthUnauthorized("client_id is required when a client_secret is supplied", nil)
+	}
+	// client_id with no secret: valid only for a registered public client.
+	// RFC 7009 §2.1 / RFC 7662 §2.1 — public clients have no secret, and
+	// standard OAuth libraries attach client_id to revocation/introspection
+	// requests. A confidential client (or an unknown client_id) must present a
+	// secret, so this neither widens access nor lets a confidential client
+	// skip authentication.
+	if clientSecret == "" {
+		if _, err := s.oauthClientSvc.GetPublicClient(ctx, clientID); err != nil {
+			if errors.Is(err, ErrOAuthClientNotFound) {
+				return oauthUnauthorized("client authentication required", nil)
+			}
+			return oauthServerError("client verification failed", err)
+		}
+		return nil
 	}
 	if _, err := s.oauthClientSvc.VerifyClientSecret(ctx, clientID, clientSecret); err != nil {
 		if errors.Is(err, ErrOAuthClientNotFound) || errors.Is(err, ErrInvalidClientSecret) {
 			return oauthUnauthorized("invalid client credentials", err)
 		}
-		return oauthUnauthorized("client verification failed", err)
+		// Operational failure — server fault, not a client auth failure.
+		return oauthServerError("client verification failed", err)
 	}
 	return nil
 }

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -1511,8 +1511,15 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 		if err := s.verifyConfidentialClientAuth(ctx, oauthClient, req.ClientID, req.ClientSecret); err != nil {
 			return nil, err
 		}
-	} else {
-		log.Warn().Err(err).Str("client_id", req.ClientID).Msg("failed to get oauth client for TTL override, using defaults")
+	} else if req.ClientID != "" {
+		// A client_id was named but the client can't be resolved (deleted, or a
+		// transient lookup error). Fail closed: proceeding here would skip
+		// verifyConfidentialClientAuth entirely, letting a confidential client
+		// refresh with no secret after its registration is gone. The client_id
+		// binding check below also rejects any client_id that doesn't match the
+		// token's bound client, so a token genuinely issued without a client
+		// (req.ClientID == "") still refreshes via the no-op branch.
+		return nil, oauthBadRequest(oautherror.InvalidClient, "client_id does not resolve to a registered client")
 	}
 
 	if accessTTL <= 0 {

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -1829,7 +1829,15 @@ func (s *OAuthService) parseWIMSEURI(wimseURI string) (accountID, projectID stri
 // ClientType. The re-fetch is intentional — VerifyClientSecret owns the
 // constant-time comparison and the active-client gate.
 func (s *OAuthService) verifyConfidentialClientAuth(ctx context.Context, client *domain.OAuthClient, clientID, clientSecret string) error {
-	if client == nil || client.ClientType != "confidential" {
+	if client == nil {
+		return nil
+	}
+	// A client is confidential if it declares so OR carries a stored secret
+	// hash. The second clause is belt-and-suspenders against an inconsistent
+	// row (secret set but client_type != "confidential"), which would
+	// otherwise skip secret verification and allow an unintended bypass. Same
+	// test the CIBA bc-authorize/redeem paths use.
+	if client.ClientType != "confidential" && client.ClientSecret == "" {
 		return nil
 	}
 	if clientSecret == "" {

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -228,6 +228,7 @@ func (s *OAuthService) Token(ctx context.Context, req TokenRequest) (*domain.Acc
 		return s.backchannelSvc.Redeem(ctx, RedeemInput{
 			AuthReqID:         req.AuthReqID,
 			ClientID:          req.ClientID,
+			ClientSecret:      req.ClientSecret,
 			DPoPKeyThumbprint: req.DPoPKeyThumbprint,
 		})
 	default:
@@ -1506,22 +1507,29 @@ func (s *OAuthService) refreshToken(ctx context.Context, req TokenRequest) (*dom
 	// possession with the refresh-token string alone and carries no secret.
 	var accessTTL, refreshTokenTTL int
 	if oauthClient, err := s.oauthClientSvc.GetClientByClientID(ctx, req.ClientID); err == nil {
+		// GetClientByClientID does not filter is_active (unlike GetPublicClient /
+		// VerifyClientSecret), and verifyConfidentialClientAuth is a no-op for
+		// public clients — so without this guard a deactivated PUBLIC client
+		// could keep rotating refresh tokens indefinitely. Same gate as the
+		// authorization_code path.
+		if !oauthClient.IsActive {
+			return nil, oauthUnauthorized("unknown or inactive client_id", nil)
+		}
 		accessTTL = oauthClient.AccessTokenTTL
 		refreshTokenTTL = oauthClient.RefreshTokenTTL
 		if err := s.verifyConfidentialClientAuth(ctx, oauthClient, req.ClientID, req.ClientSecret); err != nil {
 			return nil, err
 		}
-	} else if req.ClientID != "" {
-		// A client_id was named but the client can't be resolved. Fail closed:
-		// proceeding here would skip verifyConfidentialClientAuth entirely,
-		// letting a confidential client refresh with no secret after its
-		// registration is gone. The client_id binding check below also rejects
-		// any client_id that doesn't match the token's bound client, so a token
-		// genuinely issued without a client (req.ClientID == "") still refreshes
-		// via the no-op branch. A genuine "unknown client" is invalid_client; an
-		// operational lookup error is a server fault, not the client's.
+	} else {
+		// The named client_id (required by the entry guard above) can't be
+		// resolved. Fail closed: proceeding here would skip
+		// verifyConfidentialClientAuth entirely, letting a confidential client
+		// refresh with no secret after its registration is gone. A genuine
+		// "unknown client" is invalid_client (401, matching the
+		// authorization_code path); an operational lookup error is a server
+		// fault, not the client's.
 		if errors.Is(err, ErrOAuthClientNotFound) {
-			return nil, oauthBadRequest(oautherror.InvalidClient, "client_id does not resolve to a registered client")
+			return nil, oauthUnauthorized("client_id does not resolve to a registered client", nil)
 		}
 		return nil, oauthServerError("failed to resolve client for refresh grant", err)
 	}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
@@ -47,6 +48,13 @@ type OAuthService struct {
 	// backchannelSvc handles the urn:openid:params:grant-type:ciba grant.
 	// Wired after construction via SetBackchannelService.
 	backchannelSvc *BackchannelService
+	// requireTokenInspectionAuth, when true, makes the introspection (RFC 7662)
+	// and revocation (RFC 7009) endpoints reject anonymous callers — a caller
+	// MUST present client credentials. When false the endpoints accept-and-
+	// verify (anonymous allowed, presented credentials still verified). atomic
+	// so a test can flip it on a shared server without racing concurrent
+	// introspect/revoke reads under -race.
+	requireTokenInspectionAuth atomic.Bool
 }
 
 // CustomGrantHandler implements a custom OAuth2 grant type.
@@ -144,6 +152,16 @@ func (s *OAuthService) SetTrustedServiceValidator(v trustedServiceValidatorFunc)
 // BackchannelService for the CIBA grant.
 func (s *OAuthService) SetBackchannelService(bc *BackchannelService) {
 	s.backchannelSvc = bc
+}
+
+// SetRequireTokenInspectionAuth toggles strict client authentication on the
+// introspection (RFC 7662) and revocation (RFC 7009) endpoints. When true,
+// anonymous callers are rejected; when false, the accept-and-verify posture
+// is used (anonymous allowed, presented credentials still verified). Wired
+// from config at startup (server.go) and flippable at runtime so a test can
+// exercise both modes on a shared server without standing up a second one.
+func (s *OAuthService) SetRequireTokenInspectionAuth(require bool) {
+	s.requireTokenInspectionAuth.Store(require)
 }
 
 // RegisterGrant registers a custom grant type handler on the OAuth service.
@@ -1872,9 +1890,18 @@ func (s *OAuthService) verifyConfidentialClientAuth(ctx context.Context, client 
 // supplied without a client_id, or when a client_id without a secret does not
 // resolve to a public client. Operational failures surface as 500.
 func (s *OAuthService) VerifyPresentedClientAuth(ctx context.Context, clientID, clientSecret string) error {
-	// Anonymous call — neither half presented. Preserve existing internal-path
-	// behavior; the caller falls through to the unauthenticated flow.
+	// Anonymous call — neither half presented.
 	if clientID == "" && clientSecret == "" {
+		// Strict mode (RFC 7662 §2.1 / RFC 7009 §2.1): the endpoint MUST
+		// require some form of authorization — reject the anonymous caller.
+		// Enabled by default in production (config gate). When disabled, the
+		// existing internal/network-isolated path is preserved (anonymous
+		// allowed); ZeroID clients are global (not tenant-scoped), so a
+		// tenant cross-check against the caller is not expressible via client
+		// auth alone — gating access is the surface this closes.
+		if s.requireTokenInspectionAuth.Load() {
+			return oauthUnauthorized("client authentication is required for this endpoint", nil)
+		}
 		return nil
 	}
 	// A client_secret with no client_id is a malformed attempt — there is no

--- a/internal/service/refresh_token.go
+++ b/internal/service/refresh_token.go
@@ -109,6 +109,28 @@ func (s *RefreshTokenService) IssueRefreshToken(ctx context.Context, params *Ref
 	}, nil
 }
 
+// PeekRefreshToken returns the active, non-expired refresh-token row for the
+// presented raw token WITHOUT consuming (revoking) it. It is the non-mutating
+// counterpart to RotateRefreshToken's claim step: the caller can read binding
+// metadata (ClientID, IdentityID, tenant scalars) and run pre-rotation gates
+// (client_id binding, identity status/expiry) before committing the rotation.
+//
+// Crucially, a gate that fails AFTER a Peek leaves the token UNTOUCHED — the
+// client can retry with the same token once the transient condition clears.
+// This avoids the session-bricking failure mode where the rotation committed
+// (old token revoked, successor inserted) before a post-claim gate ran, then
+// discarded the successor on error: the client would then retry with a
+// now-revoked token and trip reuse detection, nuking the whole family over a
+// transient mistake (RFC 6749 §10.4).
+//
+// Returns an error if no active, non-expired token matches (expired, revoked,
+// or unknown). The caller maps this to invalid_grant; it does NOT trigger
+// reuse detection (that only fires inside RotateRefreshToken's claim path,
+// which distinguishes the grace window).
+func (s *RefreshTokenService) PeekRefreshToken(ctx context.Context, rawToken string) (*domain.RefreshToken, error) {
+	return s.repo.GetByTokenHash(ctx, hashRefreshToken(rawToken))
+}
+
 // RotateRefreshToken validates the presented token, revokes it, and issues a new one.
 // Implements reuse detection: if a revoked token is presented, the entire family is revoked.
 //

--- a/internal/store/postgres/backchannel_request.go
+++ b/internal/store/postgres/backchannel_request.go
@@ -15,6 +15,18 @@ import (
 // ErrBackchannelRequestNotFound is returned when GetByAuthReqID finds no row.
 var ErrBackchannelRequestNotFound = errors.New("backchannel auth request not found")
 
+// ApprovedRedemptionGrace bounds how long an APPROVED-but-not-yet-issued CIBA
+// request stays redeemable past its own expires_at. Without an upper bound an
+// approved auth_req_id was redeemable forever AND never reaped, so a leaked
+// months-old handle still minted a token (the expiry guard only covered
+// PENDING rows). The window is generous relative to the slow-poll rationale —
+// expires_at already gives the client the full DefaultExpiry/MaxExpiry to act,
+// and this grace adds a fixed cushion on top of approval so an honest client
+// whose approval landed right at expiry can still complete one final poll —
+// while keeping approvals bounded rather than immortal. MarkIssued enforces
+// it at issuance; DeleteExpired reaps past it.
+const ApprovedRedemptionGrace = 10 * time.Minute
+
 // BackchannelRequestRepository persists CIBA authentication requests.
 type BackchannelRequestRepository struct {
 	db *bun.DB
@@ -91,12 +103,35 @@ func (r *BackchannelRequestRepository) MarkDenied(ctx context.Context, authReqID
 
 // MarkIssued transitions an approved row to issued so a second redemption of
 // the same auth_req_id returns access_denied instead of minting a second token.
-func (r *BackchannelRequestRepository) MarkIssued(ctx context.Context, authReqID string) (int64, error) {
+//
+// The cutoff guard mirrors the expires_at guard MarkApproved already carries:
+// an approved-but-leaked auth_req_id polled long after the user acted must NOT
+// mint a token. Issuance is bounded to the later of the row's own expires_at
+// and (approved_at + ApprovedRedemptionGrace), so an honest slow poll that
+// approved just before expiry still completes, while a months-old leaked
+// handle is rejected at the DB layer even if a future caller skips the
+// service-side guard (defence-in-depth, same posture as the SSRF
+// re-validation in CreateAuthRequest). `cutoff` is the latest instant at
+// which issuance is still permitted (the service passes time.Now()).
+func (r *BackchannelRequestRepository) MarkIssued(ctx context.Context, authReqID string, cutoff time.Time) (int64, error) {
+	// Derive the grace floor in Go rather than doing timestamp + interval
+	// arithmetic in SQL: a Go time.Duration is int64 nanoseconds and would
+	// NOT add correctly to a Postgres timestamptz. The row is redeemable
+	// while approved_at is newer than (cutoff - grace), which is the
+	// algebraic rearrangement of "approved_at + grace > cutoff".
+	graceFloor := cutoff.Add(-ApprovedRedemptionGrace)
 	res, err := r.db.NewUpdate().
 		Model((*domain.BackchannelAuthRequest)(nil)).
 		Set("status = ?", domain.BackchannelStatusIssued).
 		Where("auth_req_id = ?", authReqID).
 		Where("status = ?", domain.BackchannelStatusApproved).
+		// Bound issuance: the row must still be within either its own
+		// expires_at OR the post-approval grace window (approved_at + grace).
+		// COALESCE(approved_at, created_at) guards a NULL approved_at — an
+		// approved row always has it stamped, but COALESCE keeps the SQL
+		// well-defined if that invariant ever slips.
+		Where("(expires_at > ? OR COALESCE(approved_at, created_at) > ?)",
+			cutoff, graceFloor).
 		Exec(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to mark backchannel request issued: %w", err)
@@ -150,18 +185,46 @@ func (r *BackchannelRequestRepository) SweepExpired(ctx context.Context, now tim
 	return res.RowsAffected()
 }
 
-// DeleteExpired reaps resolved rows (expired/denied/issued) whose expires_at
-// is past. Approved-but-not-yet-issued rows are retained so a slow poll can
-// still complete the issuance.
+// DeleteExpired reaps rows that can no longer mint a token:
+//
+//   - terminal rows (expired/denied/issued) whose expires_at is past, and
+//   - APPROVED-but-not-yet-issued rows whose post-approval grace window has
+//     also lapsed (approved_at + grace < now).
+//
+// Previously approved rows were retained indefinitely so "a slow poll can
+// still complete the issuance" — but with no upper bound, a leaked
+// approved auth_req_id stayed redeemable forever AND was never reaped. We
+// now bound it: an approved row is kept only until the later of its
+// expires_at and (approved_at + ApprovedRedemptionGrace); past both it is
+// reaped. The grace matches the redemption window MarkIssued enforces, so the
+// sweep never deletes a row that is still legitimately redeemable.
 func (r *BackchannelRequestRepository) DeleteExpired(ctx context.Context, now time.Time) (int64, error) {
+	graceFloor := now.Add(-ApprovedRedemptionGrace)
 	res, err := r.db.NewDelete().
 		Model((*domain.BackchannelAuthRequest)(nil)).
-		Where("expires_at < ?", now).
-		Where("status IN (?, ?, ?)",
-			domain.BackchannelStatusExpired,
-			domain.BackchannelStatusDenied,
-			domain.BackchannelStatusIssued,
-		).
+		WhereGroup(" AND ", func(q *bun.DeleteQuery) *bun.DeleteQuery {
+			return q.
+				WhereGroup(" OR ", func(q *bun.DeleteQuery) *bun.DeleteQuery {
+					// Terminal rows past their own expiry.
+					return q.
+						Where("status IN (?, ?, ?) AND expires_at < ?",
+							domain.BackchannelStatusExpired,
+							domain.BackchannelStatusDenied,
+							domain.BackchannelStatusIssued,
+							now,
+						)
+				}).
+				WhereGroup(" OR ", func(q *bun.DeleteQuery) *bun.DeleteQuery {
+					// Approved rows that can no longer be redeemed: past
+					// both expires_at and the post-approval grace window.
+					return q.
+						Where("status = ? AND expires_at < ? AND COALESCE(approved_at, created_at) < ?",
+							domain.BackchannelStatusApproved,
+							now,
+							graceFloor,
+						)
+				})
+		}).
 		Exec(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete expired backchannel requests: %w", err)

--- a/internal/store/postgres/credential_policy.go
+++ b/internal/store/postgres/credential_policy.go
@@ -21,6 +21,16 @@ var ErrCredentialPolicyNotFound = errors.New("credential policy not found")
 var ErrCredentialPolicyInUse = errors.New("credential policy is still referenced by service keys")
 
 // CredentialPolicyRepository handles database operations for credential policies.
+//
+// Every method participates in a caller-provided transaction via
+// postgres.WithTx(ctx, tx), falling back to the pool otherwise (dbOrTx).
+// This is load-bearing, not just hygiene: attestation verification calls
+// IssueCredential INSIDE its SELECT ... FOR UPDATE transaction, and the
+// policy-ceiling resolution there reads (and on first use, creates) the
+// tenant's policy through this repo. When these queries grabbed a fresh
+// pool connection instead of riding the tx, N concurrent verifies could
+// exhaust the pool — waiters held every connection while the lock-holder
+// waited for one — deadlocking until the driver's read timeout fired.
 type CredentialPolicyRepository struct {
 	db *bun.DB
 }
@@ -32,7 +42,7 @@ func NewCredentialPolicyRepository(db *bun.DB) *CredentialPolicyRepository {
 
 // Create inserts a new credential policy.
 func (r *CredentialPolicyRepository) Create(ctx context.Context, policy *domain.CredentialPolicy) error {
-	_, err := r.db.NewInsert().Model(policy).Exec(ctx)
+	_, err := dbOrTx(ctx, r.db).NewInsert().Model(policy).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create credential policy: %w", err)
 	}
@@ -42,7 +52,7 @@ func (r *CredentialPolicyRepository) Create(ctx context.Context, policy *domain.
 // GetByID retrieves a credential policy by ID, scoped to tenant.
 func (r *CredentialPolicyRepository) GetByID(ctx context.Context, id, accountID, projectID string) (*domain.CredentialPolicy, error) {
 	policy := &domain.CredentialPolicy{}
-	err := r.db.NewSelect().Model(policy).
+	err := dbOrTx(ctx, r.db).NewSelect().Model(policy).
 		Where("id = ?", id).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
@@ -56,7 +66,7 @@ func (r *CredentialPolicyRepository) GetByID(ctx context.Context, id, accountID,
 // List returns all credential policies for a tenant.
 func (r *CredentialPolicyRepository) List(ctx context.Context, accountID, projectID string) ([]*domain.CredentialPolicy, error) {
 	var policies []*domain.CredentialPolicy
-	err := r.db.NewSelect().Model(&policies).
+	err := dbOrTx(ctx, r.db).NewSelect().Model(&policies).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
 		OrderExpr("created_at DESC").
@@ -69,7 +79,7 @@ func (r *CredentialPolicyRepository) List(ctx context.Context, accountID, projec
 
 // Update saves changes to an existing credential policy.
 func (r *CredentialPolicyRepository) Update(ctx context.Context, policy *domain.CredentialPolicy) error {
-	_, err := r.db.NewUpdate().Model(policy).
+	_, err := dbOrTx(ctx, r.db).NewUpdate().Model(policy).
 		Where("id = ? AND account_id = ? AND project_id = ?", policy.ID, policy.AccountID, policy.ProjectID).
 		Exec(ctx)
 	if err != nil {
@@ -82,7 +92,7 @@ func (r *CredentialPolicyRepository) Update(ctx context.Context, policy *domain.
 // Returns nil, nil if no default policy exists.
 func (r *CredentialPolicyRepository) GetDefaultByTenant(ctx context.Context, accountID, projectID string) (*domain.CredentialPolicy, error) {
 	policy := &domain.CredentialPolicy{}
-	err := r.db.NewSelect().Model(policy).
+	err := dbOrTx(ctx, r.db).NewSelect().Model(policy).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
 		Where("name = ?", domain.DefaultPolicyName).
@@ -105,7 +115,7 @@ func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, 
 	// hardcoded table-name typo, and Model() makes that class of error
 	// impossible. credential_policy_id plus the account_id/project_id tenant
 	// scope all live on service_keys.
-	count, err := r.db.NewSelect().
+	count, err := dbOrTx(ctx, r.db).NewSelect().
 		Model((*domain.APIKey)(nil)).
 		Where("credential_policy_id = ?", id).
 		Where("account_id = ?", accountID).
@@ -118,7 +128,7 @@ func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, 
 		return fmt.Errorf("%w: referenced by %d service key(s)", ErrCredentialPolicyInUse, count)
 	}
 
-	res, err := r.db.NewDelete().
+	res, err := dbOrTx(ctx, r.db).NewDelete().
 		Model((*domain.CredentialPolicy)(nil)).
 		Where("id = ?", id).
 		Where("account_id = ?", accountID).
@@ -141,7 +151,7 @@ func (r *CredentialPolicyRepository) Delete(ctx context.Context, id, accountID, 
 // within now..now+within. Used by GET /expiring-soon.
 func (r *CredentialPolicyRepository) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.CredentialPolicy, error) {
 	var policies []*domain.CredentialPolicy
-	if err := r.db.NewSelect().Model(&policies).
+	if err := dbOrTx(ctx, r.db).NewSelect().Model(&policies).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
 		Where("expires_at IS NOT NULL").

--- a/internal/store/postgres/refresh_token.go
+++ b/internal/store/postgres/refresh_token.go
@@ -125,8 +125,10 @@ func (r *RefreshTokenRepository) DeleteExpired(ctx context.Context, before time.
 		return 0, fmt.Errorf("failed to delete expired refresh tokens: %w", err)
 	}
 
-	n, _ := res.RowsAffected()
-
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read expired-refresh-token delete result: %w", err)
+	}
 	return n, nil
 }
 

--- a/internal/store/postgres/refresh_token.go
+++ b/internal/store/postgres/refresh_token.go
@@ -108,6 +108,28 @@ func (r *RefreshTokenRepository) ClaimByTokenHash(ctx context.Context, db bun.ID
 	return token, nil
 }
 
+// DeleteExpired removes refresh-token rows whose expires_at is strictly before
+// the given cutoff. The cutoff MUST be lagged behind now by at least
+// domain.RefreshTokenReuseGraceWindow: reuse detection (see
+// service/refresh_token.go) relies on recently-revoked rows still existing so a
+// replay within the grace window is treated as a benign retry rather than a
+// family compromise. Deleting strictly by expires_at < (now - graceWindow)
+// keeps every row that reuse detection could still consult while still bounding
+// table growth under rotation. Returns the number of rows deleted.
+func (r *RefreshTokenRepository) DeleteExpired(ctx context.Context, before time.Time) (int64, error) {
+	res, err := r.db.NewDelete().
+		Model((*domain.RefreshToken)(nil)).
+		Where("expires_at < ?", before).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete expired refresh tokens: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+
+	return n, nil
+}
+
 // RevokeFamily revokes all active tokens in a family (reuse detection response)
 // and returns the rows it revoked so the service layer can fan out a
 // RevocationNotifier event per revoked token. Refresh tokens are opaque (hashed)

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -159,20 +159,12 @@ func (w *CleanupWorker) RunOnce(ctx context.Context) {
 	}
 
 	// Signing credentials: prune non-revoked rows whose audit-retention window
-	// has fully elapsed. This mirrors SigningCredentialRepository.PruneExpiredRetention
-	// exactly (same WHERE: revoked = false AND audit_retention_until <= now) —
-	// replicated inline rather than wired through the repo because the worker is
-	// constructed in server.go without a SigningCredentialRepository and that
-	// constructor is out of scope to change. Revoked rows are retained as a
-	// tamper-evidence trail. Backed by idx_signing_credentials_retention (023).
-	signingRes, err := w.db.NewDelete().
-		Model((*domain.SigningCredential)(nil)).
-		Where("revoked = ?", false).
-		Where("audit_retention_until <= ?", now).
-		Exec(ctx)
-	if err != nil {
+	// has fully elapsed. Revoked rows are retained as a tamper-evidence trail.
+	// Backed by idx_signing_credentials_retention (023).
+	signingRepo := postgres.NewSigningCredentialRepository(w.db)
+	if n, err := signingRepo.PruneExpiredRetention(ctx, now); err != nil {
 		log.Error().Err(err).Msg("Cleanup: failed to prune expired signing credentials")
-	} else if n, err := signingRes.RowsAffected(); err == nil && n > 0 {
+	} else if n > 0 {
 		log.Info().Int64("count", n).Msg("Cleanup: pruned expired signing credentials")
 	}
 

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -166,7 +166,7 @@ func (w *CleanupWorker) RunOnce(ctx context.Context) {
 	// constructor is out of scope to change. Revoked rows are retained as a
 	// tamper-evidence trail. Backed by idx_signing_credentials_retention (023).
 	signingRes, err := w.db.NewDelete().
-		TableExpr("signing_credentials").
+		Model((*domain.SigningCredential)(nil)).
 		Where("revoked = ?", false).
 		Where("audit_retention_until <= ?", now).
 		Exec(ctx)

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/uptrace/bun"
 
+	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
@@ -139,6 +140,40 @@ func (w *CleanupWorker) RunOnce(ctx context.Context) {
 		log.Error().Err(err).Msg("Cleanup: failed to delete expired dpop jti records")
 	} else if n, err := dpopRes.RowsAffected(); err == nil && n > 0 {
 		log.Info().Int64("count", n).Msg("Cleanup: deleted expired dpop jti records")
+	}
+
+	// Refresh tokens: under rotation every refresh inserts a successor row and
+	// revokes its predecessor, so the table grows linearly with token traffic
+	// if never swept. Delete rows whose expires_at is past the reuse-detection
+	// grace window. Reuse detection (service/refresh_token.go) consults
+	// recently-revoked rows for RefreshTokenReuseGraceWindow after revocation to
+	// distinguish a benign concurrent retry from a replay attack; lagging the
+	// cutoff by that window guarantees we never delete a row reuse detection
+	// could still need. Expiry is the bound (rotation revokes well before
+	// expires_at), so a row past expires_at - graceWindow is safe to reap.
+	refreshRepo := postgres.NewRefreshTokenRepository(w.db)
+	if n, err := refreshRepo.DeleteExpired(ctx, now.Add(-domain.RefreshTokenReuseGraceWindow)); err != nil {
+		log.Error().Err(err).Msg("Cleanup: failed to delete expired refresh tokens")
+	} else if n > 0 {
+		log.Info().Int64("count", n).Msg("Cleanup: deleted expired refresh tokens")
+	}
+
+	// Signing credentials: prune non-revoked rows whose audit-retention window
+	// has fully elapsed. This mirrors SigningCredentialRepository.PruneExpiredRetention
+	// exactly (same WHERE: revoked = false AND audit_retention_until <= now) —
+	// replicated inline rather than wired through the repo because the worker is
+	// constructed in server.go without a SigningCredentialRepository and that
+	// constructor is out of scope to change. Revoked rows are retained as a
+	// tamper-evidence trail. Backed by idx_signing_credentials_retention (023).
+	signingRes, err := w.db.NewDelete().
+		TableExpr("signing_credentials").
+		Where("revoked = ?", false).
+		Where("audit_retention_until <= ?", now).
+		Exec(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Cleanup: failed to prune expired signing credentials")
+	} else if n, err := signingRes.RowsAffected(); err == nil && n > 0 {
+		log.Info().Int64("count", n).Msg("Cleanup: pruned expired signing credentials")
 	}
 
 	// CIBA backchannel requests:

--- a/migrations/032_refresh_tokens_expires_at_index.down.sql
+++ b/migrations/032_refresh_tokens_expires_at_index.down.sql
@@ -1,0 +1,5 @@
+-- 032_refresh_tokens_expires_at_index.down.sql
+-- Reverses 032: drops the refresh_tokens expiry index. The cleanup worker's
+-- sweep still functions without it (it just falls back to a sequential scan).
+
+DROP INDEX IF EXISTS idx_refresh_tokens_expires_at;

--- a/migrations/032_refresh_tokens_expires_at_index.up.sql
+++ b/migrations/032_refresh_tokens_expires_at_index.up.sql
@@ -1,0 +1,20 @@
+-- 032_refresh_tokens_expires_at_index.up.sql
+-- Index refresh_tokens.expires_at to support the cleanup worker's expiry sweep.
+--
+-- Under refresh-token rotation every refresh inserts a successor row and
+-- revokes its predecessor (RFC 6749 §6 / reuse detection). With no sweep the
+-- table grew linearly with token traffic; the cleanup worker now deletes rows
+-- whose expires_at is past the reuse-detection grace window. That DELETE
+-- filters on expires_at, so without this index the sweep degrades to a full
+-- table scan as the table grows — defeating the purpose.
+--
+-- Mirrors idx_issued_credentials_expires_at (migration 001), which backs the
+-- analogous credential-expiry sweep.
+--
+-- Lock posture: plain CREATE INDEX takes a SHARE lock that blocks writes for
+-- the build. The table is small relative to a hot OLTP table and this runs in
+-- the migration window; if it ever needs to run online, switch to
+-- CREATE INDEX CONCURRENTLY (which cannot run inside the migration transaction).
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at
+    ON refresh_tokens (expires_at);

--- a/migrations/033_refresh_tokens_expires_at_index.down.sql
+++ b/migrations/033_refresh_tokens_expires_at_index.down.sql
@@ -1,5 +1,5 @@
--- 032_refresh_tokens_expires_at_index.down.sql
--- Reverses 032: drops the refresh_tokens expiry index. The cleanup worker's
+-- 033_refresh_tokens_expires_at_index.down.sql
+-- Reverses 033: drops the refresh_tokens expiry index. The cleanup worker's
 -- sweep still functions without it (it just falls back to a sequential scan).
 
 DROP INDEX IF EXISTS idx_refresh_tokens_expires_at;

--- a/migrations/033_refresh_tokens_expires_at_index.up.sql
+++ b/migrations/033_refresh_tokens_expires_at_index.up.sql
@@ -1,4 +1,4 @@
--- 032_refresh_tokens_expires_at_index.up.sql
+-- 033_refresh_tokens_expires_at_index.up.sql
 -- Index refresh_tokens.expires_at to support the cleanup worker's expiry sweep.
 --
 -- Under refresh-token rotation every refresh inserts a successor row and

--- a/server.go
+++ b/server.go
@@ -176,7 +176,7 @@ func NewServer(cfg Config) (*Server, error) {
 	// to exercise demo flows that submit them. Production deployments
 	// leave AllowUnsafeDevStub off and those proof types stay unimplemented.
 	attestationVerifiers := attestation.NewRegistry()
-	attestationVerifiers.Register(attestation.NewOIDCVerifier(nil))
+	attestationVerifiers.Register(attestation.NewOIDCVerifier(nil).SetAllowPrivate(cfg.Attestation.AllowPrivateIssuerEndpoints))
 	if cfg.Attestation.AllowUnsafeDevStub {
 		log.Warn().Msg("ATTESTATION: AllowUnsafeDevStub is enabled — any submitted proof will verify. DO NOT enable in production.")
 		attestationVerifiers.Register(attestation.NewDevStubVerifier(domain.ProofTypeImageHash))
@@ -208,7 +208,7 @@ func NewServer(cfg Config) (*Server, error) {
 		cfg.SigningCreds.WellKnownJWKSName,
 	)
 	identitySvc := service.NewIdentityService(identityRepo, credentialPolicySvc, apiKeyRepo, credentialSvc, signalSvc, cfg.WIMSEDomain)
-	attestationPolicySvc := attestation.NewPolicyService(attestationPolicyRepo, attestationVerifiers)
+	attestationPolicySvc := attestation.NewPolicyService(attestationPolicyRepo, attestationVerifiers).SetAllowPrivate(cfg.Attestation.AllowPrivateIssuerEndpoints)
 	attestationSvc := service.NewAttestationService(attestationRepo, credentialSvc, identitySvc, attestationVerifiers, attestationPolicySvc, db, cfg.Attestation.AllowUnsafeDevStub)
 	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, credentialPolicySvc, identitySvc)

--- a/server.go
+++ b/server.go
@@ -232,6 +232,11 @@ func NewServer(cfg Config) (*Server, error) {
 		HMACSecret:     cfg.Token.HMACSecret,
 		AuthCodeIssuer: authCodeIssuer,
 	})
+	// Strict client auth on introspection (RFC 7662) / revocation (RFC 7009):
+	// require it whenever unauthenticated inspection is NOT allowed. Validate()
+	// forces allow_unauthenticated_token_inspection=false in production, so
+	// production is strict by default.
+	oauthSvc.SetRequireTokenInspectionAuth(!cfg.Token.AllowUnauthenticatedTokenInspection)
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
 	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo, postgres.NewDPoPReplayStore(db), cfg.Token.Issuer)
 
@@ -850,6 +855,15 @@ func (s *Server) SetBackchannelNotifyDispatchSync(sync bool) {
 // configuration and never call this.
 func (s *Server) SetAttestationPermissive(enabled bool) {
 	s.attestationSvc.SetPermissive(enabled)
+}
+
+// SetRequireTokenInspectionAuth toggles strict client authentication on the
+// introspection (RFC 7662) and revocation (RFC 7009) endpoints. Mirrors the
+// token.allow_unauthenticated_token_inspection config gate (require ==
+// !allow); exposed so integration tests can exercise both postures on one
+// server without restarting it.
+func (s *Server) SetRequireTokenInspectionAuth(require bool) {
+	s.oauthSvc.SetRequireTokenInspectionAuth(require)
 }
 
 // SetBackchannelPingTransport overrides the outbound HTTP RoundTripper used

--- a/tests/integration/ciba_hardening_test.go
+++ b/tests/integration/ciba_hardening_test.go
@@ -14,22 +14,19 @@ import (
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
-// TestCIBAHardening pins three security fixes in the CIBA flow. Each subtest is
+// TestCIBAHardening pins the security fixes in the CIBA flow. Each subtest is
 // written so it FAILS if its fix is reverted (the assertion comments call out
 // the pre-fix behaviour).
 //
 // The subtests drive the service layer directly (constructed over the shared
-// testDB) rather than through HTTP, for two reasons:
+// testDB) rather than through HTTP: the expiry subtests need to backdate
+// expires_at / approved_at, which HTTP cannot do. (The bc-authorize handler
+// does forward client_secret — BcAuthorizeInput in internal/handler/oauth.go —
+// so the confidential path is also reachable over HTTP; these tests predate
+// that wiring and exercising the fix where it lives is still the tighter
+// loop.)
 //
-//  1. The bc-authorize HTTP handler (internal/handler/oauth.go, BcAuthorizeInput)
-//     does NOT read or forward client_secret, so the confidential-client
-//     positive path ("correct secret → ok") is not reachable over HTTP until
-//     that handler grows a client_secret field. Testing the service directly
-//     exercises the fix where it lives.
-//  2. The expiry subtest needs to backdate expires_at / approved_at, which the
-//     service does for us via the repo but which HTTP cannot.
-//
-// All three fixes live in internal/service/backchannel.go and
+// The fixes live in internal/service/backchannel.go and
 // internal/store/postgres/backchannel_request.go.
 func TestCIBAHardening(t *testing.T) {
 	ctx := context.Background()
@@ -147,9 +144,10 @@ func TestCIBAHardening(t *testing.T) {
 		// Guardrail for FIX #2: an honest slow poll whose approval landed just
 		// before expiry must STILL be redeemable inside the grace window — the
 		// bound must not make approvals instantly un-redeemable. We assert the
-		// row is NOT reaped and Redeem does NOT return expired_token. (It will
-		// proceed to issuance, which requires a credential service — so we use
-		// MarkIssued directly to prove the DB-layer guard admits the row.)
+		// row is NOT reaped by DeleteExpired and that MarkIssued (the DB-layer
+		// redeemability guard Redeem relies on) admits it. Redeem itself isn't
+		// called here: past this guard it proceeds to token issuance, which
+		// needs a credential service this harness deliberately leaves nil.
 		clientID := uid("ciba-hard-grace")
 		registerTestOAuthClient(clientID, []string{"client_credentials"})
 
@@ -236,6 +234,54 @@ func TestCIBAHardening(t *testing.T) {
 		})
 		require.NoError(t, e4, "public client must remain unauthenticated at bc-authorize")
 		require.NotEmpty(t, pubOut.AuthReqID)
+	})
+
+	t.Run("Redeem_ConfidentialClientAuth", func(t *testing.T) {
+		// FIX #4: token-endpoint redemption must authenticate confidential
+		// clients (CIBA Core §10.2), symmetric with the bc-authorize check —
+		// otherwise a leaked auth_req_id alone mints the token for a
+		// confidential client. Pre-fix, Redeem checked only client_id
+		// ownership; the no-secret call below would have returned
+		// authorization_pending instead of invalid_client.
+		confClient := registerOAuthClient(t, uid("ciba-hard-redeem"), []string{"openid"})
+
+		out, err := bcSvc.CreateAuthRequest(ctx, service.CreateAuthRequestInput{
+			ClientID:     confClient.ClientID,
+			ClientSecret: confClient.ClientSecret,
+			AccountID:    testAccountID,
+			ProjectID:    testProjectID,
+			LoginHint:    "frank@example.com",
+			Scope:        "openid",
+		})
+		require.NoError(t, err)
+
+		// The row stays PENDING on purpose: a correct-secret Redeem then stops
+		// at authorization_pending, proving client auth passed and the polling
+		// state machine was reached — without needing the (nil) credential
+		// service that token issuance would require.
+
+		// Missing secret → invalid_client (NOT authorization_pending).
+		_, e1 := bcSvc.Redeem(ctx, service.RedeemInput{
+			AuthReqID: out.AuthReqID,
+			ClientID:  confClient.ClientID,
+		})
+		requireOAuthError(t, e1, oautherror.InvalidClient)
+
+		// Wrong secret → invalid_client.
+		_, e2 := bcSvc.Redeem(ctx, service.RedeemInput{
+			AuthReqID:    out.AuthReqID,
+			ClientID:     confClient.ClientID,
+			ClientSecret: "definitely-not-the-secret",
+		})
+		requireOAuthError(t, e2, oautherror.InvalidClient)
+
+		// Correct secret → past client auth, into the polling state machine.
+		_, e3 := bcSvc.Redeem(ctx, service.RedeemInput{
+			AuthReqID:    out.AuthReqID,
+			ClientID:     confClient.ClientID,
+			ClientSecret: confClient.ClientSecret,
+		})
+		requireOAuthError(t, e3, oautherror.AuthorizationPending)
 	})
 }
 

--- a/tests/integration/ciba_hardening_test.go
+++ b/tests/integration/ciba_hardening_test.go
@@ -1,0 +1,251 @@
+package integration_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+	"github.com/highflame-ai/zeroid/internal/service"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
+)
+
+// TestCIBAHardening pins three security fixes in the CIBA flow. Each subtest is
+// written so it FAILS if its fix is reverted (the assertion comments call out
+// the pre-fix behaviour).
+//
+// The subtests drive the service layer directly (constructed over the shared
+// testDB) rather than through HTTP, for two reasons:
+//
+//  1. The bc-authorize HTTP handler (internal/handler/oauth.go, BcAuthorizeInput)
+//     does NOT read or forward client_secret, so the confidential-client
+//     positive path ("correct secret → ok") is not reachable over HTTP until
+//     that handler grows a client_secret field. Testing the service directly
+//     exercises the fix where it lives.
+//  2. The expiry subtest needs to backdate expires_at / approved_at, which the
+//     service does for us via the repo but which HTTP cannot.
+//
+// All three fixes live in internal/service/backchannel.go and
+// internal/store/postgres/backchannel_request.go.
+func TestCIBAHardening(t *testing.T) {
+	ctx := context.Background()
+
+	// Build the backchannel service over the same Postgres the rest of the
+	// suite uses. credentialSvc is nil: none of the paths these subtests
+	// exercise reach token issuance (Redeem returns its error before
+	// issueTokenForApprovedRow, and CreateAuthRequest never touches the
+	// credential service).
+	bcRepo := postgres.NewBackchannelRequestRepository(testDB)
+	oauthClientRepo := postgres.NewOAuthClientRepository(testDB)
+	oauthClientSvc := service.NewOAuthClientService(oauthClientRepo)
+	bcSvc := service.NewBackchannelService(bcRepo, oauthClientSvc, nil, service.DefaultBackchannelConfig())
+
+	t.Run("Redeem_OmittedClientID_Refused", func(t *testing.T) {
+		// FIX #1: Redeem must require a non-empty client_id and always compare
+		// it to the row. Pre-fix, the ownership comparison was skipped when
+		// client_id was empty, so a polling caller could redeem ANY approved
+		// auth_req_id by simply omitting client_id.
+		clientID := uid("ciba-hard-omit")
+		registerTestOAuthClient(clientID, []string{"client_credentials"})
+
+		out, err := bcSvc.CreateAuthRequest(ctx, service.CreateAuthRequestInput{
+			ClientID:  clientID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			LoginHint: "alice@example.com",
+			Scope:     "openid",
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, out.AuthReqID)
+
+		// Approve it so the row is in a redeemable state — proving the refusal
+		// is the missing-client_id guard, not just "not yet approved".
+		require.NoError(t, bcSvc.Approve(ctx, service.ApproveInput{
+			AuthReqID: out.AuthReqID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			SubjectID: "user-omit-001",
+		}))
+
+		// Redeem with an EMPTY client_id → must be refused. Pre-fix this would
+		// have skipped the ownership check and minted a token.
+		_, rerr := bcSvc.Redeem(ctx, service.RedeemInput{
+			AuthReqID: out.AuthReqID,
+			ClientID:  "", // omitted
+		})
+		requireOAuthError(t, rerr, oautherror.InvalidGrant)
+
+		// Sanity: a DIFFERENT (non-empty) client_id is also refused.
+		_, rerr2 := bcSvc.Redeem(ctx, service.RedeemInput{
+			AuthReqID: out.AuthReqID,
+			ClientID:  "some-other-client",
+		})
+		requireOAuthError(t, rerr2, oautherror.InvalidGrant)
+		// (The legitimate owner passing the ownership gate is covered by the
+		// end-to-end TestCIBA_PollingLifecycle, which redeems with the matching
+		// client_id and gets a token. Here credentialSvc is nil, so we stop at
+		// the ownership refusal and don't exercise issuance.)
+	})
+
+	t.Run("Redeem_ApprovedPastExpiryAndGrace_NotRedeemable", func(t *testing.T) {
+		// FIX #2: an APPROVED row that has outlived both expires_at and the
+		// post-approval grace window must surface expired_token, not mint a
+		// token. Pre-fix, the expiry guard only applied to PENDING rows, so an
+		// approved-but-unredeemed (leaked) auth_req_id was redeemable forever.
+		clientID := uid("ciba-hard-exp")
+		registerTestOAuthClient(clientID, []string{"client_credentials"})
+
+		out, err := bcSvc.CreateAuthRequest(ctx, service.CreateAuthRequestInput{
+			ClientID:  clientID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			LoginHint: "bob@example.com",
+			Scope:     "openid",
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, bcSvc.Approve(ctx, service.ApproveInput{
+			AuthReqID: out.AuthReqID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			SubjectID: "user-exp-001",
+		}))
+
+		// Backdate the row well past expires_at AND past approved_at + grace so
+		// neither the expires_at branch nor the grace branch keeps it alive.
+		stale := time.Now().Add(-2 * postgres.ApprovedRedemptionGrace)
+		_, uerr := testDB.NewUpdate().
+			Model((*domain.BackchannelAuthRequest)(nil)).
+			Set("expires_at = ?", stale).
+			Set("approved_at = ?", stale).
+			Where("auth_req_id = ?", out.AuthReqID).
+			Exec(ctx)
+		require.NoError(t, uerr)
+
+		// Redeem by the legitimate owner → expired_token. Pre-fix this approved
+		// row would have minted a token regardless of how old it was.
+		_, rerr := bcSvc.Redeem(ctx, service.RedeemInput{
+			AuthReqID: out.AuthReqID,
+			ClientID:  clientID,
+		})
+		requireOAuthError(t, rerr, oautherror.ExpiredToken)
+
+		// The cleanup sweep must now reap this approved-but-dead row. Pre-fix
+		// DeleteExpired excluded approved rows entirely, so it lived forever.
+		_, derr := bcSvc.DeleteExpired(ctx, time.Now())
+		require.NoError(t, derr)
+		_, gerr := bcRepo.GetByAuthReqID(ctx, out.AuthReqID)
+		require.ErrorIs(t, gerr, postgres.ErrBackchannelRequestNotFound,
+			"approved-but-dead row must be reaped by DeleteExpired")
+	})
+
+	t.Run("Redeem_ApprovedWithinGrace_StillRedeemable", func(t *testing.T) {
+		// Guardrail for FIX #2: an honest slow poll whose approval landed just
+		// before expiry must STILL be redeemable inside the grace window — the
+		// bound must not make approvals instantly un-redeemable. We assert the
+		// row is NOT reaped and Redeem does NOT return expired_token. (It will
+		// proceed to issuance, which requires a credential service — so we use
+		// MarkIssued directly to prove the DB-layer guard admits the row.)
+		clientID := uid("ciba-hard-grace")
+		registerTestOAuthClient(clientID, []string{"client_credentials"})
+
+		out, err := bcSvc.CreateAuthRequest(ctx, service.CreateAuthRequestInput{
+			ClientID:  clientID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			LoginHint: "carol@example.com",
+			Scope:     "openid",
+		})
+		require.NoError(t, err)
+		require.NoError(t, bcSvc.Approve(ctx, service.ApproveInput{
+			AuthReqID: out.AuthReqID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			SubjectID: "user-grace-001",
+		}))
+
+		// Past expires_at, but approved_at is recent → inside the grace window.
+		_, uerr := testDB.NewUpdate().
+			Model((*domain.BackchannelAuthRequest)(nil)).
+			Set("expires_at = ?", time.Now().Add(-1*time.Minute)).
+			Set("approved_at = ?", time.Now()).
+			Where("auth_req_id = ?", out.AuthReqID).
+			Exec(ctx)
+		require.NoError(t, uerr)
+
+		// DeleteExpired must NOT reap it (still inside grace).
+		_, derr := bcSvc.DeleteExpired(ctx, time.Now())
+		require.NoError(t, derr)
+		_, gerr := bcRepo.GetByAuthReqID(ctx, out.AuthReqID)
+		require.NoError(t, gerr, "row inside grace window must survive the sweep")
+
+		// MarkIssued must admit it (the DB-layer guard sees it as redeemable).
+		affected, mierr := bcRepo.MarkIssued(ctx, out.AuthReqID, time.Now())
+		require.NoError(t, mierr)
+		require.EqualValues(t, 1, affected,
+			"approved row inside grace window must be issuable")
+	})
+
+	t.Run("BcAuthorize_ConfidentialClientAuth", func(t *testing.T) {
+		// FIX #3: bc-authorize must authenticate confidential clients. Pre-fix
+		// it only checked the client existed and trusted the body — letting an
+		// unauthenticated party fire the deployer's notifier at arbitrary users.
+		confClient := registerOAuthClient(t, uid("ciba-hard-conf"), []string{"openid"})
+
+		base := service.CreateAuthRequestInput{
+			ClientID:  confClient.ClientID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			LoginHint: "dave@example.com",
+			Scope:     "openid",
+		}
+
+		// Missing secret → rejected (invalid_client). Pre-fix: accepted.
+		noSecret := base
+		_, e1 := bcSvc.CreateAuthRequest(ctx, noSecret)
+		requireOAuthError(t, e1, oautherror.InvalidClient)
+
+		// Wrong secret → rejected (invalid_client).
+		wrongSecret := base
+		wrongSecret.ClientSecret = "definitely-not-the-secret"
+		_, e2 := bcSvc.CreateAuthRequest(ctx, wrongSecret)
+		requireOAuthError(t, e2, oautherror.InvalidClient)
+
+		// Correct secret → accepted.
+		good := base
+		good.ClientSecret = confClient.ClientSecret
+		out, e3 := bcSvc.CreateAuthRequest(ctx, good)
+		require.NoError(t, e3, "confidential client with correct secret must be accepted")
+		require.NotEmpty(t, out.AuthReqID)
+
+		// Public clients per CIBA may remain unauthenticated — confirm the
+		// enforcement is scoped to confidential clients only.
+		pubClientID := uid("ciba-hard-pub")
+		registerTestOAuthClient(pubClientID, []string{"client_credentials"})
+		pubOut, e4 := bcSvc.CreateAuthRequest(ctx, service.CreateAuthRequestInput{
+			ClientID:  pubClientID,
+			AccountID: testAccountID,
+			ProjectID: testProjectID,
+			LoginHint: "erin@example.com",
+			Scope:     "openid",
+			// no client_secret
+		})
+		require.NoError(t, e4, "public client must remain unauthenticated at bc-authorize")
+		require.NotEmpty(t, pubOut.AuthReqID)
+	})
+}
+
+// requireOAuthError asserts that err is a *service.OAuthError carrying the
+// expected RFC 6749 error code (the codes are the string constants in
+// internal/oautherror).
+func requireOAuthError(t *testing.T, err error, wantCode string) {
+	t.Helper()
+	require.Error(t, err)
+	var oe *service.OAuthError
+	require.True(t, errors.As(err, &oe), "expected a *service.OAuthError, got %T: %v", err, err)
+	require.Equal(t, wantCode, oe.Code, "OAuth error code mismatch (err=%v)", err)
+}

--- a/tests/integration/cleanup_sweep_test.go
+++ b/tests/integration/cleanup_sweep_test.go
@@ -64,7 +64,6 @@ func refreshTokenExists(t *testing.T, id string) bool {
 func TestCleanupSweepsExpiredRefreshTokensPastGraceWindow(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()
-	grace := domain.RefreshTokenReuseGraceWindow
 
 	// (1) Long-expired, revoked: expires_at far beyond the cutoff → DELETE.
 	revokedAt := now.Add(-time.Hour)
@@ -76,14 +75,17 @@ func TestCleanupSweepsExpiredRefreshTokensPastGraceWindow(t *testing.T) {
 	)
 
 	// (2) Revoked, but expires_at sits INSIDE the grace window (cutoff = now -
-	// grace; this row's expires_at is now - grace/2 > cutoff) → RETAIN. This is
-	// the reuse-forensics guard: a row whose expiry is more recent than the
-	// grace lag must survive the sweep.
-	recentRevokedAt := now.Add(-grace / 2)
+	// grace; this row's expires_at is now - 1s > cutoff) → RETAIN. This is the
+	// reuse-forensics guard: a row whose expiry is more recent than the grace
+	// lag must survive the sweep. We use a fixed 1s offset (not grace/2) so the
+	// margin between this expiry and the cutoff is ~grace-1s ≈ 9s — large
+	// enough that a slow CI runner delaying between `now` here and the cleanup
+	// worker's own time.Now() can't push the row past the cutoff and flake.
+	recentRevokedAt := now.Add(-1 * time.Second)
 	withinGrace := insertRefreshTokenRow(t,
 		uid("rt-within-grace"),
 		domain.RefreshTokenStateRevoked,
-		now.Add(-grace/2),
+		now.Add(-1*time.Second),
 		&recentRevokedAt,
 	)
 

--- a/tests/integration/cleanup_sweep_test.go
+++ b/tests/integration/cleanup_sweep_test.go
@@ -1,0 +1,125 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// insertRefreshTokenRow inserts a refresh_tokens row directly via testDB so the
+// test can deterministically place rows on either side of the
+// expires_at - grace-window cutoff without driving full rotation flows. Returns
+// the row id (gen_random_uuid default).
+func insertRefreshTokenRow(t *testing.T, tokenHash, state string, expiresAt time.Time, revokedAt *time.Time) string {
+	t.Helper()
+	row := &domain.RefreshToken{
+		TokenHash: tokenHash,
+		ClientID:  "cleanup-sweep-client",
+		AccountID: testAccountID,
+		ProjectID: testProjectID,
+		UserID:    "cleanup-sweep-user",
+		FamilyID:  uuidV4(t),
+		State:     state,
+		ExpiresAt: expiresAt,
+		RevokedAt: revokedAt,
+	}
+	_, err := testDB.NewInsert().Model(row).Returning("id").Exec(context.Background())
+	require.NoError(t, err, "insert refresh_tokens row")
+	require.NotEmpty(t, row.ID)
+	return row.ID
+}
+
+// uuidV4 returns a fresh UUID string. refresh_tokens.family_id is NOT NULL
+// type uuid, so each synthetic row needs its own.
+func uuidV4(t *testing.T) string {
+	t.Helper()
+	var id string
+	err := testDB.NewSelect().ColumnExpr("gen_random_uuid()::text").Scan(context.Background(), &id)
+	require.NoError(t, err)
+	return id
+}
+
+func refreshTokenExists(t *testing.T, id string) bool {
+	t.Helper()
+	n, err := testDB.NewSelect().
+		Model((*domain.RefreshToken)(nil)).
+		Where("id = ?", id).
+		Count(context.Background())
+	require.NoError(t, err)
+	return n > 0
+}
+
+// TestCleanupSweepsExpiredRefreshTokensPastGraceWindow proves the new refresh-
+// token sweep in CleanupWorker.RunOnce:
+//   - a row expired well past the reuse-detection grace window is deleted;
+//   - a row that is revoked but whose expires_at sits inside the grace window
+//     (now - grace < expires_at) is RETAINED so reuse detection can still
+//     consult it;
+//   - an active, unexpired row is never touched.
+func TestCleanupSweepsExpiredRefreshTokensPastGraceWindow(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	grace := domain.RefreshTokenReuseGraceWindow
+
+	// (1) Long-expired, revoked: expires_at far beyond the cutoff → DELETE.
+	revokedAt := now.Add(-time.Hour)
+	wayExpired := insertRefreshTokenRow(t,
+		uid("rt-way-expired"),
+		domain.RefreshTokenStateRevoked,
+		now.Add(-time.Hour),
+		&revokedAt,
+	)
+
+	// (2) Revoked, but expires_at sits INSIDE the grace window (cutoff = now -
+	// grace; this row's expires_at is now - grace/2 > cutoff) → RETAIN. This is
+	// the reuse-forensics guard: a row whose expiry is more recent than the
+	// grace lag must survive the sweep.
+	recentRevokedAt := now.Add(-grace / 2)
+	withinGrace := insertRefreshTokenRow(t,
+		uid("rt-within-grace"),
+		domain.RefreshTokenStateRevoked,
+		now.Add(-grace/2),
+		&recentRevokedAt,
+	)
+
+	// (3) Active, unexpired → never swept.
+	active := insertRefreshTokenRow(t,
+		uid("rt-active"),
+		domain.RefreshTokenStateActive,
+		now.Add(24*time.Hour),
+		nil,
+	)
+
+	require.True(t, refreshTokenExists(t, wayExpired), "precondition: long-expired row inserted")
+	require.True(t, refreshTokenExists(t, withinGrace), "precondition: within-grace row inserted")
+	require.True(t, refreshTokenExists(t, active), "precondition: active row inserted")
+
+	testZeroIDServer.RunCleanupOnce(ctx)
+
+	assert.False(t, refreshTokenExists(t, wayExpired),
+		"refresh token expired past the grace window must be swept")
+	assert.True(t, refreshTokenExists(t, withinGrace),
+		"revoked refresh token whose expiry is inside the grace window must be retained for reuse forensics")
+	assert.True(t, refreshTokenExists(t, active),
+		"active, unexpired refresh token must never be swept")
+}
+
+// TestRefreshTokensExpiryIndexMigrationApplied asserts migration 032 created the
+// expiry index that backs the sweep. The server runs migrations on startup, so
+// reaching this point with the index present proves 032 applied cleanly.
+func TestRefreshTokensExpiryIndexMigrationApplied(t *testing.T) {
+	var count int
+	err := testDB.NewSelect().
+		ColumnExpr("count(*)").
+		TableExpr("pg_indexes").
+		Where("indexname = ?", "idx_refresh_tokens_expires_at").
+		Scan(context.Background(), &count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count,
+		"migration 032 must create idx_refresh_tokens_expires_at on refresh_tokens")
+}

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -240,6 +240,14 @@ func runTests(m *testing.M) int {
 		Backchannel: zeroid.BackchannelConfig{
 			AllowPrivateNotificationEndpoints: true,
 		},
+		// The attestation OIDC verifier fixtures run a discovery + JWKS
+		// httptest server on 127.0.0.1, which the new SSRF guard blocks by
+		// default. Relax it for this test deployment, exactly as the
+		// Backchannel flag above does for loopback notification endpoints.
+		// Production deployments keep this false.
+		Attestation: zeroid.AttestationConfig{
+			AllowPrivateIssuerEndpoints: true,
+		},
 		// Opt this test deployment into workload-attested signing with a
 		// branded well-known name + purpose allowlist — exactly what a
 		// product deployer supplies. ZeroID itself ships product-agnostic.

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -225,6 +225,13 @@ func runTests(m *testing.M) int {
 			MaxTTL:         90 * 24 * 3600, // 90 days — needed for authorization_code CLI tokens
 			HMACSecret:     testHMACSecret,
 			AuthCodeIssuer: testIssuer,
+			// Accept-and-verify posture for the suite (this is the LoadConfig
+			// default, but a struct literal doesn't get koanf defaults — so set
+			// it explicitly, else the suite would run strict and every
+			// anonymous introspect()/revoke() helper call would 401). The
+			// strict-mode path is exercised by toggling
+			// SetRequireTokenInspectionAuth in its dedicated test.
+			AllowUnauthenticatedTokenInspection: true,
 		},
 		Telemetry: zeroid.TelemetryConfig{
 			Enabled: false,

--- a/tests/integration/inspection_basic_auth_test.go
+++ b/tests/integration/inspection_basic_auth_test.go
@@ -3,6 +3,8 @@ package integration_test
 import (
 	"encoding/base64"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -130,6 +132,94 @@ func TestInspectionBasicAuth_MalformedBasicHeaderRejected(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	body := decode(t, resp)
 	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// ── client_secret_basic over application/x-www-form-urlencoded ───────────────
+//
+// The JSON cases above use post(); these mirror the meaningful ones over the
+// form wire, since form-encoding is the canonical content type for these
+// endpoints (RFC 6749 §2.3 / 7662 §2.1 / 7009 §2.1) and the realistic shape a
+// stock OAuth client pairs with a Basic header. The form body and the
+// Authorization header are decoded by independent paths (the form-compat
+// middleware vs the huma header binding), so exercising them together is the
+// gap these cover. The malformed-header and metadata cases are content-type
+// agnostic (header parsing is identical; metadata is a GET), so they are not
+// duplicated.
+
+// postFormWithHeaders posts a form-encoded body with extra headers. postForm in
+// oauth_form_compat_test.go sets no headers, so this is its header-carrying
+// analogue — the form equivalent of post(body, headers).
+func postFormWithHeaders(t *testing.T, path string, form url.Values, headers map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, testServer.URL+path, strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// TestInspectionBasicAuth_IntrospectAcceptsBasic_Form is the form-encoded twin
+// of TestInspectionBasicAuth_IntrospectAcceptsBasic.
+func TestInspectionBasicAuth_IntrospectAcceptsBasic_Form(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-introspect-form")
+
+	resp := postFormWithHeaders(t, "/oauth2/token/introspect",
+		url.Values{"token": {token}},
+		basicAuthHeader(client.ClientID, client.ClientSecret))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, true, body["active"], "valid token introspected with form body + Basic auth must be active")
+}
+
+// TestInspectionBasicAuth_IntrospectRejectsWrongBasicSecret_Form is the
+// form-encoded twin of the wrong-secret rejection.
+func TestInspectionBasicAuth_IntrospectRejectsWrongBasicSecret_Form(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-introspect-form-bad")
+
+	resp := postFormWithHeaders(t, "/oauth2/token/introspect",
+		url.Values{"token": {token}},
+		basicAuthHeader(client.ClientID, "definitely-the-wrong-secret"))
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("WWW-Authenticate"), "Basic",
+		"401 on a Basic attempt must carry a Basic WWW-Authenticate challenge (RFC 6749 §5.2)")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_client", body["error"])
+}
+
+// TestInspectionBasicAuth_RejectsBothMethods_Form verifies the one-method rule
+// (RFC 6749 §2.3) holds when the duplicate credentials arrive as form fields
+// alongside a Basic header.
+func TestInspectionBasicAuth_RejectsBothMethods_Form(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-both-methods-form")
+
+	resp := postFormWithHeaders(t, "/oauth2/token/introspect",
+		url.Values{
+			"token":         {token},
+			"client_id":     {client.ClientID},
+			"client_secret": {client.ClientSecret},
+		},
+		basicAuthHeader(client.ClientID, client.ClientSecret))
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// TestInspectionBasicAuth_RevokeAcceptsBasic_Form is the form-encoded twin of
+// the revoke happy path; confirms the token is actually revoked.
+func TestInspectionBasicAuth_RevokeAcceptsBasic_Form(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-revoke-form")
+
+	resp := postFormWithHeaders(t, "/oauth2/token/revoke",
+		url.Values{"token": {token}},
+		basicAuthHeader(client.ClientID, client.ClientSecret))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	assert.False(t, introspect(t, token)["active"].(bool), "token must be inactive after form+Basic-authed revoke")
 }
 
 // TestInspectionBasicAuth_MetadataAdvertisesAuthMethods verifies the RFC 8414

--- a/tests/integration/inspection_basic_auth_test.go
+++ b/tests/integration/inspection_basic_auth_test.go
@@ -1,0 +1,150 @@
+package integration_test
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for client_secret_basic support on the introspection (RFC 7662) and
+// revocation (RFC 7009) endpoints. The endpoints accept client credentials
+// either as body fields (client_secret_post) or via the Authorization header
+// (client_secret_basic, RFC 6749 §2.3.1); using both at once is rejected per
+// RFC 6749 §2.3.
+//
+// Run in isolation:
+//
+//	go test ./tests/integration/ -run 'TestInspectionBasicAuth' -count=1
+
+// basicAuthHeader builds an RFC 6749 §2.3.1 Basic credential header.
+func basicAuthHeader(clientID, clientSecret string) map[string]string {
+	cred := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + clientSecret))
+	return map[string]string{"Authorization": "Basic " + cred}
+}
+
+// inspectionFixture mints a token plus the confidential client that owns it.
+func inspectionFixture(t *testing.T, prefix string) (token string, client oauthClientResp) {
+	t.Helper()
+	agentID := uid(prefix)
+	registerIdentity(t, agentID, []string{"data:read"})
+	client = registerOAuthClient(t, agentID, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return decode(t, resp)["access_token"].(string), client
+}
+
+// TestInspectionBasicAuth_IntrospectAcceptsBasic verifies a valid
+// client_secret_basic header authenticates an introspection call.
+func TestInspectionBasicAuth_IntrospectAcceptsBasic(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-introspect")
+
+	resp := post(t, "/oauth2/token/introspect", map[string]any{
+		"token": token,
+	}, basicAuthHeader(client.ClientID, client.ClientSecret))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, true, body["active"], "valid token introspected with Basic auth must be active")
+}
+
+// TestInspectionBasicAuth_IntrospectRejectsWrongBasicSecret verifies a wrong
+// secret in the Basic header is rejected with invalid_client and the RFC 6749
+// §5.2 WWW-Authenticate echo.
+func TestInspectionBasicAuth_IntrospectRejectsWrongBasicSecret(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-introspect-bad")
+
+	resp := post(t, "/oauth2/token/introspect", map[string]any{
+		"token": token,
+	}, basicAuthHeader(client.ClientID, "definitely-the-wrong-secret"))
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("WWW-Authenticate"), "Basic",
+		"401 on a Basic attempt must carry a Basic WWW-Authenticate challenge (RFC 6749 §5.2)")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_client", body["error"])
+}
+
+// TestInspectionBasicAuth_RejectsBothMethods verifies that presenting Basic
+// header credentials AND body credentials in the same request is rejected
+// (RFC 6749 §2.3: at most one client authentication method per request).
+func TestInspectionBasicAuth_RejectsBothMethods(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-both-methods")
+
+	resp := post(t, "/oauth2/token/introspect", map[string]any{
+		"token":         token,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+	}, basicAuthHeader(client.ClientID, client.ClientSecret))
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// TestInspectionBasicAuth_RevokeAcceptsBasic verifies a valid
+// client_secret_basic header authenticates a revocation call, and the token
+// is actually revoked.
+func TestInspectionBasicAuth_RevokeAcceptsBasic(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-revoke")
+
+	resp := post(t, "/oauth2/token/revoke", map[string]any{
+		"token": token,
+	}, basicAuthHeader(client.ClientID, client.ClientSecret))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	assert.False(t, introspect(t, token)["active"].(bool), "token must be inactive after Basic-authed revoke")
+}
+
+// TestInspectionBasicAuth_RevokeRejectsWrongBasicSecret verifies the revoke
+// endpoint rejects a wrong Basic secret with invalid_client — the RFC 7009
+// §2.2.1 carve-out from the always-200 contract — and does NOT revoke.
+func TestInspectionBasicAuth_RevokeRejectsWrongBasicSecret(t *testing.T) {
+	token, client := inspectionFixture(t, "basic-revoke-bad")
+
+	resp := post(t, "/oauth2/token/revoke", map[string]any{
+		"token": token,
+	}, basicAuthHeader(client.ClientID, "definitely-the-wrong-secret"))
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("WWW-Authenticate"), "Basic")
+	_ = resp.Body.Close()
+
+	assert.True(t, introspect(t, token)["active"].(bool), "token must remain active after rejected revoke")
+}
+
+// TestInspectionBasicAuth_MalformedBasicHeaderRejected verifies a Basic header
+// that is not valid base64 (or lacks the id:secret shape) is invalid_request.
+func TestInspectionBasicAuth_MalformedBasicHeaderRejected(t *testing.T) {
+	token, _ := inspectionFixture(t, "basic-malformed")
+
+	resp := post(t, "/oauth2/token/introspect", map[string]any{
+		"token": token,
+	}, map[string]string{"Authorization": "Basic not-base64!!"})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_request", body["error"])
+}
+
+// TestInspectionBasicAuth_MetadataAdvertisesAuthMethods verifies the RFC 8414
+// document advertises the supported client auth methods for both endpoints.
+func TestInspectionBasicAuth_MetadataAdvertisesAuthMethods(t *testing.T) {
+	resp := get(t, "/.well-known/oauth-authorization-server", nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	for _, key := range []string{
+		"introspection_endpoint_auth_methods_supported",
+		"revocation_endpoint_auth_methods_supported",
+	} {
+		methods, ok := body[key].([]any)
+		require.True(t, ok, "metadata must include %s", key)
+		assert.ElementsMatch(t, []any{"client_secret_post", "client_secret_basic"}, methods, key)
+	}
+}

--- a/tests/integration/oauth_authz_hardening_test.go
+++ b/tests/integration/oauth_authz_hardening_test.go
@@ -302,3 +302,32 @@ func TestOAuthAuthzHardening_RevocationClientAuth(t *testing.T) {
 	_ = revokeResp.Body.Close()
 	assert.False(t, introspect(t, tokenA)["active"].(bool), "no-credential revocation must revoke the token")
 }
+
+// TestOAuthAuthzHardening_PublicClientRevocationWithoutSecret proves the
+// accept-and-verify posture honors RFC 7009 §2.1 / RFC 7662 §2.1 for public
+// clients: a registered public client presenting only its client_id (no
+// secret — which standard OAuth libraries attach to revocation requests) is
+// accepted, while a confidential client_id with no secret is rejected.
+func TestOAuthAuthzHardening_PublicClientRevocationWithoutSecret(t *testing.T) {
+	// Public client (testMCPClientID is registered without a secret) presenting
+	// only its client_id on revoke → accepted (RFC 7009 always-200), not 401.
+	resp := post(t, "/oauth2/token/revoke", map[string]any{
+		"token":     "some-unknown-token",
+		"client_id": testMCPClientID,
+	}, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"a public client presenting only client_id must be accepted on revoke")
+	_ = resp.Body.Close()
+
+	// Confidential client presenting client_id without its secret → rejected.
+	agentID := uid("revoke-conf-nosecret")
+	registerIdentity(t, agentID, []string{"data:read"})
+	conf := registerOAuthClient(t, agentID, []string{"data:read"})
+	resp = post(t, "/oauth2/token/revoke", map[string]any{
+		"token":     "some-unknown-token",
+		"client_id": conf.ClientID,
+	}, adminHeaders())
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"a confidential client must present its secret, not just client_id")
+	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
+}

--- a/tests/integration/oauth_authz_hardening_test.go
+++ b/tests/integration/oauth_authz_hardening_test.go
@@ -332,3 +332,64 @@ func TestOAuthAuthzHardening_PublicClientRevocationWithoutSecret(t *testing.T) {
 		"a confidential client must present its secret, not just client_id")
 	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
 }
+
+// TestOAuthAuthzHardening_StrictModeRejectsAnonymousInspection pins the
+// config-gated hard-require (RFC 7662 §2.1 / RFC 7009 §2.1, issue #201). With
+// token.allow_unauthenticated_token_inspection=false (forced in production by
+// Validate), introspection and revocation MUST reject an anonymous caller;
+// a caller presenting valid credentials still works. The harness default is
+// accept-and-verify, so the subtest flips strict mode on for its duration.
+func TestOAuthAuthzHardening_StrictModeRejectsAnonymousInspection(t *testing.T) {
+	testZeroIDServer.SetRequireTokenInspectionAuth(true)
+	t.Cleanup(func() { testZeroIDServer.SetRequireTokenInspectionAuth(false) })
+
+	// Mint a token to inspect/revoke, via a confidential client we can also
+	// authenticate with.
+	agentID := uid("strict-inspect")
+	registerIdentity(t, agentID, []string{"data:read"})
+	client := registerOAuthClient(t, agentID, []string{"data:read"})
+	mintResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, mintResp.StatusCode)
+	token := decode(t, mintResp)["access_token"].(string)
+
+	// Anonymous introspection → rejected (401 invalid_client) in strict mode.
+	resp := post(t, "/oauth2/token/introspect", map[string]string{"token": token}, adminHeaders())
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"strict mode must reject anonymous introspection")
+	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
+
+	// Anonymous revocation → rejected too (gate runs before the RFC 7009 §2.2
+	// always-200 contract).
+	resp = post(t, "/oauth2/token/revoke", map[string]string{"token": token}, adminHeaders())
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"strict mode must reject anonymous revocation")
+	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
+
+	// Token must NOT have been revoked by the rejected call.
+	introResp := post(t, "/oauth2/token/introspect", map[string]any{
+		"token":         token,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+	}, nil)
+	require.Equal(t, http.StatusOK, introResp.StatusCode,
+		"authenticated introspection must work in strict mode")
+	assert.Equal(t, true, decode(t, introResp)["active"],
+		"token must still be active — the rejected anonymous revoke must not have revoked it")
+
+	// Authenticated revocation works and the RFC 7009 §2.2 200 holds.
+	revResp := post(t, "/oauth2/token/revoke", map[string]any{
+		"token":         token,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+	}, nil)
+	require.Equal(t, http.StatusOK, revResp.StatusCode,
+		"authenticated revocation must succeed")
+	_ = revResp.Body.Close()
+}

--- a/tests/integration/oauth_authz_hardening_test.go
+++ b/tests/integration/oauth_authz_hardening_test.go
@@ -195,14 +195,15 @@ func TestOAuthAuthzHardening_WrongClientIDDoesNotBrickSession(t *testing.T) {
 	rt := decode(t, resp)["refresh_token"].(string)
 
 	// Refresh with a WRONG (unknown) client_id → rejected, token NOT consumed.
-	// An unknown client is invalid_client per RFC 6749 §5.2; the security
-	// property under test is that the token survives the rejection.
+	// An unknown client is invalid_client per RFC 6749 §5.2 (401, matching the
+	// authorization_code path); the security property under test is that the
+	// token survives the rejection.
 	resp = post(t, "/oauth2/token", map[string]any{
 		"grant_type":    "refresh_token",
 		"refresh_token": rt,
 		"client_id":     "some-other-client",
 	}, nil)
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
 
 	// The original token must STILL be usable with the correct client_id —

--- a/tests/integration/oauth_authz_hardening_test.go
+++ b/tests/integration/oauth_authz_hardening_test.go
@@ -1,0 +1,298 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file proves the OAuth grant/endpoint authorization-hardening fixes:
+//
+//  1. Confidential clients must authenticate (client_secret) on the
+//     refresh_token grant (RFC 6749 §6/§10.4). Public clients are unaffected.
+//  2. A client_credentials client registered with zero scopes cannot widen its
+//     authority by requesting arbitrary scopes (RFC 6749 §3.3).
+//  3. A refresh with a wrong client_id does NOT brick the session — the
+//     original refresh token remains usable (pre-rotation validation, §10.4).
+//  4. Introspection (RFC 7662) / revocation (RFC 7009) verify presented client
+//     credentials (reject a wrong secret) while leaving the existing tenant-
+//     header internal path working.
+//
+// Each test is named with the shared prefix TestOAuthAuthzHardening_ so the
+// suite can be run in isolation:
+//
+//	go test ./tests/integration/ -run 'TestOAuthAuthzHardening' -count=1
+
+// registerConfidentialClient registers a confidential OAuth client with the
+// given grant types + scopes via the admin endpoint and returns its
+// credentials. Mirrors registerOAuthClient but lets the caller choose grants
+// and supply a redirect URI (needed for the authorization_code path).
+func registerConfidentialClient(t *testing.T, clientID string, grantTypes, scopes, redirectURIs []string) oauthClientResp {
+	t.Helper()
+	resp := post(t, adminPath("/oauth/clients"), map[string]any{
+		"client_id":     clientID,
+		"name":          clientID + "-client",
+		"confidential":  true,
+		"grant_types":   grantTypes,
+		"scopes":        scopes,
+		"redirect_uris": redirectURIs,
+	}, nil)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "registerConfidentialClient: expected 201")
+	raw := decode(t, resp)
+	client := raw["client"].(map[string]any)
+	return oauthClientResp{
+		ClientID:     client["client_id"].(string),
+		ClientSecret: raw["client_secret"].(string),
+	}
+}
+
+// mintConfidentialRefreshToken runs a confidential authorization_code exchange
+// (PKCE + client_secret) and returns the issued refresh token. The client must
+// be registered with both authorization_code and refresh_token grants.
+func mintConfidentialRefreshToken(t *testing.T, client oauthClientResp, userID string) string {
+	t.Helper()
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, client.ClientID, userID, testRedirectURI, challenge, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "confidential authorization_code exchange should succeed")
+	tok := decode(t, resp)
+	rt, ok := tok["refresh_token"].(string)
+	require.True(t, ok, "confidential client with refresh_token grant must receive a refresh token")
+	require.NotEmpty(t, rt)
+	return rt
+}
+
+// TestOAuthAuthzHardening_ConfidentialRefreshRequiresSecret proves finding #1:
+// a confidential client must present its client_secret on the refresh_token
+// grant. A missing or wrong secret → invalid_client; the correct secret works.
+// (Fails if the VerifyConfidentialClientAuth call in refreshToken is reverted.)
+func TestOAuthAuthzHardening_ConfidentialRefreshRequiresSecret(t *testing.T) {
+	clientID := uid("conf-refresh")
+	client := registerConfidentialClient(t,
+		clientID,
+		[]string{"authorization_code", "refresh_token"},
+		[]string{"data:read"},
+		[]string{testRedirectURI},
+	)
+
+	// Missing secret → invalid_client.
+	rt := mintConfidentialRefreshToken(t, client, "user-conf-1")
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt,
+		"client_id":     client.ClientID,
+		// no client_secret
+	}, nil)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "confidential refresh without secret must be rejected")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_client", body["error"])
+
+	// The failed (no-secret) attempt must NOT have consumed the token —
+	// presenting it again WITH the correct secret must still succeed.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt,
+		"client_id":     client.ClientID,
+		"client_secret": "definitely-the-wrong-secret",
+	}, nil)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "confidential refresh with wrong secret must be rejected")
+	body = decode(t, resp)
+	assert.Equal(t, "invalid_client", body["error"])
+
+	// Correct secret rotates successfully — proves the earlier failures left
+	// the token untouched (also covers the session-bricking fix).
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "confidential refresh with correct secret must succeed")
+	refreshed := decode(t, resp)
+	assert.NotEmpty(t, refreshed["access_token"])
+	assert.NotEmpty(t, refreshed["refresh_token"])
+}
+
+// TestOAuthAuthzHardening_PublicRefreshStillWorks proves the confidential-auth
+// gate does not regress public clients: the existing public MCP client (no
+// secret) still rotates refresh tokens normally.
+func TestOAuthAuthzHardening_PublicRefreshStillWorks(t *testing.T) {
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, testMCPClientID, "user-pub-rt", testRedirectURI, challenge, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testMCPClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	rt := decode(t, resp)["refresh_token"].(string)
+
+	// Public client refreshes with NO client_secret — must still work.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt,
+		"client_id":     testMCPClientID,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "public client refresh must still work without a secret")
+	assert.NotEmpty(t, decode(t, resp)["access_token"])
+}
+
+// TestOAuthAuthzHardening_ScopelessClientCannotWiden proves finding #3: a
+// client_credentials client registered with an empty scope set cannot mint
+// arbitrary scopes by requesting them. Expect invalid_scope.
+// (Fails if intersectScopes' empty-allow-list passthrough is reached from
+// clientCredentials, i.e. if the deny guard is reverted.)
+func TestOAuthAuthzHardening_ScopelessClientCannotWiden(t *testing.T) {
+	agentID := uid("scopeless")
+	registerIdentity(t, agentID, []string{}) // identity with no scopes
+	client := registerOAuthClient(t, agentID, []string{})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "admin:everything billing:write",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "scope-less client must not be granted requested scopes")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestOAuthAuthzHardening_WrongClientIDDoesNotBrickSession proves finding #4:
+// a refresh presented with a WRONG client_id is rejected (invalid_grant) WITHOUT
+// consuming the token — the original refresh token (and thus the family) stays
+// usable. (Fails if the client_id binding check runs AFTER RotateRefreshToken.)
+func TestOAuthAuthzHardening_WrongClientIDDoesNotBrickSession(t *testing.T) {
+	// Use the existing public MCP client to mint a refresh token.
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, testMCPClientID, "user-brick", testRedirectURI, challenge, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testMCPClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	rt := decode(t, resp)["refresh_token"].(string)
+
+	// Refresh with the WRONG client_id → invalid_grant, token NOT consumed.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt,
+		"client_id":     "some-other-client",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "invalid_grant", decode(t, resp)["error"])
+
+	// The original token must STILL be usable with the correct client_id —
+	// the wrong-client_id attempt must not have bricked the session.
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": rt,
+		"client_id":     testMCPClientID,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"original refresh token must still be usable after a wrong-client_id attempt (session not bricked)")
+	refreshed := decode(t, resp)
+	assert.NotEmpty(t, refreshed["access_token"])
+	assert.NotEmpty(t, refreshed["refresh_token"])
+}
+
+// TestOAuthAuthzHardening_IntrospectionClientAuth proves finding #5 for
+// introspection (RFC 7662): a credentialed call with a WRONG secret is rejected
+// with invalid_client, a credentialed call with the CORRECT secret works, and
+// the existing tenant-header (no-credential) path is unchanged.
+func TestOAuthAuthzHardening_IntrospectionClientAuth(t *testing.T) {
+	// Mint a token to introspect (client_credentials, scoped client).
+	agentID := uid("introspect-auth")
+	registerIdentity(t, agentID, []string{"data:read"})
+	client := registerOAuthClient(t, agentID, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	accessToken := decode(t, resp)["access_token"].(string)
+
+	// Credentialed introspection with a WRONG secret → invalid_client.
+	resp = post(t, "/oauth2/token/introspect", map[string]any{
+		"token":         accessToken,
+		"client_id":     client.ClientID,
+		"client_secret": "wrong-secret",
+	}, adminHeaders())
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "wrong-secret introspection must be rejected")
+	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
+
+	// Credentialed introspection with the CORRECT secret → active token.
+	resp = post(t, "/oauth2/token/introspect", map[string]any{
+		"token":         accessToken,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+	}, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, decode(t, resp)["active"].(bool), "correct-secret introspection must report the token active")
+
+	// Existing tenant-header path (NO client credentials) → unchanged.
+	result := introspect(t, accessToken)
+	assert.True(t, result["active"].(bool), "no-credential introspection (internal path) must still work")
+}
+
+// TestOAuthAuthzHardening_RevocationClientAuth proves finding #5 for revocation
+// (RFC 7009): a credentialed call with a WRONG secret is rejected with
+// invalid_client (the token is NOT revoked), while the existing no-credential
+// internal path still revokes (and preserves the RFC 7009 §2.2 200 contract).
+func TestOAuthAuthzHardening_RevocationClientAuth(t *testing.T) {
+	agentID := uid("revoke-auth")
+	registerIdentity(t, agentID, []string{"data:read"})
+	client := registerOAuthClient(t, agentID, []string{"data:read"})
+
+	mint := func() string {
+		resp := post(t, "/oauth2/token", map[string]any{
+			"grant_type":    "client_credentials",
+			"account_id":    testAccountID,
+			"project_id":    testProjectID,
+			"client_id":     client.ClientID,
+			"client_secret": client.ClientSecret,
+			"scope":         "data:read",
+		}, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		return decode(t, resp)["access_token"].(string)
+	}
+
+	// Wrong-secret revocation → invalid_client, token NOT revoked.
+	tokenA := mint()
+	resp := post(t, "/oauth2/token/revoke", map[string]any{
+		"token":         tokenA,
+		"client_id":     client.ClientID,
+		"client_secret": "wrong-secret",
+	}, adminHeaders())
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "wrong-secret revocation must be rejected")
+	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
+	// Token must still be active — the rejected call must not have revoked it.
+	assert.True(t, introspect(t, tokenA)["active"].(bool), "wrong-secret revocation must not revoke the token")
+
+	// Existing no-credential internal path → revokes, returns 200.
+	revokeResp := post(t, "/oauth2/token/revoke", map[string]string{"token": tokenA}, adminHeaders())
+	require.Equal(t, http.StatusOK, revokeResp.StatusCode, "no-credential revocation (internal path) must still return 200")
+	_ = revokeResp.Body.Close()
+	assert.False(t, introspect(t, tokenA)["active"].(bool), "no-credential revocation must revoke the token")
+}

--- a/tests/integration/oauth_authz_hardening_test.go
+++ b/tests/integration/oauth_authz_hardening_test.go
@@ -173,9 +173,13 @@ func TestOAuthAuthzHardening_ScopelessClientCannotWiden(t *testing.T) {
 }
 
 // TestOAuthAuthzHardening_WrongClientIDDoesNotBrickSession proves finding #4:
-// a refresh presented with a WRONG client_id is rejected (invalid_grant) WITHOUT
-// consuming the token — the original refresh token (and thus the family) stays
-// usable. (Fails if the client_id binding check runs AFTER RotateRefreshToken.)
+// a refresh presented with a WRONG client_id is rejected WITHOUT consuming the
+// token — the original refresh token (and thus the family) stays usable.
+// (Fails if the client_id binding check / client resolution runs AFTER
+// RotateRefreshToken.) The wrong client_id here is unknown, so per RFC 6749
+// §5.2 it's rejected as invalid_client at client resolution (fail-closed:
+// an unresolvable named client must not skip confidential-client auth) before
+// the token is ever touched.
 func TestOAuthAuthzHardening_WrongClientIDDoesNotBrickSession(t *testing.T) {
 	// Use the existing public MCP client to mint a refresh token.
 	verifier, challenge := buildPKCEPair(t)
@@ -190,14 +194,16 @@ func TestOAuthAuthzHardening_WrongClientIDDoesNotBrickSession(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	rt := decode(t, resp)["refresh_token"].(string)
 
-	// Refresh with the WRONG client_id → invalid_grant, token NOT consumed.
+	// Refresh with a WRONG (unknown) client_id → rejected, token NOT consumed.
+	// An unknown client is invalid_client per RFC 6749 §5.2; the security
+	// property under test is that the token survives the rejection.
 	resp = post(t, "/oauth2/token", map[string]any{
 		"grant_type":    "refresh_token",
 		"refresh_token": rt,
 		"client_id":     "some-other-client",
 	}, nil)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	assert.Equal(t, "invalid_grant", decode(t, resp)["error"])
+	assert.Equal(t, "invalid_client", decode(t, resp)["error"])
 
 	// The original token must STILL be usable with the correct client_id —
 	// the wrong-client_id attempt must not have bricked the session.

--- a/tests/integration/policy_ceiling_test.go
+++ b/tests/integration/policy_ceiling_test.go
@@ -1,0 +1,193 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the security finding that IssueCredential — documented as
+// "the authoritative chokepoint" — was a no-op whenever its caller didn't
+// supply IdentityPolicyID. Three issuance paths did exactly that:
+// RotateCredential, the admin /credentials/issue handler, and post-attestation
+// verification. The fix makes the chokepoint resolve the identity's policy
+// itself when none is passed, so a since-tightened ceiling is enforced on
+// every path, not just the OAuth grants that happened to resolve it.
+//
+// Each test below would PASS (i.e. the bypass would succeed) if the fix were
+// reverted — that's the property that makes them regression coverage rather
+// than mere happy-path checks.
+
+// seedCredential issues an initial credential for identityID via the admin
+// path and returns its credential ID. Used to seed a rotation target.
+func seedCredential(t *testing.T, identityID string, ttlSeconds int, scopes []string) string {
+	t.Helper()
+	body := map[string]any{
+		"identity_id": identityID,
+		"grant_type":  "client_credentials",
+	}
+	if ttlSeconds > 0 {
+		body["ttl_seconds"] = ttlSeconds
+	}
+	if len(scopes) > 0 {
+		body["scopes"] = scopes
+	}
+	resp := post(t, adminPath("/credentials/issue"), body, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "seedCredential: initial issue must succeed under permissive policy")
+	cred := decode(t, resp)["credential"].(map[string]any)
+	id, ok := cred["id"].(string)
+	require.True(t, ok, "seedCredential: response missing credential id")
+	require.NotEmpty(t, id)
+	return id
+}
+
+// TestPolicyCeiling_RotateEnforcesTightenedTTL is the load-bearing regression
+// for the RotateCredential bypass. Sequence:
+//
+//  1. Permissive policy (max_ttl=3600). Identity bound to it.
+//  2. Seed a credential with TTL=3600 — succeeds (within policy).
+//  3. Admin tightens the policy to max_ttl=60.
+//  4. Rotate the seeded credential. RotateCredential re-mints with the OLD
+//     TTL (3600), which now exceeds the tightened ceiling.
+//
+// Pre-fix: rotate left IdentityPolicyID empty, the chokepoint skipped policy
+// enforcement entirely, and the rotate succeeded — re-minting a 3600s token
+// the security team had since capped at 60s. Post-fix: the chokepoint resolves
+// the (now-tightened) policy and rejects the over-TTL re-issue.
+func TestPolicyCeiling_RotateEnforcesTightenedTTL(t *testing.T) {
+	policyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("ceiling-rotate-ttl-cp"),
+		"allowed_grant_types":  []string{"client_credentials"},
+		"max_ttl_seconds":      3600,
+		"max_delegation_depth": 1,
+	}, adminHeaders())
+
+	identityID := registerIdentityWithPolicy(t, uid("ceiling-rotate-ttl"), policyID, "", nil, adminHeaders())
+
+	credID := seedCredential(t, identityID, 3600, nil)
+
+	// Tighten the ceiling well below the seeded credential's TTL.
+	patchCredentialPolicy(t, policyID, map[string]any{
+		"max_ttl_seconds": 60,
+	}, adminHeaders())
+
+	resp := post(t, adminPath("/credentials/"+credID+"/rotate"), nil, adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.NotEqual(t, http.StatusCreated, resp.StatusCode,
+		"rotate must NOT re-mint a credential whose inherited TTL exceeds the since-tightened policy ceiling")
+	assert.GreaterOrEqual(t, resp.StatusCode, 400,
+		"rotate against a tightened TTL ceiling must fail, not silently re-issue the old TTL")
+}
+
+// TestPolicyCeiling_RotateEnforcesGrantType pins the grant-type axis on the
+// rotate path. The seeded credential is client_credentials; after the policy
+// is tightened to forbid that grant type, rotation (which re-mints with the
+// old grant type) must be rejected at the chokepoint.
+func TestPolicyCeiling_RotateEnforcesGrantType(t *testing.T) {
+	policyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("ceiling-rotate-gt-cp"),
+		"allowed_grant_types":  []string{"client_credentials"},
+		"max_ttl_seconds":      3600,
+		"max_delegation_depth": 1,
+	}, adminHeaders())
+
+	identityID := registerIdentityWithPolicy(t, uid("ceiling-rotate-gt"), policyID, "", nil, adminHeaders())
+
+	credID := seedCredential(t, identityID, 600, nil)
+
+	// Tighten: drop client_credentials from the allow-list (only token_exchange
+	// permitted now). The seeded credential's grant type is no longer allowed.
+	patchCredentialPolicy(t, policyID, map[string]any{
+		"allowed_grant_types": []string{"token_exchange"},
+	}, adminHeaders())
+
+	resp := post(t, adminPath("/credentials/"+credID+"/rotate"), nil, adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.GreaterOrEqual(t, resp.StatusCode, 400,
+		"rotate must be rejected when the inherited grant type is no longer permitted by the tightened policy")
+}
+
+// TestPolicyCeiling_AdminIssueEnforcesTightenedTTL pins the admin
+// /credentials/issue path. The handler clamps TTL only against the
+// service-wide maxTTL (90 days in the test config), NOT the identity's policy
+// — so before the fix an operator could request a 3600s token against an
+// identity whose policy caps TTL at 60s and the chokepoint would let it
+// through. Post-fix the resolved policy rejects it.
+func TestPolicyCeiling_AdminIssueEnforcesTightenedTTL(t *testing.T) {
+	policyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("ceiling-issue-ttl-cp"),
+		"allowed_grant_types":  []string{"client_credentials"},
+		"max_ttl_seconds":      60,
+		"max_delegation_depth": 1,
+	}, adminHeaders())
+
+	identityID := registerIdentityWithPolicy(t, uid("ceiling-issue-ttl"), policyID, "", nil, adminHeaders())
+
+	// Request a TTL above the policy ceiling (60s) but well below the
+	// service maxTTL (90 days), so only policy enforcement can reject it.
+	resp := post(t, adminPath("/credentials/issue"), map[string]any{
+		"identity_id": identityID,
+		"grant_type":  "client_credentials",
+		"ttl_seconds": 3600,
+	}, adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.NotEqual(t, http.StatusCreated, resp.StatusCode,
+		"admin issue must NOT mint a token whose TTL exceeds the identity policy ceiling")
+	assert.GreaterOrEqual(t, resp.StatusCode, 400,
+		"admin issue against an over-TTL request must fail at the policy ceiling")
+}
+
+// TestPolicyCeiling_AdminIssueEnforcesGrantType pins the grant-type axis on
+// the admin issue path: requesting a grant type the identity's policy forbids
+// must be rejected even though the admin handler itself does no grant-type
+// check.
+func TestPolicyCeiling_AdminIssueEnforcesGrantType(t *testing.T) {
+	policyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("ceiling-issue-gt-cp"),
+		"allowed_grant_types":  []string{"token_exchange"},
+		"max_ttl_seconds":      3600,
+		"max_delegation_depth": 1,
+	}, adminHeaders())
+
+	identityID := registerIdentityWithPolicy(t, uid("ceiling-issue-gt"), policyID, "", nil, adminHeaders())
+
+	// Policy permits only token_exchange; request client_credentials.
+	resp := post(t, adminPath("/credentials/issue"), map[string]any{
+		"identity_id": identityID,
+		"grant_type":  "client_credentials",
+		"ttl_seconds": 60,
+	}, adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.GreaterOrEqual(t, resp.StatusCode, 400,
+		"admin issue must reject a grant type the identity policy forbids")
+}
+
+// TestPolicyCeiling_NoPolicyStillIssues is the don't-fail-closed guard. An
+// identity bound to the tenant default policy (the normal case when no
+// explicit policy is configured) must still issue and rotate cleanly with a
+// reasonable TTL — the chokepoint's self-resolution must fall back to the
+// permissive default exactly as ResolveCredentialPolicy does, never reject a
+// tenant that simply never set a custom policy.
+func TestPolicyCeiling_NoPolicyStillIssues(t *testing.T) {
+	// Omit credential_policy_id → identity is bound to the tenant default.
+	identityID := registerIdentityWithPolicy(t, uid("ceiling-no-policy"), "", "", nil, adminHeaders())
+
+	resp := post(t, adminPath("/credentials/issue"), map[string]any{
+		"identity_id": identityID,
+		"grant_type":  "client_credentials",
+		"ttl_seconds": 600,
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode,
+		"identity with no custom policy must still issue under the permissive tenant default")
+	credID := decode(t, resp)["credential"].(map[string]any)["id"].(string)
+	require.NotEmpty(t, credID)
+
+	// And rotation of that credential must also succeed — the chokepoint's
+	// self-resolution must not turn the default-policy case into a rejection.
+	rotateResp := post(t, adminPath("/credentials/"+credID+"/rotate"), nil, adminHeaders())
+	require.Equal(t, http.StatusCreated, rotateResp.StatusCode,
+		"rotating a credential under the permissive tenant default must succeed")
+	rotateResp.Body.Close()
+}

--- a/zeroid.yaml
+++ b/zeroid.yaml
@@ -3,11 +3,20 @@
 
 server:
   port: "8899"
+  # env gates production-only safety checks in Validate(): when set to
+  # "production" (or "prod"), ZeroID refuses to start with the unsafe dev
+  # attestation stub on or with the built-in default issuer / wimse_domain
+  # left unchanged. Leave as "development" for local/test.
   env: development
   read_timeout: "15s"
   write_timeout: "15s"
   idle_timeout: "60s"
   shutdown_timeout_seconds: 30
+  # Trust X-Forwarded-Proto / X-Forwarded-Host when reconstructing the
+  # request URL for DPoP htu validation (RFC 9449 §4.3). Set true ONLY
+  # behind a trusted edge proxy that strips client-supplied values;
+  # leave false when ZeroID terminates TLS itself. Env: ZEROID_TRUST_FORWARDED_HEADERS
+  trust_forwarded_headers: false
 
 database:
   url: "postgres://zeroid:zeroid@localhost:5432/zeroid?sslmode=disable"
@@ -39,6 +48,12 @@ token:
   issuer: "http://localhost:8899"
   default_ttl: 3600
   max_ttl: 7776000  # 90 days
+  # hmac_secret signs/verifies stateless authorization_code JWTs (HS256).
+  # Only needed if the authorization_code grant is enabled. When set it
+  # MUST be at least 32 bytes (Validate() rejects shorter secrets — a short
+  # secret is forgeable, and a leak forges auth codes). Prefer the env var
+  # ZEROID_HMAC_SECRET over committing a secret to YAML.
+  # hmac_secret: ""
 
 wimse_domain: "highflame.ai"
 
@@ -48,10 +63,12 @@ wimse_domain: "highflame.ai"
 
 telemetry:
   enabled: false
-  endpoint: "localhost:4317"
-  insecure: true
   service_name: "zeroid"
   sampling_rate: 1.0
+  # NOTE: exporter endpoint / TLS are NOT configured here. They are read
+  # by the OTel SDK from the standard env vars OTEL_EXPORTER_OTLP_ENDPOINT
+  # and OTEL_EXPORTER_OTLP_INSECURE. The old telemetry.endpoint /
+  # telemetry.insecure keys were removed — setting them now fails startup.
 
 logging:
   level: "debug"
@@ -65,3 +82,21 @@ logging:
 # ZEROID_ALLOW_UNSAFE_DEV_STUB=false).
 attestation:
   allow_unsafe_dev_stub: true
+  # Relaxes the SSRF guard the OIDC verifier applies to a proof's issuer
+  # endpoint (the URL it fetches OIDC discovery + JWKS from). Default false
+  # rejects issuers resolving to private/loopback/link-local IPs. Set true
+  # ONLY in single-tenant dev/test where the attestation issuer is itself
+  # on localhost / a private network. Production MUST keep this false.
+  # Env: ZEROID_ATTESTATION_ALLOW_PRIVATE_ISSUER_ENDPOINTS
+  allow_private_issuer_endpoints: false
+
+# CIBA (OpenID Client-Initiated Backchannel Authentication) settings.
+backchannel:
+  # Relaxes the SSRF guard on CIBA outbound client_notification_endpoint
+  # destinations. Default false rejects endpoints resolving to
+  # private/loopback/link-local IPs (re-checked at request time as a
+  # DNS-rebinding defense). Set true ONLY in single-tenant dev/test that
+  # registers endpoints like https://localhost:9000/. Production MUST keep
+  # this false (see GHSA-599q-j34m-33vc).
+  # Env: ZEROID_BACKCHANNEL_ALLOW_PRIVATE_ENDPOINTS
+  allow_private_notification_endpoints: false

--- a/zeroid.yaml
+++ b/zeroid.yaml
@@ -55,6 +55,18 @@ token:
   # ZEROID_HMAC_SECRET over committing a secret to YAML.
   # hmac_secret: ""
 
+  # allow_unauthenticated_token_inspection controls whether the introspection
+  # (RFC 7662) and revocation (RFC 7009) endpoints accept anonymous callers.
+  # true  → accept-and-verify: anonymous allowed, presented client credentials
+  #         still verified. Suitable for a standalone, network-isolated
+  #         deployment or local development.
+  # false → strict: a caller MUST present client credentials; anonymous calls
+  #         are rejected with invalid_client (RFC 7662 §2.1 / RFC 7009 §2.1).
+  # Default true, BUT Validate() rejects true when server.env=production, so
+  # production is spec-compliant (strict) by default. Env override:
+  # ZEROID_ALLOW_UNAUTHENTICATED_TOKEN_INSPECTION.
+  allow_unauthenticated_token_inspection: true
+
 wimse_domain: "highflame.ai"
 
 # Admin routes (/api/v1/*) have no built-in auth.


### PR DESCRIPTION
## Summary

Closes the medium-severity backlog from the deep security review (the critical cluster shipped in #197 as well as Closes #201). Built as six disjoint-file workstreams, integrated, and reviewed end-to-end before this PR. Full suite green under \`-race\` (696 tests); \`golangci-lint\` clean.

## What's fixed

**OAuth grant & endpoint client auth** (\`internal/service/oauth.go\`, \`internal/handler/oauth.go\`, \`internal/service/refresh_token.go\`)
- Confidential clients must now present \`client_secret\` on the **refresh_token** and **authorization_code** grants (RFC 6749 §6/§4.1.3/§10.4). Public/PKCE clients unchanged.
- **Introspection** (RFC 7662) and **revocation** (RFC 7009) now *verify* client credentials when presented (wrong secret → \`invalid_client\`); the existing internal/network-isolated path (no credentials) is preserved — non-breaking for that deployment model.
- **Scope-less client_credentials clients can no longer widen** — an empty registered scope set is deny, not allow-all (RFC 6749 §3.3).
- **Refresh-rotation no longer bricks a session.** A non-consuming \`PeekRefreshToken\` runs the client_id binding + identity-status gates *before* rotation consumes the token, so a transient failure (wrong client_id, briefly-suspended identity, DB blip) no longer trips reuse-detection and revokes the family. Unresolvable \`client_id\` fails closed (\`invalid_client\`) rather than skipping confidential-client auth.

**Policy ceiling** (\`internal/service/credential.go\`, \`internal/handler/credential.go\`, \`internal/service/attestation.go\`)
- The identity-policy ceiling (TTL / grant-type / delegation depth / attestation / scope) is now enforced on the three issuance paths that previously bypassed it: \`RotateCredential\`, the admin issue handler, and post-attestation issuance. Implemented via an opt-in \`IssueRequest.ResolveIdentityPolicy\` so the client-mediated grant paths (authcode/refresh/CIBA with no linked identity) keep their existing client-gated behavior — no over-reach.

**CIBA hardening** (\`internal/service/backchannel.go\`, \`internal/store/postgres/backchannel_request.go\`)
- \`Redeem\` requires a non-empty \`client_id\` and always compares it to the row (omitting it no longer skips the ownership check).
- Approved-but-unredeemed requests are bounded by \`expires_at\` + a grace window (enforced consistently across \`Redeem\`, \`MarkIssued\`, and \`DeleteExpired\`) instead of being redeemable forever.
- \`bc-authorize\` requires confidential-client auth and rejects deactivated clients.

**Attestation OIDC SSRF** (\`internal/attestation/oidc.go\`, \`internal/attestation/policy.go\`)
- Issuer discovery **and** the discovery-provided \`jwks_uri\` fetch now reject private / loopback / link-local / CGN / cloud-metadata IPs, with a dial-time re-check (DNS-rebind defense). The loopback-over-HTTP carve-out is gated behind a new \`AllowPrivateIssuerEndpoints\` flag (default **false**).

**Unbounded table growth** (\`internal/worker/cleanup.go\`, \`internal/store/postgres/refresh_token.go\`, migration \`032\`)
- Expired refresh tokens and signing credentials are now swept; refresh-token deletion lags the reuse-detection grace window so forensics aren't lost. Adds \`refresh_tokens(expires_at)\` index.

**Config hardening** (\`config.go\`, \`zeroid.yaml\`)
- Unparseable bool/int/float env values now **fail loud** at startup (a typo'd \`ZEROID_ALLOW_UNSAFE_DEV_STUB=flase\` no longer silently keeps the stub on).
- \`attestation.allow_unsafe_dev_stub=true\` and the default \`issuer\`/\`wimse_domain\` are **rejected when \`server.env == production\`** (gives the previously-dead \`server.env\` key a job); dev/test keep working.
- \`hmac_secret\` gets a ≥32-byte validation when set; new env mappings for \`hmac_secret\`, \`trust_forwarded_headers\`, \`backchannel.allow_private_notification_endpoints\`, and the attestation SSRF flag; removed telemetry keys now caught by \`rejectRemovedKeys\`.

## ⚠️ Behavior changes deployers should audit

1. **Confidential clients must authenticate** on refresh_token / authorization_code / CIBA bc-authorize. A confidential client that previously relied on PKCE/possession alone will get \`invalid_client\` until it sends its secret.
2. **client_credentials clients registered with zero scopes** are now rejected (\`invalid_scope\`) instead of receiving whatever they request.
3. **CIBA token requests must include \`client_id\`** (per CIBA Core §11) — a poller that omitted it will now be rejected.
4. **Production deployments must set an explicit issuer + wimse_domain and disable the dev stub** (these were silently defaulting).

## Testing

New tests pin each fix and were verified to fail with the fix reverted: \`oauth_authz_hardening_test.go\`, \`policy_ceiling_test.go\`, \`ciba_hardening_test.go\`, \`cleanup_sweep_test.go\`, \`internal/attestation/oidc_ssrf_test.go\`, plus \`config_test.go\` cases. Full unit + integration suite passes under \`-race\` (696 tests); CI now runs unit tests with the race detector (from #197).

## Review

Ran security + correctness review passes over the full diff before opening. Findings addressed: refresh-grant fails closed on an unresolvable client_id (was a confidential-auth-skip edge); confirmed no secret-hash persistence/leak on the CIBA path; stale code comment refreshed. No critical/high findings outstanding.