### PR TITLE
fix: add expired identity status for subagent lifecycle

### DIFF
--- a/domain/identity.go
+++ b/domain/identity.go
@@ -198,11 +198,11 @@ func (s IdentityStatus) CanTransitionTo(target IdentityStatus) bool {
 	case IdentityStatusActive:
 		return target == IdentityStatusSuspended || target == IdentityStatusDeactivated || target == IdentityStatusExpired
 	case IdentityStatusSuspended:
-		return target == IdentityStatusActive || target == IdentityStatusDeactivated
+		return target == IdentityStatusActive || target == IdentityStatusDeactivated || target == IdentityStatusExpired
 	case IdentityStatusDeactivated:
 		return target == IdentityStatusActive
 	case IdentityStatusExpired:
-		return false // terminal
+		return target == IdentityStatusDeactivated
 	default:
 		return false
 	}

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -170,6 +170,7 @@ func (s SubType) ValidForIdentityType(t IdentityType) bool {
 //
 //	pending → active → suspended → active (reactivation)
 //	                 → deactivated (terminal)
+//	                 → expired (terminal — time-bound authority lapsed)
 //	pending → deactivated (registration rejected)
 type IdentityStatus string
 
@@ -178,11 +179,12 @@ const (
 	IdentityStatusActive      IdentityStatus = "active"
 	IdentityStatusSuspended   IdentityStatus = "suspended"
 	IdentityStatusDeactivated IdentityStatus = "deactivated"
+	IdentityStatusExpired     IdentityStatus = "expired"
 )
 
 func (s IdentityStatus) Valid() bool {
 	switch s {
-	case IdentityStatusPending, IdentityStatusActive, IdentityStatusSuspended, IdentityStatusDeactivated:
+	case IdentityStatusPending, IdentityStatusActive, IdentityStatusSuspended, IdentityStatusDeactivated, IdentityStatusExpired:
 		return true
 	}
 	return false
@@ -194,11 +196,13 @@ func (s IdentityStatus) CanTransitionTo(target IdentityStatus) bool {
 	case IdentityStatusPending:
 		return target == IdentityStatusActive || target == IdentityStatusDeactivated
 	case IdentityStatusActive:
-		return target == IdentityStatusSuspended || target == IdentityStatusDeactivated
+		return target == IdentityStatusSuspended || target == IdentityStatusDeactivated || target == IdentityStatusExpired
 	case IdentityStatusSuspended:
 		return target == IdentityStatusActive || target == IdentityStatusDeactivated
 	case IdentityStatusDeactivated:
 		return target == IdentityStatusActive
+	case IdentityStatusExpired:
+		return false // terminal
 	default:
 		return false
 	}
@@ -439,6 +443,7 @@ func GetIdentitySchema() *IdentitySchema {
 			{Value: string(IdentityStatusActive), Label: "Active", Description: "Fully operational"},
 			{Value: string(IdentityStatusSuspended), Label: "Suspended", Description: "Temporarily disabled"},
 			{Value: string(IdentityStatusDeactivated), Label: "Deactivated", Description: "Permanently disabled"},
+		{Value: string(IdentityStatusExpired), Label: "Expired", Description: "Time-bound authority lapsed"},
 		},
 	}
 }

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -443,7 +443,7 @@ func GetIdentitySchema() *IdentitySchema {
 			{Value: string(IdentityStatusActive), Label: "Active", Description: "Fully operational"},
 			{Value: string(IdentityStatusSuspended), Label: "Suspended", Description: "Temporarily disabled"},
 			{Value: string(IdentityStatusDeactivated), Label: "Deactivated", Description: "Permanently disabled"},
-		{Value: string(IdentityStatusExpired), Label: "Expired", Description: "Time-bound authority lapsed"},
+			{Value: string(IdentityStatusExpired), Label: "Expired", Description: "Time-bound authority lapsed"},
 		},
 	}
 }

--- a/domain/identity_test.go
+++ b/domain/identity_test.go
@@ -53,6 +53,50 @@ func TestValidateWIMSEURI(t *testing.T) {
 	})
 }
 
+// TestIdentityStatusExpired_Valid confirms expired is a valid status.
+func TestIdentityStatusExpired_Valid(t *testing.T) {
+	if !IdentityStatusExpired.Valid() {
+		t.Fatal("IdentityStatusExpired.Valid() = false, want true")
+	}
+}
+
+// TestIdentityStatusExpired_IsUsable confirms expired identities cannot authenticate.
+func TestIdentityStatusExpired_IsUsable(t *testing.T) {
+	if IdentityStatusExpired.IsUsable() {
+		t.Fatal("IdentityStatusExpired.IsUsable() = true, want false")
+	}
+}
+
+// TestCanTransitionTo_Expired pins the expired state machine transitions.
+func TestCanTransitionTo_Expired(t *testing.T) {
+	tests := []struct {
+		from   IdentityStatus
+		to     IdentityStatus
+		expect bool
+	}{
+		// Into expired
+		{IdentityStatusActive, IdentityStatusExpired, true},
+		{IdentityStatusSuspended, IdentityStatusExpired, true},
+		{IdentityStatusPending, IdentityStatusExpired, false},
+		{IdentityStatusDeactivated, IdentityStatusExpired, false},
+		// Out of expired
+		{IdentityStatusExpired, IdentityStatusDeactivated, true},
+		{IdentityStatusExpired, IdentityStatusActive, false},
+		{IdentityStatusExpired, IdentityStatusSuspended, false},
+		{IdentityStatusExpired, IdentityStatusPending, false},
+		{IdentityStatusExpired, IdentityStatusExpired, false},
+	}
+	for _, tc := range tests {
+		name := string(tc.from) + " → " + string(tc.to)
+		t.Run(name, func(t *testing.T) {
+			got := tc.from.CanTransitionTo(tc.to)
+			if got != tc.expect {
+				t.Fatalf("CanTransitionTo = %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}
+
 // TestBuildWIMSEURI_LengthCap pins the SPIFFE §2.4 invariant: any URI that
 // would exceed MaxSPIFFEIDBytes is rejected at construction time, returning
 // ErrSPIFFEIDTooLong so callers can errors.Is. Three cases — happy path, the

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -179,6 +179,15 @@ func (a *API) registerIdentityRoutes(api huma.API) {
 		Description: "Soft-deletes the identity and returns the deactivated record. The published SDKs (highflame on PyPI, @highflame/sdk on npm) parse the response as an Identity, so this must stay 200 + body — a 204 breaks them.",
 		Tags:        []string{"Identities"},
 	}, a.deleteIdentityOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "expire-identity",
+		Method:      http.MethodPost,
+		Path:        "/identities/{id}/expire",
+		Summary:     "Expire an active identity (time-bound authority lapsed)",
+		Description: "Transitions an active identity to expired status and runs cleanup (revoke credentials, API keys, emit CAE signal). Used by Cerberus on subagent session stop.",
+		Tags:        []string{"Identities"},
+	}, a.expireIdentityOp)
 }
 
 type IdentitySchemaOutput struct {
@@ -431,6 +440,21 @@ func (a *API) deleteIdentityOp(ctx context.Context, input *IdentityIDInput) (*Id
 	identity, err := a.identitySvc.DeactivateIdentity(ctx, input.ID, tenant.AccountID, tenant.ProjectID)
 	if err != nil {
 		log.Error().Err(err).Str("identity_id", input.ID).Msg("failed to deactivate identity")
+		return nil, mapErr(err)
+	}
+
+	return &IdentityOutput{Body: identity}, nil
+}
+
+func (a *API) expireIdentityOp(ctx context.Context, input *IdentityIDInput) (*IdentityOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	identity, err := a.identitySvc.ExpireIdentity(ctx, input.ID, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		log.Error().Err(err).Str("identity_id", input.ID).Msg("failed to expire identity")
 		return nil, mapErr(err)
 	}
 

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -560,13 +560,13 @@ func (s *IdentityService) SweepExpiredIdentities(ctx context.Context) (int, erro
 	ctx = middleware.SetCallerName(ctx, middleware.SystemCallerPrefix+"expired_sweep")
 	count := 0
 	for _, row := range expired {
-		claimed, identity, err := s.repo.ExpireIfActive(ctx, row.ID, row.AccountID, row.ProjectID)
+		claimed, identity, err := s.repo.DeactivateIfActive(ctx, row.ID, row.AccountID, row.ProjectID)
 		if err != nil {
 			log.Warn().Err(err).
 				Str("identity_id", row.ID).
 				Str("account_id", row.AccountID).
 				Str("project_id", row.ProjectID).
-				Msg("sweep: failed to expire identity")
+				Msg("sweep: failed to deactivate expired identity")
 			continue
 		}
 		if !claimed {
@@ -576,7 +576,7 @@ func (s *IdentityService) SweepExpiredIdentities(ctx context.Context) (int, erro
 		count++
 	}
 	if count > 0 {
-		log.Info().Int("count", count).Msg("sweep: expired identities")
+		log.Info().Int("count", count).Msg("sweep: deactivated expired identities")
 	}
 	return count, nil
 }

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -468,13 +468,18 @@ func (s *IdentityService) UpdateIdentity(ctx context.Context, id, accountID, pro
 		return nil, err
 	}
 
-	// Fresh transition into deactivated: sweep linked API keys, cascade-revoke
-	// active credentials, and emit a retirement signal. Centralized here so
-	// every update path (PUT /identities/{id}, AgentService.DeactivateAgent,
-	// or any programmatic caller) runs the same cleanup.
+	// Fresh transition into deactivated or expired: sweep linked API keys,
+	// cascade-revoke active credentials, and emit a retirement/expiry signal.
+	// Centralized here so every update path (PUT /identities/{id},
+	// AgentService.DeactivateAgent, or any programmatic caller) runs the same
+	// cleanup.
 	if priorStatus != domain.IdentityStatusDeactivated &&
 		identity.Status == domain.IdentityStatusDeactivated {
 		s.runDeactivationCleanup(ctx, identity, "identity_deactivated")
+	}
+	if priorStatus != domain.IdentityStatusExpired &&
+		identity.Status == domain.IdentityStatusExpired {
+		s.runDeactivationCleanup(ctx, identity, "expired")
 	}
 	return identity, nil
 }
@@ -555,13 +560,13 @@ func (s *IdentityService) SweepExpiredIdentities(ctx context.Context) (int, erro
 	ctx = middleware.SetCallerName(ctx, middleware.SystemCallerPrefix+"expired_sweep")
 	count := 0
 	for _, row := range expired {
-		claimed, identity, err := s.repo.DeactivateIfActive(ctx, row.ID, row.AccountID, row.ProjectID)
+		claimed, identity, err := s.repo.ExpireIfActive(ctx, row.ID, row.AccountID, row.ProjectID)
 		if err != nil {
 			log.Warn().Err(err).
 				Str("identity_id", row.ID).
 				Str("account_id", row.AccountID).
 				Str("project_id", row.ProjectID).
-				Msg("sweep: failed to deactivate expired identity")
+				Msg("sweep: failed to expire identity")
 			continue
 		}
 		if !claimed {
@@ -571,7 +576,7 @@ func (s *IdentityService) SweepExpiredIdentities(ctx context.Context) (int, erro
 		count++
 	}
 	if count > 0 {
-		log.Info().Int("count", count).Msg("sweep: deactivated expired identities")
+		log.Info().Int("count", count).Msg("sweep: expired identities")
 	}
 	return count, nil
 }
@@ -630,6 +635,28 @@ func (s *IdentityService) DeactivateIdentity(ctx context.Context, id, accountID,
 	}
 
 	status := domain.IdentityStatusDeactivated
+
+	updated, err := s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}
+
+// ExpireIdentity transitions an active identity to expired. It runs the same
+// cleanup cascade as deactivation (revoke keys, credentials, emit CAE signal).
+func (s *IdentityService) ExpireIdentity(ctx context.Context, id, accountID, projectID string) (*domain.Identity, error) {
+	identity, err := s.repo.GetByID(ctx, id, accountID, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	if identity.Status == domain.IdentityStatusExpired {
+		return identity, nil
+	}
+
+	status := domain.IdentityStatusExpired
 
 	updated, err := s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
 	if err != nil {

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -277,38 +277,6 @@ func (r *IdentityRepository) DeactivateIfActive(ctx context.Context, id, account
 	return true, identity, nil
 }
 
-// ExpireIfActive atomically transitions an active identity to expired. Returns
-// (true, identity) when the row was claimed, (false, nil) when someone else
-// already transitioned it.
-func (r *IdentityRepository) ExpireIfActive(ctx context.Context, id, accountID, projectID string) (claimed bool, identity *domain.Identity, err error) {
-	db := dbOrTx(ctx, r.db)
-	identity = &domain.Identity{}
-	q := db.NewUpdate().Model(identity).
-		Set("status = ?", string(domain.IdentityStatusExpired)).
-		Set("updated_at = ?", time.Now())
-	if callerID := middleware.GetCallerName(ctx); callerID != "" {
-		q = q.Set("modified_by = ?", callerID)
-	}
-	res, err := q.
-		Where("id = ?", id).
-		Where("account_id = ?", accountID).
-		Where("project_id = ?", projectID).
-		Where("status = ?", string(domain.IdentityStatusActive)).
-		Returning("*").
-		Exec(ctx)
-	if err != nil {
-		return false, nil, fmt.Errorf("expire-if-active: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return false, nil, fmt.Errorf("expire-if-active rows: %w", err)
-	}
-	if n == 0 {
-		return false, nil, nil
-	}
-	return true, identity, nil
-}
-
 // ListExpiredActive returns identities whose expires_at has passed while
 // their status is still 'active'. Used by the cleanup worker's identity
 // sweep. The partial index on (expires_at) WHERE status='active' makes

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -277,6 +277,38 @@ func (r *IdentityRepository) DeactivateIfActive(ctx context.Context, id, account
 	return true, identity, nil
 }
 
+// ExpireIfActive atomically transitions an active identity to expired. Returns
+// (true, identity) when the row was claimed, (false, nil) when someone else
+// already transitioned it.
+func (r *IdentityRepository) ExpireIfActive(ctx context.Context, id, accountID, projectID string) (claimed bool, identity *domain.Identity, err error) {
+	db := dbOrTx(ctx, r.db)
+	identity = &domain.Identity{}
+	q := db.NewUpdate().Model(identity).
+		Set("status = ?", string(domain.IdentityStatusExpired)).
+		Set("updated_at = ?", time.Now())
+	if callerID := middleware.GetCallerName(ctx); callerID != "" {
+		q = q.Set("modified_by = ?", callerID)
+	}
+	res, err := q.
+		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("status = ?", string(domain.IdentityStatusActive)).
+		Returning("*").
+		Exec(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("expire-if-active: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, nil, fmt.Errorf("expire-if-active rows: %w", err)
+	}
+	if n == 0 {
+		return false, nil, nil
+	}
+	return true, identity, nil
+}
+
 // ListExpiredActive returns identities whose expires_at has passed while
 // their status is still 'active'. Used by the cleanup worker's identity
 // sweep. The partial index on (expires_at) WHERE status='active' makes

--- a/migrations/032_identity_status_expired.down.sql
+++ b/migrations/032_identity_status_expired.down.sql
@@ -1,0 +1,8 @@
+-- Revert: remove 'expired' from the identity status CHECK constraint.
+-- Any rows with status='expired' must be updated first.
+UPDATE identities SET status = 'deactivated' WHERE status = 'expired';
+
+ALTER TABLE identities
+    DROP CONSTRAINT identities_status_check,
+    ADD CONSTRAINT identities_status_check
+        CHECK (status IN ('pending', 'active', 'suspended', 'deactivated'));

--- a/migrations/032_identity_status_expired.up.sql
+++ b/migrations/032_identity_status_expired.up.sql
@@ -1,0 +1,6 @@
+-- Add 'expired' to the identity status CHECK constraint.
+-- Subagent identities transition to 'expired' on session stop.
+ALTER TABLE identities
+    DROP CONSTRAINT identities_status_check,
+    ADD CONSTRAINT identities_status_check
+        CHECK (status IN ('pending', 'active', 'suspended', 'deactivated', 'expired'));


### PR DESCRIPTION
## Summary
Adds `expired` as a first-class identity status for subagent lifecycle. When a subagent session stops, Cerberus calls the new expire endpoint to transition the identity from active → expired, with full cleanup cascade (revoke credentials, API keys, emit CAE signal).

## Changes
- `domain/identity.go` — new `IdentityStatusExpired` constant, state machine: `active → expired`, `suspended → expired`, `expired → deactivated` (terminal, no reactivation)
- `internal/service/identity.go` — new `ExpireIdentity` service method reusing `UpdateIdentity` + `runDeactivationCleanup`; cleanup now triggers on expired transition too
- `internal/handler/identity.go` — new `POST /identities/{id}/expire` endpoint
- `migrations/032_identity_status_expired` — adds `expired` to the `identities_status_check` CHECK constraint
- `domain/identity_test.go` — tests for `Valid()`, `IsUsable()`, and all `CanTransitionTo` expired transitions
- Sweep worker unchanged — continues to deactivate (not expire) time-lapsed identities; expired is only set by the explicit endpoint

## Test plan
- [x] `go test ./domain/...` passes (all transition cases covered)
- [x] Migration 032 applies cleanly (tested locally)
- [x] `POST /identities/{id}/expire` returns 200 with expired identity (verified end-to-end)
- [x] Non-subagent identities unaffected — sweep still uses DeactivateIfActive

Resolves highflame-ai/highflame-studio#956

🤖 Generated with [Claude Code](https://claude.com/claude-code)