### PR TITLE
feat: add metadata filter to identity/agent list

### DIFF
--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -90,6 +90,7 @@ type ListAgentsInput struct {
 	TrustLevel   string   `query:"trust_level" doc:"Filter by trust level"`
 	IsActive     string   `query:"is_active" doc:"Filter by active status"`
 	Search       string   `query:"search" doc:"Search by name or external_id"`
+	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
 	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
 	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
@@ -357,7 +358,7 @@ func (a *API) listAgentsOp(ctx context.Context, input *ListAgentsInput) (*ListAg
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Limit, input.Offset)
+	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Limit, input.Offset)
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -69,6 +69,7 @@ type ListIdentitiesInput struct {
 	TrustLevel   string   `query:"trust_level" doc:"Filter by trust level"`
 	IsActive     string   `query:"is_active" doc:"Filter by active status"`
 	Search       string   `query:"search" doc:"Search by name or external_id"`
+	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
 	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
 	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
@@ -333,7 +334,7 @@ func (a *API) listIdentitiesOp(ctx context.Context, input *ListIdentitiesInput) 
 	}
 	offset := max(input.Offset, 0)
 
-	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, limit, offset)
+	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, limit, offset)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list identities")
 		return nil, huma.Error500InternalServerError("failed to list identities")

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -245,8 +245,9 @@ func (s *AgentService) GetAgent(ctx context.Context, id, accountID, projectID st
 	return &resp, nil
 }
 
-// ListAgents lists agents for a tenant, optionally filtered by identity_type(s) and label.
-func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search string, limit, offset int) (*AgentListResponse, error) {
+// ListAgents lists agents for a tenant, optionally filtered by identity_type(s),
+// label, and metadata (key presence or key:value).
+func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata string, limit, offset int) (*AgentListResponse, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
@@ -254,7 +255,7 @@ func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID stri
 		offset = 0
 	}
 
-	identities, total, err := s.identitySvc.ListIdentities(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, limit, offset)
+	identities, total, err := s.identitySvc.ListIdentities(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -312,9 +312,10 @@ func (s *IdentityService) GetIdentityByWIMSEURI(ctx context.Context, wimseURI, a
 	return identity, nil
 }
 
-// ListIdentities returns identities for a tenant, optionally filtered by identity_type(s) and label.
-func (s *IdentityService) ListIdentities(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search string, limit, offset int) ([]*domain.Identity, int, error) {
-	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, limit, offset)
+// ListIdentities returns identities for a tenant, optionally filtered by
+// identity_type(s), label, and metadata (key presence or key:value).
+func (s *IdentityService) ListIdentities(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata string, limit, offset int) ([]*domain.Identity, int, error) {
+	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, limit, offset)
 }
 
 // ListExpiringSoon returns active identities whose expires_at falls within

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -104,10 +104,17 @@ func (r *IdentityRepository) GetByWIMSEURI(ctx context.Context, wimseURI, accoun
 	return identity, nil
 }
 
-// List returns identities for a tenant, optionally filtered by identity_type(s) and label.
-// The label parameter accepts "key:value" format (e.g. "product:guardrails", "team:platform")
-// and filters using JSONB containment: labels @> {"key": "value"}.
-func (r *IdentityRepository) List(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search string, limit, offset int) ([]*domain.Identity, int, error) {
+// List returns identities for a tenant, optionally filtered by identity_type(s),
+// label, and metadata.
+//
+// The label parameter accepts "key:value" format (e.g. "product:guardrails") and
+// filters using JSONB containment: labels @> {"key": "value"}.
+//
+// The metadata parameter accepts either "key" — key presence (jsonb_exists) — or
+// "key:value" — containment (metadata @> {"key": "value"}). Key-presence is used
+// e.g. to list identities that have a redteam_target object configured, whose
+// value is not a scalar and so can't be matched by containment.
+func (r *IdentityRepository) List(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata string, limit, offset int) ([]*domain.Identity, int, error) {
 	var identities []*domain.Identity
 	db := dbOrTx(ctx, r.db)
 	q := db.NewSelect().Model(&identities).
@@ -127,6 +134,19 @@ func (r *IdentityRepository) List(ctx context.Context, accountID, projectID stri
 		}
 		labelJSON, _ := json.Marshal(map[string]string{parts[0]: parts[1]})
 		q = q.Where("labels @> ?::jsonb", string(labelJSON))
+	}
+	if metadata != "" {
+		parts := strings.SplitN(metadata, ":", 2)
+		if parts[0] == "" {
+			return nil, 0, fmt.Errorf("invalid metadata filter: expected key or key:value, got %q", metadata)
+		}
+		if len(parts) == 2 {
+			metaJSON, _ := json.Marshal(map[string]string{parts[0]: parts[1]})
+			q = q.Where("metadata @> ?::jsonb", string(metaJSON))
+		} else {
+			// key-presence: identities whose metadata has this top-level key.
+			q = q.Where("jsonb_exists(metadata, ?)", parts[0])
+		}
 	}
 	if trustLevel != "" {
 		q = q.Where("trust_level = ?", trustLevel)


### PR DESCRIPTION
## What

Adds a `metadata` query param to `GET /agents` and `GET /identities`:

- `metadata=key` → **key presence** (`jsonb_exists(metadata, key)`) — e.g. `metadata=redteam_target`
- `metadata=key:value` → **containment** (`metadata @> {"key":"value"}`)

Threaded `handler → service (ListAgents / ListIdentities) → store List`. Uses the existing GIN index on `identities.metadata`.

## Why

The redteam dashboard's "configured targets" = identities carrying a `metadata.redteam_target` object. There was **no server-side metadata filter**, so Studio fetched all identities — capped at 100 server-side — and filtered client-side. Tenants with >100 identities saw **0 configured targets** (the targets sit beyond the first page; `created_at DESC` puts older targets last).

Key presence (not `key:value` containment) is required because `redteam_target` is a nested **object** — containment can't match it.

With this, Studio can request only the configured set:
```
GET /agents?metadata=redteam_target&is_active=true
```

## Validation

- `go build ./...` + `go vet ./internal/...` clean; existing service tests pass; `gofmt` clean.
- **Against dev1 `highflame_authn`:** `jsonb_exists(metadata, 'redteam_target')` returns **84 (54 active)** — the exact configured-target set, identical to the `metadata ? 'redteam_target'` operator.

## Before releasing

The store has no DB test harness, so this was validated against real data rather than a unit test. Recommend the standard local-downstream check (authn with a `go.mod replace` → this branch, `curl '/v1/auth/agents?metadata=redteam_target'`) before cutting a zeroid version.

## Follow-up

A Studio change will switch the redteam configured-targets views from the interim fetch-all (`useAllIdentities`) to this server-side filter once a zeroid version ships (highflame-studio#939 is the interim fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)