### PR TITLE
fix: add identity origin filter + facets endpoint for registry

### DIFF
--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -92,7 +92,7 @@ type ListAgentsInput struct {
 	IsActive     string   `query:"is_active" doc:"Filter by active status"`
 	Search       string   `query:"search" doc:"Search by name or external_id"`
 	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
-	Origin       string   `query:"origin" doc:"Filter by creation origin: \"manual\" (user-created, no created_via) or \"auto\" (auto-created via hooks)"`
+	IdentityClass string  `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
 	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
 	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
@@ -372,11 +372,11 @@ func (a *API) listAgentsOp(ctx context.Context, input *ListAgentsInput) (*ListAg
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	if input.Origin != "" && input.Origin != "manual" && input.Origin != "auto" {
-		return nil, huma.Error400BadRequest("invalid origin: must be manual or auto")
+	if input.IdentityClass != "" && input.IdentityClass != "custom" && input.IdentityClass != "code_agent" {
+		return nil, huma.Error400BadRequest("invalid identity_class: must be custom or code_agent")
 	}
 
-	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Origin, input.Limit, input.Offset)
+	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.IdentityClass, input.Limit, input.Offset)
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -91,6 +91,7 @@ type ListAgentsInput struct {
 	IsActive     string   `query:"is_active" doc:"Filter by active status"`
 	Search       string   `query:"search" doc:"Search by name or external_id"`
 	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
+	Origin       string   `query:"origin" doc:"Filter by creation origin: \"manual\" (user-created, no created_via) or \"auto\" (auto-created via hooks)"`
 	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
 	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
@@ -358,7 +359,7 @@ func (a *API) listAgentsOp(ctx context.Context, input *ListAgentsInput) (*ListAg
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Limit, input.Offset)
+	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Origin, input.Limit, input.Offset)
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -85,16 +85,16 @@ type GetAgentOutput struct {
 }
 
 type ListAgentsInput struct {
-	AgentType    string   `query:"agent_type" doc:"Filter by agent type"`
-	IdentityType []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
-	Label        string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
-	TrustLevel   string   `query:"trust_level" doc:"Filter by trust level"`
-	IsActive     string   `query:"is_active" doc:"Filter by active status"`
-	Search       string   `query:"search" doc:"Search by name or external_id"`
-	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
-	IdentityClass string  `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
-	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
-	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
+	AgentType     string   `query:"agent_type" doc:"Filter by agent type"`
+	IdentityType  []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
+	Label         string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
+	TrustLevel    string   `query:"trust_level" doc:"Filter by trust level"`
+	IsActive      string   `query:"is_active" doc:"Filter by active status"`
+	Search        string   `query:"search" doc:"Search by name or external_id"`
+	Metadata      string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
+	IdentityClass string   `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
+	Limit         int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
+	Offset        int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
 
 type ListAgentsOutput struct {

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -359,6 +359,10 @@ func (a *API) listAgentsOp(ctx context.Context, input *ListAgentsInput) (*ListAg
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
+	if input.Origin != "" && input.Origin != "manual" && input.Origin != "auto" {
+		return nil, huma.Error400BadRequest("invalid origin: must be manual or auto")
+	}
+
 	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Origin, input.Limit, input.Offset)
 	if err != nil {
 		return nil, mapErr(err)

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/highflame-ai/zeroid/domain"
 	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
 	"github.com/highflame-ai/zeroid/internal/service"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
 // mapErr converts service-layer errors to huma errors with proper HTTP status codes.
@@ -100,6 +101,10 @@ type ListAgentsOutput struct {
 	Body *service.AgentListResponse
 }
 
+type AgentFacetsOutput struct {
+	Body *postgres.IdentityFacets
+}
+
 type UpdateAgentInput struct {
 	ID   string `path:"id" doc:"Agent identity UUID"`
 	Body struct {
@@ -162,6 +167,14 @@ func (a *API) registerAgentRoutes(api huma.API) {
 		Summary:     "List agents for the current tenant",
 		Tags:        []string{"Agents"},
 	}, a.listAgentsOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "agent-facets",
+		Method:      http.MethodGet,
+		Path:        "/agents/registry/facets",
+		Summary:     "Get aggregated filter counts for identity dimensions",
+		Tags:        []string{"Agents"},
+	}, a.agentFacetsOp)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "update-agent",
@@ -369,6 +382,20 @@ func (a *API) listAgentsOp(ctx context.Context, input *ListAgentsInput) (*ListAg
 	}
 
 	return &ListAgentsOutput{Body: resp}, nil
+}
+
+func (a *API) agentFacetsOp(ctx context.Context, input *struct{}) (*AgentFacetsOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	facets, err := a.agentSvc.GetIdentityFacets(ctx, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+
+	return &AgentFacetsOutput{Body: facets}, nil
 }
 
 func (a *API) updateAgentOp(ctx context.Context, input *UpdateAgentInput) (*GetAgentOutput, error) {

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -335,6 +335,10 @@ func (a *API) listIdentitiesOp(ctx context.Context, input *ListIdentitiesInput) 
 	}
 	offset := max(input.Offset, 0)
 
+	if input.Origin != "" && input.Origin != "manual" && input.Origin != "auto" {
+		return nil, huma.Error400BadRequest("invalid origin: must be manual or auto")
+	}
+
 	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Origin, limit, offset)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list identities")

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -70,6 +70,7 @@ type ListIdentitiesInput struct {
 	IsActive     string   `query:"is_active" doc:"Filter by active status"`
 	Search       string   `query:"search" doc:"Search by name or external_id"`
 	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
+	Origin       string   `query:"origin" doc:"Filter by creation origin: \"manual\" (user-created, no created_via) or \"auto\" (auto-created via hooks)"`
 	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
 	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
@@ -334,7 +335,7 @@ func (a *API) listIdentitiesOp(ctx context.Context, input *ListIdentitiesInput) 
 	}
 	offset := max(input.Offset, 0)
 
-	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, limit, offset)
+	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Origin, limit, offset)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list identities")
 		return nil, huma.Error500InternalServerError("failed to list identities")

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -70,7 +70,7 @@ type ListIdentitiesInput struct {
 	IsActive     string   `query:"is_active" doc:"Filter by active status"`
 	Search       string   `query:"search" doc:"Search by name or external_id"`
 	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
-	Origin       string   `query:"origin" doc:"Filter by creation origin: \"manual\" (user-created, no created_via) or \"auto\" (auto-created via hooks)"`
+	IdentityClass string  `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
 	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
 	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
@@ -335,11 +335,11 @@ func (a *API) listIdentitiesOp(ctx context.Context, input *ListIdentitiesInput) 
 	}
 	offset := max(input.Offset, 0)
 
-	if input.Origin != "" && input.Origin != "manual" && input.Origin != "auto" {
-		return nil, huma.Error400BadRequest("invalid origin: must be manual or auto")
+	if input.IdentityClass != "" && input.IdentityClass != "custom" && input.IdentityClass != "code_agent" {
+		return nil, huma.Error400BadRequest("invalid identity_class: must be custom or code_agent")
 	}
 
-	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.Origin, limit, offset)
+	identities, total, err := a.identitySvc.ListIdentities(ctx, tenant.AccountID, tenant.ProjectID, input.IdentityType, input.Label, input.TrustLevel, input.IsActive, input.Search, input.Metadata, input.IdentityClass, limit, offset)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list identities")
 		return nil, huma.Error500InternalServerError("failed to list identities")

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -64,15 +64,15 @@ type GetIdentityByWIMSEInput struct {
 }
 
 type ListIdentitiesInput struct {
-	IdentityType []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
-	Label        string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
-	TrustLevel   string   `query:"trust_level" doc:"Filter by trust level"`
-	IsActive     string   `query:"is_active" doc:"Filter by active status"`
-	Search       string   `query:"search" doc:"Search by name or external_id"`
-	Metadata     string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
-	IdentityClass string  `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
-	Limit        int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
-	Offset       int      `query:"offset" default:"0" doc:"Offset for pagination"`
+	IdentityType  []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
+	Label         string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
+	TrustLevel    string   `query:"trust_level" doc:"Filter by trust level"`
+	IsActive      string   `query:"is_active" doc:"Filter by active status"`
+	Search        string   `query:"search" doc:"Search by name or external_id"`
+	Metadata      string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
+	IdentityClass string   `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
+	Limit         int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
+	Offset        int      `query:"offset" default:"0" doc:"Offset for pagination"`
 }
 
 type IdentityListOutput struct {

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -259,7 +259,7 @@ func (s *AgentService) GetAgent(ctx context.Context, id, accountID, projectID st
 
 // ListAgents lists agents for a tenant, optionally filtered by identity_type(s),
 // label, and metadata (key presence or key:value).
-func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata string, limit, offset int) (*AgentListResponse, error) {
+func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, origin string, limit, offset int) (*AgentListResponse, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
@@ -267,7 +267,7 @@ func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID stri
 		offset = 0
 	}
 
-	identities, total, err := s.identitySvc.ListIdentities(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, limit, offset)
+	identities, total, err := s.identitySvc.ListIdentities(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, origin, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -304,6 +304,11 @@ func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID stri
 	}, nil
 }
 
+// GetIdentityFacets returns grouped counts for each filterable identity dimension.
+func (s *AgentService) GetIdentityFacets(ctx context.Context, accountID, projectID string) (*postgres.IdentityFacets, error) {
+	return s.identitySvc.GetFacets(ctx, accountID, projectID)
+}
+
 // UpdateAgent updates an agent identity with PATCH semantics.
 func (s *AgentService) UpdateAgent(ctx context.Context, id, accountID, projectID string, req UpdateAgentRequest) (*AgentResponse, error) {
 	var subType domain.SubType

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -259,7 +259,7 @@ func (s *AgentService) GetAgent(ctx context.Context, id, accountID, projectID st
 
 // ListAgents lists agents for a tenant, optionally filtered by identity_type(s),
 // label, and metadata (key presence or key:value).
-func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, origin string, limit, offset int) (*AgentListResponse, error) {
+func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, identityClass string, limit, offset int) (*AgentListResponse, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
@@ -267,7 +267,7 @@ func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID stri
 		offset = 0
 	}
 
-	identities, total, err := s.identitySvc.ListIdentities(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, origin, limit, offset)
+	identities, total, err := s.identitySvc.ListIdentities(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, identityClass, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -314,8 +314,8 @@ func (s *IdentityService) GetIdentityByWIMSEURI(ctx context.Context, wimseURI, a
 
 // ListIdentities returns identities for a tenant, optionally filtered by
 // identity_type(s), label, and metadata (key presence or key:value).
-func (s *IdentityService) ListIdentities(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata string, limit, offset int) ([]*domain.Identity, int, error) {
-	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, limit, offset)
+func (s *IdentityService) ListIdentities(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, origin string, limit, offset int) ([]*domain.Identity, int, error) {
+	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, origin, limit, offset)
 }
 
 // ListExpiringSoon returns active identities whose expires_at falls within

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -314,8 +314,8 @@ func (s *IdentityService) GetIdentityByWIMSEURI(ctx context.Context, wimseURI, a
 
 // ListIdentities returns identities for a tenant, optionally filtered by
 // identity_type(s), label, and metadata (key presence or key:value).
-func (s *IdentityService) ListIdentities(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, origin string, limit, offset int) ([]*domain.Identity, int, error) {
-	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, origin, limit, offset)
+func (s *IdentityService) ListIdentities(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, identityClass string, limit, offset int) ([]*domain.Identity, int, error) {
+	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, identityClass, limit, offset)
 }
 
 // GetFacets returns grouped counts for each filterable identity dimension.

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -318,6 +318,11 @@ func (s *IdentityService) ListIdentities(ctx context.Context, accountID, project
 	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevel, isActive, search, metadata, origin, limit, offset)
 }
 
+// GetFacets returns grouped counts for each filterable identity dimension.
+func (s *IdentityService) GetFacets(ctx context.Context, accountID, projectID string) (*postgres.IdentityFacets, error) {
+	return s.repo.GetFacets(ctx, accountID, projectID)
+}
+
 // ListExpiringSoon returns active identities whose expires_at falls within
 // now..now+within. Used by GET /expiring-soon.
 func (s *IdentityService) ListExpiringSoon(ctx context.Context, accountID, projectID string, now time.Time, within time.Duration) ([]*domain.Identity, error) {

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -114,7 +114,7 @@ func (r *IdentityRepository) GetByWIMSEURI(ctx context.Context, wimseURI, accoun
 // "key:value" — containment (metadata @> {"key": "value"}). Key-presence is used
 // e.g. to list identities that have a redteam_target object configured, whose
 // value is not a scalar and so can't be matched by containment.
-func (r *IdentityRepository) List(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata string, limit, offset int) ([]*domain.Identity, int, error) {
+func (r *IdentityRepository) List(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, origin string, limit, offset int) ([]*domain.Identity, int, error) {
 	var identities []*domain.Identity
 	db := dbOrTx(ctx, r.db)
 	q := db.NewSelect().Model(&identities).
@@ -147,6 +147,12 @@ func (r *IdentityRepository) List(ctx context.Context, accountID, projectID stri
 			// key-presence: identities whose metadata has this top-level key.
 			q = q.Where("jsonb_exists(metadata, ?)", parts[0])
 		}
+	}
+	switch origin {
+	case "manual":
+		q = q.Where("NOT jsonb_exists(metadata, 'created_via')")
+	case "auto":
+		q = q.Where("jsonb_exists(metadata, 'created_via')")
 	}
 	if trustLevel != "" {
 		q = q.Where("trust_level = ?", trustLevel)

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -197,11 +197,11 @@ type FacetValue struct {
 
 // IdentityFacets holds grouped counts for identity filter dimensions.
 type IdentityFacets struct {
-	IdentityTypes []FacetValue `json:"identity_types"`
-	TrustLevels   []FacetValue `json:"trust_levels"`
-	Statuses      []FacetValue `json:"statuses"`
+	IdentityTypes   []FacetValue `json:"identity_types"`
+	TrustLevels     []FacetValue `json:"trust_levels"`
+	Statuses        []FacetValue `json:"statuses"`
 	IdentityClasses []FacetValue `json:"identity_classes"`
-	CreatedBy     []FacetValue `json:"created_by"`
+	CreatedBy       []FacetValue `json:"created_by"`
 }
 
 // GetFacets returns grouped counts for each filterable dimension, scoped to a tenant.

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -114,7 +114,7 @@ func (r *IdentityRepository) GetByWIMSEURI(ctx context.Context, wimseURI, accoun
 // "key:value" — containment (metadata @> {"key": "value"}). Key-presence is used
 // e.g. to list identities that have a redteam_target object configured, whose
 // value is not a scalar and so can't be matched by containment.
-func (r *IdentityRepository) List(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, origin string, limit, offset int) ([]*domain.Identity, int, error) {
+func (r *IdentityRepository) List(ctx context.Context, accountID, projectID string, identityTypes []string, label, trustLevel, isActive, search, metadata, identityClass string, limit, offset int) ([]*domain.Identity, int, error) {
 	var identities []*domain.Identity
 	db := dbOrTx(ctx, r.db)
 	q := db.NewSelect().Model(&identities).
@@ -148,10 +148,10 @@ func (r *IdentityRepository) List(ctx context.Context, accountID, projectID stri
 			q = q.Where("jsonb_exists(metadata, ?)", parts[0])
 		}
 	}
-	switch origin {
-	case "manual":
+	switch identityClass {
+	case "custom":
 		q = q.Where("NOT jsonb_exists(metadata, 'created_via')")
-	case "auto":
+	case "code_agent":
 		q = q.Where("jsonb_exists(metadata, 'created_via')")
 	}
 	if trustLevel != "" {
@@ -200,7 +200,7 @@ type IdentityFacets struct {
 	IdentityTypes []FacetValue `json:"identity_types"`
 	TrustLevels   []FacetValue `json:"trust_levels"`
 	Statuses      []FacetValue `json:"statuses"`
-	Origins       []FacetValue `json:"origins"`
+	IdentityClasses []FacetValue `json:"identity_classes"`
 	CreatedBy     []FacetValue `json:"created_by"`
 }
 
@@ -254,20 +254,20 @@ func (r *IdentityRepository) GetFacets(ctx context.Context, accountID, projectID
 	}
 	facets.Statuses = statusFacets
 
-	// origin (manual vs auto-created, based on metadata.created_via)
-	var originFacets []FacetValue
+	// identity class (custom vs code_agent, based on metadata.created_via)
+	var classFacets []FacetValue
 	err = db.NewSelect().TableExpr("identities").
-		ColumnExpr("CASE WHEN jsonb_exists(metadata, 'created_via') THEN 'auto' ELSE 'manual' END AS value").
+		ColumnExpr("CASE WHEN jsonb_exists(metadata, 'created_via') THEN 'code_agent' ELSE 'custom' END AS value").
 		ColumnExpr("COUNT(*) AS count").
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
-		GroupExpr("CASE WHEN jsonb_exists(metadata, 'created_via') THEN 'auto' ELSE 'manual' END").
+		GroupExpr("CASE WHEN jsonb_exists(metadata, 'created_via') THEN 'code_agent' ELSE 'custom' END").
 		OrderExpr("count DESC").
-		Scan(ctx, &originFacets)
+		Scan(ctx, &classFacets)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get origin facets: %w", err)
+		return nil, fmt.Errorf("failed to get identity_class facets: %w", err)
 	}
-	facets.Origins = originFacets
+	facets.IdentityClasses = classFacets
 
 	// created_by (owner_user_id)
 	var createdByFacets []FacetValue

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -189,6 +189,105 @@ func (r *IdentityRepository) List(ctx context.Context, accountID, projectID stri
 	return identities, total, nil
 }
 
+// FacetValue is a single value+count pair in a faceted aggregation.
+type FacetValue struct {
+	Value string `json:"value"`
+	Count int    `json:"count"`
+}
+
+// IdentityFacets holds grouped counts for identity filter dimensions.
+type IdentityFacets struct {
+	IdentityTypes []FacetValue `json:"identity_types"`
+	TrustLevels   []FacetValue `json:"trust_levels"`
+	Statuses      []FacetValue `json:"statuses"`
+	Origins       []FacetValue `json:"origins"`
+	CreatedBy     []FacetValue `json:"created_by"`
+}
+
+// GetFacets returns grouped counts for each filterable dimension, scoped to a tenant.
+func (r *IdentityRepository) GetFacets(ctx context.Context, accountID, projectID string) (*IdentityFacets, error) {
+	db := dbOrTx(ctx, r.db)
+	facets := &IdentityFacets{}
+
+	// identity_type
+	var typeFacets []FacetValue
+	err := db.NewSelect().TableExpr("identities").
+		ColumnExpr("identity_type AS value").
+		ColumnExpr("COUNT(*) AS count").
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		GroupExpr("identity_type").
+		OrderExpr("count DESC").
+		Scan(ctx, &typeFacets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get identity_type facets: %w", err)
+	}
+	facets.IdentityTypes = typeFacets
+
+	// trust_level
+	var trustFacets []FacetValue
+	err = db.NewSelect().TableExpr("identities").
+		ColumnExpr("trust_level AS value").
+		ColumnExpr("COUNT(*) AS count").
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		GroupExpr("trust_level").
+		OrderExpr("count DESC").
+		Scan(ctx, &trustFacets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get trust_level facets: %w", err)
+	}
+	facets.TrustLevels = trustFacets
+
+	// status
+	var statusFacets []FacetValue
+	err = db.NewSelect().TableExpr("identities").
+		ColumnExpr("status AS value").
+		ColumnExpr("COUNT(*) AS count").
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		GroupExpr("status").
+		OrderExpr("count DESC").
+		Scan(ctx, &statusFacets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get status facets: %w", err)
+	}
+	facets.Statuses = statusFacets
+
+	// origin (manual vs auto-created, based on metadata.created_via)
+	var originFacets []FacetValue
+	err = db.NewSelect().TableExpr("identities").
+		ColumnExpr("CASE WHEN jsonb_exists(metadata, 'created_via') THEN 'auto' ELSE 'manual' END AS value").
+		ColumnExpr("COUNT(*) AS count").
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		GroupExpr("CASE WHEN jsonb_exists(metadata, 'created_via') THEN 'auto' ELSE 'manual' END").
+		OrderExpr("count DESC").
+		Scan(ctx, &originFacets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get origin facets: %w", err)
+	}
+	facets.Origins = originFacets
+
+	// created_by (owner_user_id)
+	var createdByFacets []FacetValue
+	err = db.NewSelect().TableExpr("identities").
+		ColumnExpr("COALESCE(NULLIF(owner_user_id, ''), created_by) AS value").
+		ColumnExpr("COUNT(*) AS count").
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("COALESCE(NULLIF(owner_user_id, ''), created_by) != ''").
+		GroupExpr("COALESCE(NULLIF(owner_user_id, ''), created_by)").
+		OrderExpr("count DESC").
+		Scan(ctx, &createdByFacets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get created_by facets: %w", err)
+	}
+	facets.CreatedBy = createdByFacets
+
+	return facets, nil
+}
+
 // Update saves changes to an existing identity. Participates in a caller-
 // provided transaction via postgres.WithTx(ctx, tx); falls through to a
 // single auto-commit update otherwise.


### PR DESCRIPTION
## Summary
- Adds `identity_class` query parameter to `/agents` and `/identities` list endpoints (`custom` / `code_agent`)
- Adds `GET /agents/registry/facets` endpoint returning grouped counts for all filterable dimensions (identity_type, trust_level, status, identity_class, created_by)
- Validates `identity_class` param — returns 400 for invalid values
- Uses existing GIN-indexed `metadata` JSONB column — no migration needed

## Changes
- `store/postgres/identity.go` — `GetFacets()` with 5 GROUP BY queries + identity_class filter in `List()`
- `service/identity.go` + `service/agent.go` — passthrough methods
- `handler/agent.go` + `handler/identity.go` — identity_class param + facets handler + route

## Test plan
- [ ] `GET /agents?identity_class=custom` returns only user-created identities (no `metadata.created_via`)
- [ ] `GET /agents?identity_class=code_agent` returns only auto-registered identities (`metadata.created_via` present)
- [ ] `GET /agents?identity_class=invalid` returns 400
- [ ] `GET /agents/registry/facets` returns correct counts for all dimensions
- [ ] Omitting `identity_class` returns all identities (backwards compatible)

Resolves highflame-ai/highflame-studio#981, highflame-ai/highflame-studio#956

🤖 Generated with [Claude Code](https://claude.com/claude-code)