### PR TITLE
fix: sweep expired refresh_tokens to bound table growth

### DIFF
--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -18,7 +18,8 @@ type IdentityExpirer interface {
 }
 
 // CleanupWorker periodically removes expired issued_credentials, proof_tokens,
-// and auth_codes rows, and sweeps expired identities into status=deactivated
+// auth_codes, refresh_tokens, and dpop_jti rows, and sweeps expired identities
+// into status=deactivated
 // via IdentityService.SweepExpiredIdentities (an atomic conditional UPDATE
 // claim followed by the existing runDeactivationCleanup cascade).
 // Running the cleanup prevents unbounded table growth since credentials have
@@ -126,6 +127,24 @@ func (w *CleanupWorker) RunOnce(ctx context.Context) {
 		log.Error().Err(err).Msg("Cleanup: failed to delete expired auth codes")
 	} else if n, err := authCodeRes.RowsAffected(); err == nil && n > 0 {
 		log.Info().Int64("count", n).Msg("Cleanup: deleted expired auth codes")
+	}
+
+	// Refresh tokens past expiry are unusable: every lookup requires
+	// expires_at > now (refresh_token.go GetByTokenHash/ClaimByTokenHash), and
+	// reuse detection only needs a revoked row while the token could still be
+	// replayed within its validity. Once expired, drop it — under rotation the
+	// table otherwise grows one row per refresh forever. Filter is backed by
+	// idx_refresh_tokens_expires_at (migration 033). No retention window: unlike
+	// issued_credentials (whose expired rows hold parent_jti edges the cascade
+	// walk still needs), refresh_tokens have no cross-row dependency.
+	refreshRes, err := w.db.NewDelete().
+		TableExpr("refresh_tokens").
+		Where("expires_at < ?", now).
+		Exec(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Cleanup: failed to delete expired refresh tokens")
+	} else if n, err := refreshRes.RowsAffected(); err == nil && n > 0 {
+		log.Info().Int64("count", n).Msg("Cleanup: deleted expired refresh tokens")
 	}
 
 	// DPoP JTIs are only needed within the freshness window (RFC 9449 §4.2).

--- a/migrations/033_refresh_tokens_expires_at_index.down.sql
+++ b/migrations/033_refresh_tokens_expires_at_index.down.sql
@@ -1,0 +1,5 @@
+-- 033_refresh_tokens_expires_at_index.down.sql
+-- Reverses 033: drops the refresh_tokens expiry index. The cleanup worker's
+-- sweep still functions without it (it just falls back to a sequential scan).
+
+DROP INDEX IF EXISTS idx_refresh_tokens_expires_at;

--- a/migrations/033_refresh_tokens_expires_at_index.up.sql
+++ b/migrations/033_refresh_tokens_expires_at_index.up.sql
@@ -1,0 +1,22 @@
+-- 033_refresh_tokens_expires_at_index.up.sql
+-- Index refresh_tokens.expires_at to support the cleanup worker's expiry sweep.
+--
+-- Under refresh-token rotation every refresh inserts a successor row and
+-- revokes its predecessor (RFC 6749 §6 / reuse detection). Nothing deleted
+-- those rows, so the table grew one row per refresh forever. The cleanup
+-- worker now deletes refresh_tokens whose expires_at is in the past (an
+-- expired refresh token is unusable: every lookup requires expires_at > now).
+-- That DELETE filters on expires_at, so without this index the sweep degrades
+-- to a full table scan as the table grows — defeating the purpose.
+--
+-- Mirrors idx_issued_credentials_expires_at (migration 001), which backs the
+-- analogous credential-expiry sweep.
+--
+-- Lock posture: plain CREATE INDEX (not CONCURRENTLY) because golang-migrate
+-- wraps each migration in a transaction and CONCURRENTLY cannot run inside
+-- one. The table is small relative to a hot OLTP table and this runs in the
+-- migration window; if it ever needs to run online, pull this statement out
+-- and rerun manually with CREATE INDEX CONCURRENTLY.
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at
+    ON refresh_tokens (expires_at);

--- a/tests/integration/refresh_token_cleanup_test.go
+++ b/tests/integration/refresh_token_cleanup_test.go
@@ -1,0 +1,60 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// TestCleanupWorkerSweepsExpiredRefreshTokens locks in migration 033 + the
+// cleanup sweep: a refresh_tokens row past expires_at is deleted, an
+// unexpired one survives. Without the sweep the table grows one row per
+// refresh forever (rotation inserts a successor and revokes its predecessor,
+// RFC 6749 §6).
+func TestCleanupWorkerSweepsExpiredRefreshTokens(t *testing.T) {
+	ctx := context.Background()
+	family := "33333333-3333-3333-3333-333333333333"
+
+	expired := &domain.RefreshToken{
+		TokenHash: uid("rt-expired"),
+		ClientID:  "test-client",
+		AccountID: "acct-rt-cleanup",
+		UserID:    "user-rt-cleanup",
+		FamilyID:  family,
+		State:     domain.RefreshTokenStateActive,
+		ExpiresAt: time.Now().Add(-time.Hour),
+	}
+	live := &domain.RefreshToken{
+		TokenHash: uid("rt-live"),
+		ClientID:  "test-client",
+		AccountID: "acct-rt-cleanup",
+		UserID:    "user-rt-cleanup",
+		FamilyID:  family,
+		State:     domain.RefreshTokenStateActive,
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+
+	_, err := testDB.NewInsert().Model(expired).Exec(ctx)
+	require.NoError(t, err)
+	_, err = testDB.NewInsert().Model(live).Exec(ctx)
+	require.NoError(t, err)
+
+	testZeroIDServer.RunCleanupOnce(ctx)
+
+	exists := func(hash string) bool {
+		n, err := testDB.NewSelect().
+			Model((*domain.RefreshToken)(nil)).
+			Where("token_hash = ?", hash).
+			Count(ctx)
+		require.NoError(t, err)
+		return n > 0
+	}
+
+	assert.False(t, exists(expired.TokenHash), "expired refresh token must be swept")
+	assert.True(t, exists(live.TokenHash), "unexpired refresh token must survive the sweep")
+}


### PR DESCRIPTION
## Problem

`refresh_tokens` grew **unbounded**. Under rotation, every refresh inserts a successor row and revokes its predecessor (RFC 6749 §6 / reuse detection), but nothing ever deleted the old rows. The cleanup worker reaps `issued_credentials`, `proof_tokens`, `auth_codes`, `dpop_jti`, and CIBA requests — refresh tokens were the one expiring table left out.

## Change

- **Cleanup sweep** (`internal/worker/cleanup.go`): `DELETE FROM refresh_tokens WHERE expires_at < now`. An expired refresh token is unusable — every lookup (`GetByTokenHash` / `ClaimByTokenHash`) already requires `expires_at > now`.
  - **No retention window.** Unlike `issued_credentials`, whose expired rows hold the `parent_jti` edges the cascade-revocation walk still needs, `refresh_tokens` have no cross-row dependency. Revoked-but-*unexpired* rows are kept — they're the reuse-detection tripwires for still-active families; only past-expiry rows drop.
- **Migration 033** adds `idx_refresh_tokens_expires_at` so the sweep filters on an index instead of a full table scan, mirroring `idx_issued_credentials_expires_at` (migration 001). Plain `CREATE INDEX` — golang-migrate wraps each migration in a transaction, so `CONCURRENTLY` can't run there.

## Test

`tests/integration/refresh_token_cleanup_test.go` — asserts an expired row is swept and an unexpired one survives. Passes locally (`GOEXPERIMENT=jsonv2 go test`).

## Note

A duplicate, never-committed `032_refresh_tokens_expires_at_index` (collided with the committed `032_identity_status_expired` from #208, and indexed for a sweep that didn't exist) was discarded in favor of this `033` that ships the index **and** the sweep together.