### PR TITLE
feat: direct OIDC IdP federation (closes #88)

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,8 @@ import (
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
+
+	"github.com/highflame-ai/zeroid/domain"
 )
 
 // DefaultAdminPathPrefix is the default URL prefix for admin API routes.
@@ -43,6 +45,13 @@ type Config struct {
 
 	// WIMSEDomain is the domain prefix for SPIFFE/WIMSE URIs (e.g. "zeroid.dev").
 	WIMSEDomain string `koanf:"wimse_domain"`
+
+	// ExternalIssuers configures direct OIDC IdP federation (issue #88).
+	// When grant_type=token-exchange and subject_token_type=id_token, ZeroID
+	// looks up the upstream iss in this list, fetches the issuer's JWKS, and
+	// verifies the ID token before minting a ZeroID token. Empty list (default)
+	// disables direct federation — only the broker path remains available.
+	ExternalIssuers []domain.ExternalIssuerConfig `koanf:"external_issuers"`
 }
 
 // BackchannelConfig governs CIBA (OpenID CIBA Core 1.0) behavior. All fields
@@ -377,6 +386,18 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("token.hmac_secret must be at least 32 bytes when set, got %d: it signs stateless auth-code JWTs (HS256) and a short secret is forgeable", len(c.Token.HMACSecret))
 	}
 
+	seen := make(map[string]struct{}, len(c.ExternalIssuers))
+	for i := range c.ExternalIssuers {
+		c.ExternalIssuers[i].Defaults()
+		if err := c.ExternalIssuers[i].Validate(); err != nil {
+			return fmt.Errorf("external_issuers[%d]: %w", i, err)
+		}
+		iss := c.ExternalIssuers[i].Issuer
+		if _, dup := seen[iss]; dup {
+			return fmt.Errorf("external_issuers[%d]: duplicate issuer %q", i, iss)
+		}
+		seen[iss] = struct{}{}
+	}
 	return nil
 }
 

--- a/docs/identity-model.md
+++ b/docs/identity-model.md
@@ -53,8 +53,7 @@ identity in the caller's tenant — same IDOR guard the broker path uses.
 | Claim            | Source                                              | Purpose                                                    |
 | ---------------- | --------------------------------------------------- | ---------------------------------------------------------- |
 | `iss`            | ZeroID's configured issuer                          | Standard.                                                  |
-| `sub`            | Upstream → `claim_mapping.user_id`                  | The principal — same identifier downstream services check. |
-| `user_id`        | Upstream → `claim_mapping.user_id`                  | Stable subject identifier.                                 |
+| `sub`            | Upstream → `claim_mapping.user_id`                  | The principal — the stable subject identifier downstream services check. (The token-endpoint JSON response also echoes it as `user_id`; the JWT itself carries it only as `sub`.) |
 | `user_id_iss`    | Upstream `iss`                                      | **IdP-granular provenance** — the headline addition.       |
 | `user_email`     | Upstream → `claim_mapping.email`                    | Optional.                                                  |
 | `user_name`      | Upstream → `claim_mapping.name`                     | Optional.                                                  |

--- a/docs/identity-model.md
+++ b/docs/identity-model.md
@@ -1,0 +1,160 @@
+# ZeroID identity model — composing claims from upstream IdPs
+
+ZeroID is an identity layer for autonomous agents and human users. When the
+calling principal is a human authenticated by an external OIDC provider
+(Okta, Entra ID, Auth0, Google Workspace, custom OIDC), there are two paths
+for getting that identity into a ZeroID-issued token:
+
+1. **Direct OIDC IdP federation** — the spec-aligned default. ZeroID itself
+   verifies the upstream IdP's ID token signature.
+2. **Trusted-service broker** — a fallback for narrow operational cases. A
+   deployer-controlled service does the IdP-side verification and tells
+   ZeroID who the user is.
+
+**For new deployments, default to direct federation.** The broker path
+remains available but is strictly lossier: it cannot answer the question
+"which IdP authenticated this user?" from the issued token alone.
+
+## Direct OIDC IdP federation (preferred)
+
+### What it is
+
+ZeroID accepts an upstream OIDC ID token at `/oauth2/token` via RFC 8693
+token exchange and verifies it directly against the issuer's published JWKS
+before minting a ZeroID-signed token.
+
+Standards anchor:
+
+- **RFC 8693 §3** defines `subject_token_type =
+urn:ietf:params:oauth:token-type:id_token` for exactly this case.
+- **RFC 9068** specifies `acr` / `amr` / `auth_time` as
+  authentication-context claims. These are only meaningful when the issuer
+  that authenticated the subject is the one that signed the claims.
+- **NIST SP 800-63C §4.1** requires federation assertions to name the IdP
+  that authenticated the subject — not an aggregator or relay.
+
+### Request shape
+
+```
+POST /oauth2/token
+  grant_type           = urn:ietf:params:oauth:grant-type:token-exchange
+  subject_token        = <upstream IdP's ID token>
+  subject_token_type   = urn:ietf:params:oauth:token-type:id_token
+  account_id           = <tenant>
+  project_id           = <tenant>
+  scope                = <optional>
+```
+
+`application_id` is optional. When present it must resolve to an active
+identity in the caller's tenant — same IDOR guard the broker path uses.
+
+### Issued-token claim shape
+
+| Claim            | Source                                              | Purpose                                                    |
+| ---------------- | --------------------------------------------------- | ---------------------------------------------------------- |
+| `iss`            | ZeroID's configured issuer                          | Standard.                                                  |
+| `sub`            | Upstream → `claim_mapping.user_id`                  | The principal — same identifier downstream services check. |
+| `user_id`        | Upstream → `claim_mapping.user_id`                  | Stable subject identifier.                                 |
+| `user_id_iss`    | Upstream `iss`                                      | **IdP-granular provenance** — the headline addition.       |
+| `user_email`     | Upstream → `claim_mapping.email`                    | Optional.                                                  |
+| `user_name`      | Upstream → `claim_mapping.name`                     | Optional.                                                  |
+| `auth_time`      | Upstream `auth_time` (when configured to propagate) | RFC 9068 — copied through, never synthesized.              |
+| `acr`            | Upstream `acr` (when configured to propagate)       | RFC 9068.                                                  |
+| `amr`            | Upstream `amr` (when configured to propagate)       | RFC 9068.                                                  |
+| `token_exchange` | Constant `external_id_token`                        | Distinguishes from the broker path's `external_principal`. |
+
+ZeroID never default-fills `auth_time` / `acr` / `amr`. If the upstream
+omitted them, they are absent from the issued token. Synthesizing them
+would defeat the entire point of carrying authentication-context claims.
+
+### Configuration
+
+```yaml
+external_issuers:
+  - issuer: "https://auth.example.okta.com"
+    jwks_uri: "https://auth.example.okta.com/.well-known/jwks.json"
+    audience: "https://zeroid.example.com"
+    algorithms: ["RS256", "ES256"] # default
+    max_token_age: 10m # iat must not exceed this
+    jwks_cache_ttl: 5m # JWKS refresh interval
+    claim_mapping:
+      user_id: sub # required
+      email: email # optional
+    allowed_accounts: ["acct-prod"] # empty = any tenant
+    propagate_claims: ["auth_time", "acr", "amr"]
+```
+
+The deployer is the trust anchor: only issuers listed here are accepted.
+There is no auto-discovery, no OIDF chain, no implicit trust.
+
+### Verification semantics
+
+For each request:
+
+1. The upstream `iss` is read from the subject_token (without verifying
+   yet) and looked up against the configured allowlist.
+2. The token's algorithm is checked against the issuer's `algorithms`
+   list. Anything outside the asymmetric RS/ES/PS family is rejected
+   regardless of configuration — `none` and HS-family tokens never reach
+   verification.
+3. `iss`, `aud`, `exp`, `nbf` are all enforced. `iat` is required and
+   capped by `max_token_age` to prevent replay of old tokens.
+4. The signature is verified against the cached JWKS. On unknown `kid` the
+   JWKS is refreshed once and verification is retried — covers upstream
+   key rotation without a server restart.
+5. Claim mapping extracts `user_id` (required), `email`, `name`. Missing
+   `user_id` is `invalid_grant`.
+6. `account_id` is checked against the issuer's `allowed_accounts` list.
+7. ZeroID issues an RS256 token (15-minute TTL) carrying the provenance
+   claims above.
+
+`TrustedServiceValidator` is not consulted on this path — the JWKS
+signature check, issuer allowlist, and audience binding are the trust
+proof.
+
+## Trusted-service broker (fallback)
+
+### What it is
+
+A deployer-controlled service authenticates the upstream user (perhaps
+because it already does OIDC for many backend services), then calls ZeroID
+with pre-validated user claims. ZeroID validates the **caller** via
+`TrustedServiceValidator` but does **not** re-verify the upstream JWT.
+
+### When to use it
+
+| Constraint                                                   | Use the broker                          |
+| ------------------------------------------------------------ | --------------------------------------- |
+| Existing gateway already does OIDC for many services         | ✅ avoids duplication                   |
+| Complex internal claim-normalization logic                   | ✅ keeps it out of ZeroID               |
+| Air-gapped / egress-restricted ZeroID                        | ✅ broker does the IdP call             |
+| Per-IdP provenance required (finance, healthcare, regulated) | ❌ insufficient — use direct federation |
+
+### Request shape
+
+```
+POST /oauth2/token
+  grant_type    = urn:ietf:params:oauth:grant-type:token-exchange
+  subject_token = <pre-validated jwt>      # NOT re-verified by ZeroID
+  account_id    = <tenant>
+  project_id    = <tenant>
+  user_id       = <external user ID>
+```
+
+`subject_token_type` is left blank (or anything other than `id_token`).
+The broker path is the default when `actor_token` is absent and the
+subject token type is not `id_token`.
+
+### Issued-token claim shape
+
+The broker path emits `trusted_by: <service-name>` instead of
+`user_id_iss`. Consumers can see _which service vouched_ but not _which
+IdP authenticated_. For regulated deployments where per-IdP provenance is
+required, this is insufficient — direct federation is the answer.
+
+## Choosing between paths
+
+If you can use direct federation, do. The broker path remains for the
+narrow operational cases above; for everything else direct federation is
+simpler, more spec-aligned, and carries strictly more information forward
+to downstream consumers.

--- a/domain/external_issuer.go
+++ b/domain/external_issuer.go
@@ -66,9 +66,10 @@ type ExternalIssuerConfig struct {
 	// PropagateClaims is the explicit allow-list of upstream claims to
 	// copy onto the issued ZeroID token. Only auth_time, acr, and amr are
 	// recognized in v1 — these are RFC 9068 authentication-context claims
-	// and only meaningful when copied through directly from the IdP.
-	// Anything else is ignored. We never default-fill these claims; if the
-	// upstream omitted them, ZeroID does not synthesize them.
+	// and only meaningful when copied through directly from the IdP. Any other
+	// entry is rejected by Validate() at config load. We never default-fill
+	// these claims; if the upstream omitted them, ZeroID does not synthesize
+	// them.
 	PropagateClaims []string `koanf:"propagate_claims"`
 
 	// AllowPrivateEndpoints relaxes the SSRF guard applied to this issuer's
@@ -107,8 +108,24 @@ func (e *ExternalIssuerConfig) Validate() error {
 	if e.JWKSCacheTTL < 0 {
 		return fmt.Errorf("external_issuer %s: jwks_cache_ttl must be > 0", e.Issuer)
 	}
+	// pkg/authjwt clamps refresh intervals below 30s; a configured value under
+	// that floor would be silently ignored, so reject it rather than surprise
+	// the deployer. Zero is allowed — Defaults() fills it with 5m.
+	if e.JWKSCacheTTL > 0 && e.JWKSCacheTTL < 30*time.Second {
+		return fmt.Errorf("external_issuer %s: jwks_cache_ttl must be at least 30s (got %s)", e.Issuer, e.JWKSCacheTTL)
+	}
 	if _, ok := e.ClaimMapping["user_id"]; !ok {
 		return fmt.Errorf("external_issuer %s: claim_mapping.user_id is required (need a stable subject identifier)", e.Issuer)
+	}
+	// Only RS256/ES256/PS256 are supported by the verifier (jwtalg's asymmetric
+	// allow-list). Reject unsupported entries at config load instead of failing
+	// every exchange at runtime.
+	for _, alg := range e.Algorithms {
+		switch alg {
+		case "RS256", "ES256", "PS256":
+		default:
+			return fmt.Errorf("external_issuer %s: algorithm %q is not supported (allowed: RS256, ES256, PS256)", e.Issuer, alg)
+		}
 	}
 	for _, claim := range e.PropagateClaims {
 		switch claim {
@@ -124,7 +141,9 @@ func (e *ExternalIssuerConfig) Validate() error {
 // fills zero-valued fields.
 func (e *ExternalIssuerConfig) Defaults() {
 	if len(e.Algorithms) == 0 {
-		e.Algorithms = []string{"RS256", "ES256"}
+		// PS256 alongside RS256/ES256: widely used by Google/Okta/Entra and
+		// recommended by FAPI, so it belongs in the out-of-the-box set.
+		e.Algorithms = []string{"RS256", "ES256", "PS256"}
 	}
 	if e.MaxTokenAge == 0 {
 		e.MaxTokenAge = 10 * time.Minute

--- a/domain/external_issuer.go
+++ b/domain/external_issuer.go
@@ -58,9 +58,16 @@ type ExternalIssuerConfig struct {
 	//	  email:   email
 	ClaimMapping map[string]string `koanf:"claim_mapping"`
 
-	// AllowedAccounts limits the tenants that may use this issuer. When
-	// non-empty, the request's account_id must appear in this list. Empty
-	// means any tenant may use it.
+	// AllowedAccounts is the REQUIRED, non-empty list of tenants permitted to
+	// exchange tokens from this issuer. The request's account_id must appear
+	// here. It is the only thing that binds an upstream ID token to a ZeroID
+	// tenant: the token's aud binds it to ZeroID-the-RP, not to a specific
+	// account, and account_id is caller-supplied on the (public) token
+	// endpoint — so a globally-trusted issuer with no tenant binding would let
+	// a token validly issued for tenant A's user be exchanged under tenant B.
+	// Validate() rejects an empty list (fail closed): the deployer must declare
+	// which tenants each IdP serves. For a single-tenant deployment, list that
+	// one account explicitly.
 	AllowedAccounts []string `koanf:"allowed_accounts"`
 
 	// PropagateClaims is the explicit allow-list of upstream claims to
@@ -117,6 +124,20 @@ func (e *ExternalIssuerConfig) Validate() error {
 	if _, ok := e.ClaimMapping["user_id"]; !ok {
 		return fmt.Errorf("external_issuer %s: claim_mapping.user_id is required (need a stable subject identifier)", e.Issuer)
 	}
+	// allowed_accounts is required and non-empty: it is the only binding of an
+	// upstream token to a ZeroID tenant. An empty list would mean "any tenant
+	// may exchange this IdP's tokens", which lets a token issued for one tenant
+	// be replayed under another (the upstream aud only binds to ZeroID-the-RP,
+	// not to an account_id). Fail closed — force the deployer to declare the
+	// tenants each issuer serves.
+	if len(e.AllowedAccounts) == 0 {
+		return fmt.Errorf("external_issuer %s: allowed_accounts is required and must be non-empty (it binds this IdP's tokens to specific tenants; an empty list would let a token issued for one tenant be exchanged under another)", e.Issuer)
+	}
+	for _, acct := range e.AllowedAccounts {
+		if acct == "" {
+			return fmt.Errorf("external_issuer %s: allowed_accounts must not contain empty entries", e.Issuer)
+		}
+	}
 	// Only RS256/ES256/PS256 are supported by the verifier (jwtalg's asymmetric
 	// allow-list). Reject unsupported entries at config load instead of failing
 	// every exchange at runtime.
@@ -154,11 +175,10 @@ func (e *ExternalIssuerConfig) Defaults() {
 }
 
 // AccountAllowed reports whether the given tenant is permitted to exchange
-// tokens issued by this IdP. Empty AllowedAccounts means any tenant.
+// tokens issued by this IdP. Fail closed: an empty AllowedAccounts denies all
+// tenants. Validate() already rejects an empty list at config load, so this is
+// defense-in-depth against a registry built from unvalidated config.
 func (e *ExternalIssuerConfig) AccountAllowed(accountID string) bool {
-	if len(e.AllowedAccounts) == 0 {
-		return true
-	}
 	for _, a := range e.AllowedAccounts {
 		if a == accountID {
 			return true

--- a/domain/external_issuer.go
+++ b/domain/external_issuer.go
@@ -1,0 +1,149 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// ExternalIssuerConfig describes a single trusted upstream OIDC IdP that the
+// /oauth2/token endpoint will accept ID tokens from when grant_type is
+// urn:ietf:params:oauth:grant-type:token-exchange and subject_token_type is
+// urn:ietf:params:oauth:token-type:id_token.
+//
+// The deployer is the trust anchor. Only issuers listed here are accepted —
+// there is no auto-discovery, no OIDF, no implicit trust. ZeroID fetches the
+// issuer's JWKS from JWKSURI, verifies the ID token's signature against it,
+// and propagates the upstream iss into the issued token as user_id_iss so
+// downstream consumers can answer "which IdP authenticated this user?" from
+// the token alone (NIST SP 800-63C §4.1).
+type ExternalIssuerConfig struct {
+	// Issuer is the upstream IdP's iss value, matched verbatim against the
+	// ID token's iss claim. Must be an absolute https:// URL.
+	Issuer string `koanf:"issuer"`
+
+	// JWKSURI is fetched on startup and re-fetched every JWKSCacheTTL. The
+	// HTTP client used for fetching is the one configured on the JWKS client
+	// (defaults to http.DefaultClient). Must be an absolute https:// URL.
+	JWKSURI string `koanf:"jwks_uri"`
+
+	// Audience is the value the upstream IdP is expected to set as aud on
+	// tokens it issues for ZeroID. Required — token exchange without an
+	// audience binding lets a token issued for some other RP be replayed
+	// against ZeroID.
+	Audience string `koanf:"audience"`
+
+	// Algorithms is the allow-list of JWS algorithms accepted on incoming ID
+	// tokens. Defaults to {"RS256", "ES256"} when empty. Only RS256/ES256/PS256
+	// are supported by the underlying verifier; entries outside that set are
+	// rejected at validation time.
+	Algorithms []string `koanf:"algorithms"`
+
+	// MaxTokenAge caps the time between the upstream iat and "now". An ID
+	// token whose iat is older than MaxTokenAge is rejected even if it has
+	// not yet expired. Defaults to 10m. Must be > 0.
+	MaxTokenAge time.Duration `koanf:"max_token_age"`
+
+	// JWKSCacheTTL controls how often the JWKS is refreshed in the
+	// background. Minimum 30s (matches pkg/authjwt). Defaults to 5m.
+	JWKSCacheTTL time.Duration `koanf:"jwks_cache_ttl"`
+
+	// ClaimMapping maps ZeroID claim names to upstream claim paths. v1
+	// supports single-level keys only — no JSONPath, no expressions. The
+	// only required mapping is "user_id"; everything else is optional.
+	//
+	//	claim_mapping:
+	//	  user_id: sub          # or "preferred_username", "oid", etc.
+	//	  email:   email
+	ClaimMapping map[string]string `koanf:"claim_mapping"`
+
+	// AllowedAccounts limits the tenants that may use this issuer. When
+	// non-empty, the request's account_id must appear in this list. Empty
+	// means any tenant may use it.
+	AllowedAccounts []string `koanf:"allowed_accounts"`
+
+	// PropagateClaims is the explicit allow-list of upstream claims to
+	// copy onto the issued ZeroID token. Only auth_time, acr, and amr are
+	// recognized in v1 — these are RFC 9068 authentication-context claims
+	// and only meaningful when copied through directly from the IdP.
+	// Anything else is ignored. We never default-fill these claims; if the
+	// upstream omitted them, ZeroID does not synthesize them.
+	PropagateClaims []string `koanf:"propagate_claims"`
+
+	// AllowPrivateEndpoints relaxes the SSRF guard applied to this issuer's
+	// JWKSURI fetch. Default false rejects a jwks_uri host that resolves to a
+	// private/loopback/link-local/metadata/reserved address (re-checked at
+	// dial time as a DNS-rebinding defense), mirroring the attestation OIDC
+	// verifier's guard (issue #198). Set true ONLY when the upstream IdP is
+	// deliberately on a private network (corporate IdP behind a VPN) or in
+	// single-tenant dev/test pointing at localhost. Production with a public
+	// IdP MUST keep this false.
+	AllowPrivateEndpoints bool `koanf:"allow_private_endpoints"`
+}
+
+// Validate checks the config for the bare minimum needed to verify a token:
+// an issuer URL, a JWKS URL, an audience, and at least a user_id claim
+// mapping. Defaults are applied for the optional knobs.
+func (e *ExternalIssuerConfig) Validate() error {
+	if e.Issuer == "" {
+		return errors.New("external_issuer: issuer is required")
+	}
+	if u, err := url.Parse(e.Issuer); err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("external_issuer: issuer must be an absolute https URL, got %q", e.Issuer)
+	}
+	if e.JWKSURI == "" {
+		return fmt.Errorf("external_issuer %s: jwks_uri is required", e.Issuer)
+	}
+	if u, err := url.Parse(e.JWKSURI); err != nil || u.Scheme != "https" || u.Host == "" {
+		return fmt.Errorf("external_issuer %s: jwks_uri must be an absolute https URL, got %q", e.Issuer, e.JWKSURI)
+	}
+	if e.Audience == "" {
+		return fmt.Errorf("external_issuer %s: audience is required (token-exchange without aud binding allows token replay)", e.Issuer)
+	}
+	if e.MaxTokenAge < 0 {
+		return fmt.Errorf("external_issuer %s: max_token_age must be > 0", e.Issuer)
+	}
+	if e.JWKSCacheTTL < 0 {
+		return fmt.Errorf("external_issuer %s: jwks_cache_ttl must be > 0", e.Issuer)
+	}
+	if _, ok := e.ClaimMapping["user_id"]; !ok {
+		return fmt.Errorf("external_issuer %s: claim_mapping.user_id is required (need a stable subject identifier)", e.Issuer)
+	}
+	for _, claim := range e.PropagateClaims {
+		switch claim {
+		case "auth_time", "acr", "amr":
+		default:
+			return fmt.Errorf("external_issuer %s: propagate_claims entry %q not supported (allowed: auth_time, acr, amr)", e.Issuer, claim)
+		}
+	}
+	return nil
+}
+
+// Defaults applies runtime defaults to the optional knobs. Idempotent — only
+// fills zero-valued fields.
+func (e *ExternalIssuerConfig) Defaults() {
+	if len(e.Algorithms) == 0 {
+		e.Algorithms = []string{"RS256", "ES256"}
+	}
+	if e.MaxTokenAge == 0 {
+		e.MaxTokenAge = 10 * time.Minute
+	}
+	if e.JWKSCacheTTL == 0 {
+		e.JWKSCacheTTL = 5 * time.Minute
+	}
+}
+
+// AccountAllowed reports whether the given tenant is permitted to exchange
+// tokens issued by this IdP. Empty AllowedAccounts means any tenant.
+func (e *ExternalIssuerConfig) AccountAllowed(accountID string) bool {
+	if len(e.AllowedAccounts) == 0 {
+		return true
+	}
+	for _, a := range e.AllowedAccounts {
+		if a == accountID {
+			return true
+		}
+	}
+	return false
+}

--- a/domain/external_issuer_test.go
+++ b/domain/external_issuer_test.go
@@ -1,0 +1,93 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestExternalIssuerConfigValidate locks in the bare-minimum requirements
+// for a usable external IdP entry. Each negative case names the field whose
+// absence should fail validation; if the rule changes, the test must fail.
+func TestExternalIssuerConfigValidate(t *testing.T) {
+	good := func() ExternalIssuerConfig {
+		return ExternalIssuerConfig{
+			Issuer:       "https://auth.example.okta.com",
+			JWKSURI:      "https://auth.example.okta.com/.well-known/jwks.json",
+			Audience:     "https://zeroid.example.com",
+			ClaimMapping: map[string]string{"user_id": "sub"},
+		}
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*ExternalIssuerConfig)
+		wantErr string
+	}{
+		{name: "happy path", mutate: nil, wantErr: ""},
+		{name: "missing issuer", mutate: func(c *ExternalIssuerConfig) { c.Issuer = "" }, wantErr: "issuer is required"},
+		{name: "non-https issuer", mutate: func(c *ExternalIssuerConfig) { c.Issuer = "http://insecure" }, wantErr: "absolute https URL"},
+		{name: "missing jwks_uri", mutate: func(c *ExternalIssuerConfig) { c.JWKSURI = "" }, wantErr: "jwks_uri is required"},
+		{name: "missing audience", mutate: func(c *ExternalIssuerConfig) { c.Audience = "" }, wantErr: "audience is required"},
+		{name: "missing user_id mapping", mutate: func(c *ExternalIssuerConfig) { c.ClaimMapping = map[string]string{} }, wantErr: "claim_mapping.user_id is required"},
+		{name: "unsupported propagate claim", mutate: func(c *ExternalIssuerConfig) {
+			c.PropagateClaims = []string{"groups"}
+		}, wantErr: "propagate_claims entry"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := good()
+			if tc.mutate != nil {
+				tc.mutate(&cfg)
+			}
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected ok, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+// TestExternalIssuerConfigDefaults checks that the optional knobs receive
+// sensible defaults so deployers can lean on omission for the common case.
+func TestExternalIssuerConfigDefaults(t *testing.T) {
+	cfg := ExternalIssuerConfig{}
+	cfg.Defaults()
+	if got, want := cfg.MaxTokenAge, 10*time.Minute; got != want {
+		t.Errorf("MaxTokenAge default = %s, want %s", got, want)
+	}
+	if got, want := cfg.JWKSCacheTTL, 5*time.Minute; got != want {
+		t.Errorf("JWKSCacheTTL default = %s, want %s", got, want)
+	}
+	if len(cfg.Algorithms) != 2 {
+		t.Errorf("Algorithms default len = %d, want 2 (RS256, ES256)", len(cfg.Algorithms))
+	}
+}
+
+func TestExternalIssuerConfigAccountAllowed(t *testing.T) {
+	t.Run("empty allow-list permits any tenant", func(t *testing.T) {
+		cfg := ExternalIssuerConfig{}
+		if !cfg.AccountAllowed("any-tenant") {
+			t.Fatalf("empty AllowedAccounts must permit any tenant")
+		}
+	})
+	t.Run("non-empty allow-list gates membership", func(t *testing.T) {
+		cfg := ExternalIssuerConfig{AllowedAccounts: []string{"a", "b"}}
+		if !cfg.AccountAllowed("a") {
+			t.Fatalf("a should be allowed")
+		}
+		if cfg.AccountAllowed("c") {
+			t.Fatalf("c should be denied")
+		}
+	})
+}

--- a/domain/external_issuer_test.go
+++ b/domain/external_issuer_test.go
@@ -69,8 +69,41 @@ func TestExternalIssuerConfigDefaults(t *testing.T) {
 	if got, want := cfg.JWKSCacheTTL, 5*time.Minute; got != want {
 		t.Errorf("JWKSCacheTTL default = %s, want %s", got, want)
 	}
-	if len(cfg.Algorithms) != 2 {
-		t.Errorf("Algorithms default len = %d, want 2 (RS256, ES256)", len(cfg.Algorithms))
+	if got, want := strings.Join(cfg.Algorithms, ","), "RS256,ES256,PS256"; got != want {
+		t.Errorf("Algorithms default = %q, want %q", got, want)
+	}
+}
+
+// TestExternalIssuerConfigValidateRejectsUnsupportedAlg locks in that the
+// alg allow-list is enforced at config load (the doc promises it), and that
+// a jwks_cache_ttl below the authjwt floor is rejected rather than silently
+// clamped.
+func TestExternalIssuerConfigValidateRejectsUnsupportedAlg(t *testing.T) {
+	base := func() ExternalIssuerConfig {
+		return ExternalIssuerConfig{
+			Issuer:       "https://idp.example.com",
+			JWKSURI:      "https://idp.example.com/jwks",
+			Audience:     "https://zeroid.example.com",
+			ClaimMapping: map[string]string{"user_id": "sub"},
+		}
+	}
+
+	bad := base()
+	bad.Algorithms = []string{"RS256", "HS256"}
+	if err := bad.Validate(); err == nil {
+		t.Errorf("Validate must reject unsupported algorithm HS256")
+	}
+
+	tooShort := base()
+	tooShort.JWKSCacheTTL = 5 * time.Second
+	if err := tooShort.Validate(); err == nil {
+		t.Errorf("Validate must reject jwks_cache_ttl below the 30s floor")
+	}
+
+	ok := base()
+	ok.Defaults()
+	if err := ok.Validate(); err != nil {
+		t.Errorf("default config must validate, got %v", err)
 	}
 }
 

--- a/domain/external_issuer_test.go
+++ b/domain/external_issuer_test.go
@@ -12,10 +12,11 @@ import (
 func TestExternalIssuerConfigValidate(t *testing.T) {
 	good := func() ExternalIssuerConfig {
 		return ExternalIssuerConfig{
-			Issuer:       "https://auth.example.okta.com",
-			JWKSURI:      "https://auth.example.okta.com/.well-known/jwks.json",
-			Audience:     "https://zeroid.example.com",
-			ClaimMapping: map[string]string{"user_id": "sub"},
+			Issuer:          "https://auth.example.okta.com",
+			JWKSURI:         "https://auth.example.okta.com/.well-known/jwks.json",
+			Audience:        "https://zeroid.example.com",
+			ClaimMapping:    map[string]string{"user_id": "sub"},
+			AllowedAccounts: []string{"acct-1"},
 		}
 	}
 
@@ -30,6 +31,10 @@ func TestExternalIssuerConfigValidate(t *testing.T) {
 		{name: "missing jwks_uri", mutate: func(c *ExternalIssuerConfig) { c.JWKSURI = "" }, wantErr: "jwks_uri is required"},
 		{name: "missing audience", mutate: func(c *ExternalIssuerConfig) { c.Audience = "" }, wantErr: "audience is required"},
 		{name: "missing user_id mapping", mutate: func(c *ExternalIssuerConfig) { c.ClaimMapping = map[string]string{} }, wantErr: "claim_mapping.user_id is required"},
+		{name: "missing allowed_accounts", mutate: func(c *ExternalIssuerConfig) { c.AllowedAccounts = nil }, wantErr: "allowed_accounts is required"},
+		{name: "empty allowed_accounts entry", mutate: func(c *ExternalIssuerConfig) {
+			c.AllowedAccounts = []string{""}
+		}, wantErr: "must not contain empty entries"},
 		{name: "unsupported propagate claim", mutate: func(c *ExternalIssuerConfig) {
 			c.PropagateClaims = []string{"groups"}
 		}, wantErr: "propagate_claims entry"},
@@ -81,10 +86,11 @@ func TestExternalIssuerConfigDefaults(t *testing.T) {
 func TestExternalIssuerConfigValidateRejectsUnsupportedAlg(t *testing.T) {
 	base := func() ExternalIssuerConfig {
 		return ExternalIssuerConfig{
-			Issuer:       "https://idp.example.com",
-			JWKSURI:      "https://idp.example.com/jwks",
-			Audience:     "https://zeroid.example.com",
-			ClaimMapping: map[string]string{"user_id": "sub"},
+			Issuer:          "https://idp.example.com",
+			JWKSURI:         "https://idp.example.com/jwks",
+			Audience:        "https://zeroid.example.com",
+			ClaimMapping:    map[string]string{"user_id": "sub"},
+			AllowedAccounts: []string{"acct-1"},
 		}
 	}
 
@@ -108,10 +114,10 @@ func TestExternalIssuerConfigValidateRejectsUnsupportedAlg(t *testing.T) {
 }
 
 func TestExternalIssuerConfigAccountAllowed(t *testing.T) {
-	t.Run("empty allow-list permits any tenant", func(t *testing.T) {
+	t.Run("empty allow-list denies all tenants (fail closed)", func(t *testing.T) {
 		cfg := ExternalIssuerConfig{}
-		if !cfg.AccountAllowed("any-tenant") {
-			t.Fatalf("empty AllowedAccounts must permit any tenant")
+		if cfg.AccountAllowed("any-tenant") {
+			t.Fatalf("empty AllowedAccounts must deny all tenants (fail closed)")
 		}
 	})
 	t.Run("non-empty allow-list gates membership", func(t *testing.T) {

--- a/internal/attestation/oidc.go
+++ b/internal/attestation/oidc.go
@@ -515,6 +515,24 @@ func ssrfGuardedTransport(allowPrivate func() bool) *http.Transport {
 	return base
 }
 
+// NewSSRFGuardedHTTPClient returns an *http.Client whose dialer rejects any
+// connection resolving to a private/loopback/link-local/metadata/reserved
+// address (see isBlockedIP) — the same DNS-rebinding-safe guard the OIDC
+// verifier applies to issuer/jwks_uri fetches. allowPrivate=true disables the
+// blocklist for single-tenant dev/test or a deliberately internal upstream.
+//
+// Exported so other server-side outbound fetchers (e.g. the direct-OIDC-
+// federation external-issuer JWKS registry, issue #88) reuse one audited
+// implementation rather than duplicating the blocklist. The block sentinel is
+// ErrPrivateAttestationEndpoint regardless of caller; callers that surface it
+// should wrap it with their own context.
+func NewSSRFGuardedHTTPClient(allowPrivate bool) *http.Client {
+	return &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: ssrfGuardedTransport(func() bool { return allowPrivate }),
+	}
+}
+
 // isBlockedIP returns true for any IP that must never be a verify-time fetch
 // target. Mirrors the CIBA notification guard's blocklist:
 //

--- a/internal/attestation/oidc_ssrf_test.go
+++ b/internal/attestation/oidc_ssrf_test.go
@@ -232,3 +232,34 @@ func (rt *recordingTransport) RoundTrip(_ *http.Request) (*http.Response, error)
 	rt.onRoundTrip()
 	return nil, errors.New("recordingTransport: network must not be reached")
 }
+
+// TestNewSSRFGuardedHTTPClient covers the exported constructor reused by the
+// direct-OIDC-federation external-issuer JWKS registry (issue #88): the guard
+// blocks a loopback target by default and allows it only when allowPrivate is
+// set. A plain-HTTP loopback server is used so the dial-time block is isolated
+// from any TLS-verification failure.
+func TestNewSSRFGuardedHTTPClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Default (guarded): loopback must be refused at dial time.
+	guarded := NewSSRFGuardedHTTPClient(false)
+	if _, err := guarded.Get(srv.URL); err == nil {
+		t.Fatalf("guarded client must refuse a loopback target; got nil error")
+	} else if !errors.Is(err, ErrPrivateAttestationEndpoint) {
+		t.Fatalf("expected ErrPrivateAttestationEndpoint, got %v", err)
+	}
+
+	// Relaxed (allowPrivate): the same loopback target must connect.
+	relaxed := NewSSRFGuardedHTTPClient(true)
+	resp, err := relaxed.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("relaxed client must allow loopback; got %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}

--- a/internal/service/external_issuer_registry.go
+++ b/internal/service/external_issuer_registry.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/attestation"
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
+)
+
+// ExternalIssuerEntry pairs a configured external IdP with its live JWKS
+// client. The registry owns the client's lifecycle — it is created on
+// NewExternalIssuerRegistry and shut down on Close.
+type ExternalIssuerEntry struct {
+	Config domain.ExternalIssuerConfig
+	JWKS   *authjwt.JWKSClient
+}
+
+// ExternalIssuerRegistry resolves a token's iss claim to a configured
+// upstream IdP and holds a cached JWKS for it. Lookup is read-only after
+// construction; the JWKS clients themselves refresh in the background.
+//
+// The registry is intentionally separate from OAuthService so that a deployer
+// can construct it with custom HTTP clients (proxies, mTLS) before wiring it
+// into the server.
+type ExternalIssuerRegistry struct {
+	mu      sync.RWMutex
+	byIss   map[string]*ExternalIssuerEntry
+	closers []func()
+}
+
+// NewExternalIssuerRegistry builds a registry from validated config. Each
+// entry's JWKS client warms up best-effort: authjwt.NewJWKSClient does an
+// initial fetch but deliberately does NOT fail on an unreachable JWKS — it
+// logs a warning and relies on background refresh plus a synchronous
+// EnsureLoaded on the first verification (externalIDTokenExchange calls it).
+// This keeps ZeroID startup resilient to a transient external-IdP outage;
+// a genuinely unreachable issuer fails closed at token-exchange time rather
+// than blocking boot. Only config-level errors (e.g. empty jwks_uri) fail
+// here. Entries are created in order; partial failure closes whatever
+// clients were already created and returns the failing issuer's error.
+func NewExternalIssuerRegistry(ctx context.Context, configs []domain.ExternalIssuerConfig, opts ...authjwt.JWKSOption) (*ExternalIssuerRegistry, error) {
+	_ = ctx // reserved for future use; current authjwt.NewJWKSClient does its own fetch context
+	r := &ExternalIssuerRegistry{
+		byIss: make(map[string]*ExternalIssuerEntry, len(configs)),
+	}
+	for _, cfg := range configs {
+		// SSRF-guarded HTTP client for the JWKS fetch: reject a jwks_uri host
+		// that resolves to a private/loopback/metadata address unless the
+		// issuer opted in (AllowPrivateEndpoints) for an internal IdP. Reuses
+		// the audited guard the attestation OIDC verifier uses (issue #198).
+		// Listed first so a deployer/test can still override the HTTP client
+		// via opts (WithExternalIssuerJWKSOption) — the last WithHTTPClient
+		// wins. Then the per-issuer refresh interval overrides the package
+		// default; caller-supplied opts follow so they can override anything.
+		issuerOpts := append([]authjwt.JWKSOption{
+			authjwt.WithHTTPClient(attestation.NewSSRFGuardedHTTPClient(cfg.AllowPrivateEndpoints)),
+			authjwt.WithRefreshInterval(cfg.JWKSCacheTTL),
+		}, opts...)
+		client, err := authjwt.NewJWKSClient(cfg.JWKSURI, issuerOpts...)
+		if err != nil {
+			r.Close()
+			return nil, fmt.Errorf("external issuer %s: %w", cfg.Issuer, err)
+		}
+		entry := &ExternalIssuerEntry{Config: cfg, JWKS: client}
+		r.byIss[cfg.Issuer] = entry
+		r.closers = append(r.closers, client.Close)
+	}
+	return r, nil
+}
+
+// Lookup returns the entry registered for the given upstream iss, or nil if
+// the issuer is not configured. Safe for concurrent use.
+func (r *ExternalIssuerRegistry) Lookup(iss string) *ExternalIssuerEntry {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.byIss[iss]
+}
+
+// HasAny reports whether any external issuer is configured. The OAuth service
+// uses this to short-circuit dispatch when the deployer has not opted into
+// direct federation.
+func (r *ExternalIssuerRegistry) HasAny() bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.byIss) > 0
+}
+
+// Close stops every background JWKS refresh goroutine. Idempotent.
+func (r *ExternalIssuerRegistry) Close() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	closers := r.closers
+	r.closers = nil
+	r.mu.Unlock()
+	for _, c := range closers {
+		c()
+	}
+}

--- a/internal/service/external_issuer_registry_test.go
+++ b/internal/service/external_issuer_registry_test.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
+)
+
+// insecureHTTPClient returns an http.Client that skips TLS verification —
+// used to talk to the httptest TLS server, whose self-signed cert is not in
+// the system trust store.
+func insecureHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec
+	}
+}
+
+// fakeJWKSServer publishes a JWKS containing a single ES256 key. The
+// rotateKey method swaps in a new key and bumps the served kid — used by
+// the rotation test to verify on-demand JWKS refresh works.
+type fakeJWKSServer struct {
+	t       *testing.T
+	srv     *httptest.Server
+	hits    atomic.Int64
+	keySet  jwk.Set
+	curPriv *ecdsa.PrivateKey
+}
+
+func newFakeJWKSServer(t *testing.T, kid string) *fakeJWKSServer {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ec key: %v", err)
+	}
+	keySet := jwk.NewSet()
+	pub, err := jwk.Import[jwk.Key](&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("jwk.Import: %v", err)
+	}
+	_ = pub.Set(jwk.KeyIDKey, kid)
+	_ = pub.Set(jwk.AlgorithmKey, jwa.ES256())
+	_ = pub.Set(jwk.KeyUsageKey, jwk.ForSignature)
+	_ = keySet.AddKey(pub)
+
+	f := &fakeJWKSServer{t: t, keySet: keySet, curPriv: priv}
+	f.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(f.keySet)
+	}))
+	return f
+}
+
+func (f *fakeJWKSServer) URL() string { return f.srv.URL }
+
+func (f *fakeJWKSServer) Close() { f.srv.Close() }
+
+func (f *fakeJWKSServer) Hits() int64 { return f.hits.Load() }
+
+// TestExternalIssuerRegistry_LifecycleAndLookup exercises the registry
+// happy path: synchronous initial JWKS fetch on construction, lookup by
+// configured iss, miss for an unconfigured iss, and clean shutdown.
+func TestExternalIssuerRegistry_LifecycleAndLookup(t *testing.T) {
+	jwks := newFakeJWKSServer(t, "test-kid-1")
+	defer jwks.Close()
+
+	cfg := domain.ExternalIssuerConfig{
+		Issuer:       "https://auth.example.test",
+		JWKSURI:      jwks.URL(),
+		Audience:     "https://zeroid.example.test",
+		ClaimMapping: map[string]string{"user_id": "sub"},
+	}
+	cfg.Defaults()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	registry, err := NewExternalIssuerRegistry(
+		context.Background(),
+		[]domain.ExternalIssuerConfig{cfg},
+		authjwt.WithHTTPClient(insecureHTTPClient(2*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("NewExternalIssuerRegistry: %v", err)
+	}
+	defer registry.Close()
+
+	if !registry.HasAny() {
+		t.Fatalf("HasAny() = false, want true after registering one issuer")
+	}
+	if jwks.Hits() == 0 {
+		t.Fatalf("expected JWKS to be fetched synchronously on registry construction; hit count = 0")
+	}
+
+	entry := registry.Lookup(cfg.Issuer)
+	if entry == nil {
+		t.Fatalf("Lookup(%q) returned nil; want non-nil entry", cfg.Issuer)
+	}
+	if entry.Config.Issuer != cfg.Issuer {
+		t.Errorf("entry.Config.Issuer = %q, want %q", entry.Config.Issuer, cfg.Issuer)
+	}
+	if entry.JWKS == nil {
+		t.Fatalf("entry.JWKS is nil; expected a configured JWKS client")
+	}
+	if entry.JWKS.KeySet() == nil || entry.JWKS.KeySet().Len() != 1 {
+		t.Fatalf("expected JWKS client to hold exactly 1 key; got %v", entry.JWKS.KeySet())
+	}
+
+	if registry.Lookup("https://unknown.example.test") != nil {
+		t.Errorf("Lookup of unconfigured issuer should return nil")
+	}
+}
+
+// TestExternalIssuerRegistry_ToleratesUnreachableJWKSAtStartup pins the
+// deliberate behavior inherited from authjwt.NewJWKSClient: construction does
+// NOT fail when an issuer's JWKS is unreachable. The warm-up is best-effort so
+// a transient external-IdP outage during a ZeroID deploy cannot block boot;
+// the issuer fails closed at token-exchange time instead (EnsureLoaded retries
+// synchronously on the first verification, then the empty-keyset guard rejects
+// the request). See externalIDTokenExchange.
+func TestExternalIssuerRegistry_ToleratesUnreachableJWKSAtStartup(t *testing.T) {
+	cfg := domain.ExternalIssuerConfig{
+		Issuer:       "https://auth.example.test",
+		JWKSURI:      "https://127.0.0.1:1/.well-known/jwks.json", // port 1 is reserved → connect refused
+		Audience:     "https://zeroid.example.test",
+		ClaimMapping: map[string]string{"user_id": "sub"},
+	}
+	cfg.Defaults()
+
+	reg, err := NewExternalIssuerRegistry(
+		context.Background(),
+		[]domain.ExternalIssuerConfig{cfg},
+		authjwt.WithHTTPClient(insecureHTTPClient(500*time.Millisecond)),
+	)
+	if err != nil {
+		t.Fatalf("construction must tolerate an unreachable JWKS (best-effort warm-up); got %v", err)
+	}
+	defer reg.Close()
+
+	// The issuer is still registered so dispatch routes to it; the empty
+	// keyset is what makes verification fail closed at request time.
+	if entry := reg.Lookup(cfg.Issuer); entry == nil {
+		t.Fatalf("issuer should be registered even though its JWKS is unreachable")
+	}
+}

--- a/internal/service/external_issuer_registry_test.go
+++ b/internal/service/external_issuer_registry_test.go
@@ -80,10 +80,11 @@ func TestExternalIssuerRegistry_LifecycleAndLookup(t *testing.T) {
 	defer jwks.Close()
 
 	cfg := domain.ExternalIssuerConfig{
-		Issuer:       "https://auth.example.test",
-		JWKSURI:      jwks.URL(),
-		Audience:     "https://zeroid.example.test",
-		ClaimMapping: map[string]string{"user_id": "sub"},
+		Issuer:          "https://auth.example.test",
+		JWKSURI:         jwks.URL(),
+		Audience:        "https://zeroid.example.test",
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct"},
 	}
 	cfg.Defaults()
 	if err := cfg.Validate(); err != nil {

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -45,6 +45,11 @@ type OAuthService struct {
 	trustedServiceValidator trustedServiceValidatorFunc
 	// customGrants holds registered custom grant type handlers.
 	customGrants map[string]CustomGrantHandler
+	// externalIssuerRegistry resolves direct-federation token-exchange
+	// requests (subject_token_type=id_token) to a configured upstream IdP.
+	// Nil when no external_issuers are configured — direct federation is
+	// disabled in that case and only the broker path remains.
+	externalIssuerRegistry *ExternalIssuerRegistry
 	// backchannelSvc handles the urn:openid:params:grant-type:ciba grant.
 	// Wired after construction via SetBackchannelService.
 	backchannelSvc *BackchannelService
@@ -77,7 +82,7 @@ var reservedClaims = map[string]bool{
 	"capabilities": true, "scopes": true, "grant_type": true, "delegation_depth": true,
 	"user_email": true, "user_name": true,
 	// ZeroID internal claims
-	"act": true, "token_exchange": true, "trusted_by": true,
+	"act": true, "token_exchange": true, "trusted_by": true, "user_id_iss": true,
 	// RFC 9449 — cnf.jkt is set only from a validated DPoP proof. Block
 	// callers from injecting it via additional_claims, which would otherwise
 	// let a trusted-service caller mint a token that appears DPoP-bound to
@@ -447,10 +452,21 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 		return nil, oauthBadRequest(oautherror.InvalidRequest, "subject_token is required for token_exchange grant")
 	}
 
-	// RFC 8693 defines two exchange modes:
-	//   1. NHI delegation: subject_token (orchestrator) + actor_token (sub-agent) → delegated token
-	//   2. External principal exchange: subject_token (external JWT) from a trusted service → zeroid token
-	// Mode is determined by the presence of actor_token.
+	// RFC 8693 defines several exchange modes:
+	//   1. Direct OIDC federation (issue #88): subject_token_type=id_token →
+	//      ZeroID itself verifies the upstream IdP's signature against a
+	//      configured JWKS. The TrustedServiceValidator hook is *not* used —
+	//      this path is the trust anchor. Dispatch happens before the
+	//      actor_token check because direct federation never carries one.
+	//   2. NHI delegation: subject_token (orchestrator) + actor_token
+	//      (sub-agent) → delegated token.
+	//   3. External principal exchange (broker): subject_token from a
+	//      trusted upstream service → zeroid token. ZeroID gates on the
+	//      caller via TrustedServiceValidator and trusts the relay to
+	//      have done the IdP-side verification.
+	if req.SubjectTokenType == SubjectTokenTypeIDToken {
+		return s.externalIDTokenExchange(ctx, req)
+	}
 	if req.ActorToken == "" {
 		return s.ExternalPrincipalExchange(ctx, req)
 	}

--- a/internal/service/oauth_external_idp.go
+++ b/internal/service/oauth_external_idp.go
@@ -1,0 +1,373 @@
+package service
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/jwtalg"
+)
+
+// SubjectTokenTypeIDToken is the RFC 8693 subject_token_type for an OIDC ID
+// token. ZeroID dispatches token-exchange requests carrying this type to the
+// direct-federation path (issue #88) instead of the broker path.
+const SubjectTokenTypeIDToken = "urn:ietf:params:oauth:token-type:id_token"
+
+// ErrUnknownExternalIssuer is returned when a token-exchange request carries
+// an upstream `iss` that is not in the deployer-configured external_issuers
+// allowlist. Wrapped onto the *OAuthError so callers can branch with
+// errors.Is while the handler still maps the OAuth error code via errors.As.
+//
+// We classify this as `invalid_request` (RFC 6749 §5.2) rather than
+// `invalid_grant`: the token may be perfectly valid against its real issuer;
+// the failure is that the deployer has not configured this IdP. Per the RFC,
+// `invalid_grant` covers credentials that "are invalid, expired, revoked"
+// against a trust config the server does have — not credentials whose issuer
+// the server has never been told to trust.
+var ErrUnknownExternalIssuer = errors.New("issuer is not a configured external issuer")
+
+// SetExternalIssuerRegistry installs a registry of trusted external IdPs.
+// Must be set before /oauth2/token requests with subject_token_type=id_token
+// can be served — without a registry, those requests are rejected with
+// invalid_request.
+func (s *OAuthService) SetExternalIssuerRegistry(r *ExternalIssuerRegistry) {
+	s.externalIssuerRegistry = r
+}
+
+// externalIDTokenExchange handles RFC 8693 token exchange where the
+// subject_token is an OIDC ID token and ZeroID itself verifies it (issue
+// #88).
+//
+// This is the spec-aligned preferred path for ingesting upstream user
+// identity. Compared to ExternalPrincipalExchange (the broker pattern):
+//
+//   - ZeroID verifies the upstream signature against a configured JWKS,
+//     so trust flows from the IdP directly rather than from a relay
+//     service.
+//   - The issued token carries user_id_iss = upstream iss, giving every
+//     downstream consumer per-IdP provenance (NIST SP 800-63C §4.1).
+//   - RFC 9068 authentication-context claims (auth_time, acr, amr) can
+//     be propagated through truthfully because we read them from the
+//     token we just verified.
+//
+// TrustedServiceValidator is bypassed on this path: the JWKS signature
+// check + issuer allowlist + audience binding are the proof of trust.
+// That bypass is intentional and the entire point of the new path.
+func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenRequest) (*domain.AccessToken, error) {
+	if s.externalIssuerRegistry == nil || !s.externalIssuerRegistry.HasAny() {
+		return nil, oauthBadRequest("invalid_request", "no external issuers are configured for direct OIDC federation")
+	}
+	if req.SubjectToken == "" {
+		return nil, oauthBadRequest("invalid_request", "subject_token is required")
+	}
+	if req.AccountID == "" || req.ProjectID == "" {
+		return nil, oauthBadRequest("invalid_request", "account_id and project_id are required for external id_token exchange")
+	}
+
+	// Peek at the token to extract iss without validating signatures yet —
+	// we need iss to look up which IdP's JWKS to verify against.
+	peeked, err := jwt.ParseInsecure([]byte(req.SubjectToken))
+	if err != nil {
+		return nil, oauthBadRequestCause("invalid_grant", "subject_token is malformed", err)
+	}
+	upstreamIss, ok := peeked.Issuer()
+	if !ok || upstreamIss == "" {
+		return nil, oauthBadRequest("invalid_grant", "subject_token missing iss claim")
+	}
+
+	entry := s.externalIssuerRegistry.Lookup(upstreamIss)
+	if entry == nil {
+		// Unknown issuer — invalid_request, not invalid_grant: the deployer
+		// has not configured this IdP, which is a configuration mismatch
+		// rather than a credential failure. Wrap ErrUnknownExternalIssuer as
+		// the cause so callers can errors.Is while the handler still picks up
+		// the OAuth error code via errors.As on *OAuthError.
+		return nil, oauthBadRequestCause(
+			"invalid_request",
+			fmt.Sprintf("issuer %s is not a configured external issuer", upstreamIss),
+			fmt.Errorf("%w: %s", ErrUnknownExternalIssuer, upstreamIss),
+		)
+	}
+	cfg := entry.Config
+
+	if !cfg.AccountAllowed(req.AccountID) {
+		return nil, oauthBadRequest("invalid_request", fmt.Sprintf("account %s is not allowed to use issuer %s", req.AccountID, upstreamIss))
+	}
+
+	// Algorithm allowlist gate. Read the JWS header before signature
+	// verification — defense-in-depth against alg confusion. Any alg outside
+	// the configured set (or outside the small whitelist of secure asymmetric
+	// algs we actually support) is rejected.
+	if err := checkExternalIDTokenAlg(req.SubjectToken, cfg.Algorithms); err != nil {
+		return nil, oauthBadRequestCause("invalid_grant", "subject_token uses a disallowed algorithm", err)
+	}
+
+	// Ensure the issuer's JWKS is loaded. authjwt warms up best-effort at
+	// startup and refreshes in the background (it deliberately does not fail
+	// construction on an unreachable JWKS, to survive transient IdP blips).
+	// This synchronous load covers the case where the startup warm-up failed,
+	// so the first request self-heals rather than failing. A genuinely
+	// unreachable IdP returns an error here and we fail closed.
+	if err := entry.JWKS.EnsureLoaded(ctx); err != nil {
+		return nil, oauthServerError(fmt.Sprintf("failed to load JWKS for issuer %s", upstreamIss), err)
+	}
+
+	// Verify signature, exp, nbf, iss, and aud against the configured IdP
+	// in one Parse call. WithKeySet picks the right key by kid+alg from
+	// the JWKS we cache for this issuer.
+	keySet := entry.JWKS.KeySet()
+	if keySet == nil || keySet.Len() == 0 {
+		return nil, oauthServerError(fmt.Sprintf("JWKS for issuer %s is empty", upstreamIss), nil)
+	}
+	verified, err := jwt.Parse([]byte(req.SubjectToken),
+		jwt.WithKeySet(keySet),
+		jwt.WithValidate(true),
+		jwt.WithIssuer(upstreamIss),
+		jwt.WithAudience(cfg.Audience),
+	)
+	if err != nil {
+		// On unknown kid, refresh the JWKS once and retry — handles upstream
+		// key rotation without requiring a server restart.
+		if kid := extractJWSKeyID(req.SubjectToken); kid != "" && entry.JWKS.RefreshIfMissing(ctx, kid) {
+			keySet = entry.JWKS.KeySet()
+			verified, err = jwt.Parse([]byte(req.SubjectToken),
+				jwt.WithKeySet(keySet),
+				jwt.WithValidate(true),
+				jwt.WithIssuer(upstreamIss),
+				jwt.WithAudience(cfg.Audience),
+			)
+		}
+		if err != nil {
+			return nil, oauthBadRequestCause("invalid_grant", "subject_token verification failed", err)
+		}
+	}
+
+	// Stale-token cap. exp guards future-side; iat guards past-side. We
+	// require iat present and not older than max_token_age — the upstream
+	// signed it for a fresh authentication, not a replay from days ago.
+	iat, iatPresent := verified.IssuedAt()
+	if !iatPresent || iat.IsZero() {
+		return nil, oauthBadRequest("invalid_grant", "subject_token missing iat claim")
+	}
+	if age := time.Since(iat); age > cfg.MaxTokenAge {
+		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("subject_token age %s exceeds max_token_age %s", age.Round(time.Second), cfg.MaxTokenAge))
+	}
+
+	// Claim mapping. user_id is required (validated at config load); other
+	// mappings are optional. Single-level keys only in v1. v4 dropped AsMap,
+	// so iterate Keys()/Get() to materialize a plain map.
+	rawClaims := tokenClaimsAsMap(verified)
+	userID, ok := extractMappedClaimString(rawClaims, cfg.ClaimMapping["user_id"])
+	if !ok || userID == "" {
+		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("subject_token missing claim %q (mapped to user_id)", cfg.ClaimMapping["user_id"]))
+	}
+	userEmail, _ := extractMappedClaimString(rawClaims, cfg.ClaimMapping["email"])
+	userName, _ := extractMappedClaimString(rawClaims, cfg.ClaimMapping["name"])
+
+	// Resolve the application identity if requested. Same IDOR-guarded
+	// lookup the broker path uses — falling back to a synthetic service
+	// identity when no application_id is provided.
+	identity, err := s.resolveExternalPrincipalIdentity(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build provenance claims. user_id_iss is the headline addition: it
+	// pins the upstream IdP onto every issued token, so consumers can
+	// answer "which IdP authenticated this user" from the token alone.
+	customClaims := map[string]any{
+		"token_exchange": "external_id_token",
+		"user_id_iss":    upstreamIss,
+	}
+
+	// Honest propagation: only forward auth_time/acr/amr when (a) the
+	// deployer asked for them and (b) the upstream actually set them.
+	// We never default-fill — RFC 9068 authentication-context claims are
+	// only meaningful when they reflect the IdP's authentication event.
+	for _, claim := range cfg.PropagateClaims {
+		if v, present := rawClaims[claim]; present {
+			customClaims[claim] = v
+		}
+	}
+
+	// Caller-provided AdditionalClaims pass through the same blocklist as
+	// the broker path. user_id_iss is in reservedClaims so callers cannot
+	// spoof IdP provenance.
+	for k, v := range req.AdditionalClaims {
+		if reservedClaims[k] {
+			continue
+		}
+		customClaims[k] = v
+	}
+
+	scopes := parseScopeString(req.Scope)
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+		Identity:        identity,
+		GrantType:       domain.GrantTypeTokenExchange,
+		Scopes:          scopes,
+		UseRS256:        true,
+		SubjectOverride: userID,
+		UserEmail:       userEmail,
+		UserName:        userName,
+		ApplicationID:   req.ApplicationID,
+		TTL:             900, // 15 minutes — same short-lived posture as the broker path
+		CustomClaims:    customClaims,
+	})
+	if err != nil {
+		return nil, oauthServerError("failed to issue external id_token exchange token", err)
+	}
+
+	accessToken.AccountID = req.AccountID
+	accessToken.ProjectID = req.ProjectID
+	accessToken.UserID = userID
+
+	log.Info().
+		Str("upstream_iss", upstreamIss).
+		Str("account_id", req.AccountID).
+		Str("project_id", req.ProjectID).
+		Str("user_id", userID).
+		Msg("external id_token exchange succeeded")
+
+	return accessToken, nil
+}
+
+// resolveExternalPrincipalIdentity factors out the identity-resolution step
+// shared between the broker and direct-federation paths. ApplicationID, when
+// provided, must resolve to an active identity in the caller's tenant; this
+// is the IDOR guard that prevents a token-exchange request from minting a
+// token for someone else's application. With no ApplicationID we synthesize
+// a service identity (same shape the broker path used).
+func (s *OAuthService) resolveExternalPrincipalIdentity(ctx context.Context, req TokenRequest) (*domain.Identity, error) {
+	if req.ApplicationID == "" {
+		return &domain.Identity{
+			AccountID:    req.AccountID,
+			ProjectID:    req.ProjectID,
+			IdentityType: domain.IdentityTypeService,
+			Status:       domain.IdentityStatusActive,
+		}, nil
+	}
+	resolved, err := s.identitySvc.GetIdentity(ctx, req.ApplicationID, req.AccountID, req.ProjectID)
+	if err != nil {
+		return nil, oauthBadRequest("invalid_request", fmt.Sprintf("application_id %s not found or access denied", req.ApplicationID))
+	}
+	if !resolved.Status.IsUsable() {
+		return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
+	}
+	return resolved, nil
+}
+
+// extractMappedClaimString reads a single-level claim by name and coerces it
+// to string. Returns ok=false when the path is empty (no mapping configured)
+// or the upstream value is not stringifiable. Numeric claims are accepted
+// because some IdPs (Entra) emit numeric subject identifiers.
+func extractMappedClaimString(claims map[string]any, path string) (string, bool) {
+	if path == "" {
+		return "", false
+	}
+	v, ok := claims[path]
+	if !ok {
+		return "", false
+	}
+	switch tv := v.(type) {
+	case string:
+		return tv, true
+	case float64:
+		// %v / %g switch to scientific notation for large floats
+		// (1.23e+18), which would silently corrupt large numeric subject
+		// identifiers. FormatFloat with 'f' keeps a plain decimal. Note
+		// that float64 still loses integer precision past 2^53; an IdP
+		// that mints subjects above that range is the one violating the
+		// JWT/JSON contract — we just don't add a second bug on top.
+		return strconv.FormatFloat(tv, 'f', -1, 64), true
+	case int64:
+		return strconv.FormatInt(tv, 10), true
+	}
+	return "", false
+}
+
+// checkExternalIDTokenAlg enforces the JWT-SVID §3 asymmetric allow-list
+// (via jwtalg.Validate — also rejects alg=none and HS*) and then narrows
+// further if the deployer configured a per-issuer allow-list. Runs before
+// any signature work so a bad alg dies up front.
+func checkExternalIDTokenAlg(tokenStr string, allowed []string) error {
+	if err := jwtalg.Validate(tokenStr); err != nil {
+		return err
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+	alg := readJWSAlg(tokenStr)
+	for _, a := range allowed {
+		if a == alg {
+			return nil
+		}
+	}
+	return fmt.Errorf("alg %q not in issuer allow-list %v", alg, allowed)
+}
+
+// extractJWSKeyID reads kid from a JWT protected header without verifying.
+// Returns "" if the header is unreadable. Used to drive a one-shot JWKS
+// refresh after a verification failure that might be caused by upstream key
+// rotation.
+func extractJWSKeyID(tokenStr string) string {
+	hdr, ok := decodeJWTHeader(tokenStr)
+	if !ok {
+		return ""
+	}
+	return hdr.Kid
+}
+
+// readJWSAlg returns the alg header value or "" when the header is
+// unreadable. Used by the per-issuer allow-list comparison; jwtalg.Validate
+// already guarantees alg is present and asymmetric by the time we get here.
+func readJWSAlg(tokenStr string) string {
+	hdr, ok := decodeJWTHeader(tokenStr)
+	if !ok {
+		return ""
+	}
+	return hdr.Alg
+}
+
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+}
+
+// tokenClaimsAsMap materializes every claim on a v4 jwt.Token into a plain
+// map[string]any. v4 dropped AsMap, so we iterate Claims() (an iter.Seq2).
+// Used for claim-mapping lookups and propagation passes.
+func tokenClaimsAsMap(t jwt.Token) map[string]any {
+	out := make(map[string]any, len(t.Keys()))
+	for k, v := range t.Claims() {
+		out[k] = v
+	}
+	return out
+}
+
+// decodeJWTHeader base64url-decodes the protected header of a compact JWS
+// without doing any signature work. Mirrors the technique used in
+// internal/jwtalg so we stay independent of the jwx major version.
+func decodeJWTHeader(tokenStr string) (jwtHeader, bool) {
+	header, _, found := strings.Cut(tokenStr, ".")
+	if !found || header == "" {
+		return jwtHeader{}, false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(header)
+	if err != nil {
+		return jwtHeader{}, false
+	}
+	var hdr jwtHeader
+	if err := json.Unmarshal(raw, &hdr); err != nil {
+		return jwtHeader{}, false
+	}
+	return hdr, true
+}

--- a/internal/service/oauth_external_idp.go
+++ b/internal/service/oauth_external_idp.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -16,6 +17,12 @@ import (
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/jwtalg"
 )
+
+// externalIDTokenClockSkew is the leeway allowed when validating the upstream
+// ID token's exp/nbf/iat against ZeroID's clock. Per issue #88 (and standard
+// OIDC practice) a small skew absorbs clock drift between the IdP and ZeroID
+// so federation isn't brittle to sub-minute differences.
+const externalIDTokenClockSkew = 60 * time.Second
 
 // SubjectTokenTypeIDToken is the RFC 8693 subject_token_type for an OIDC ID
 // token. ZeroID dispatches token-exchange requests carrying this type to the
@@ -133,6 +140,7 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 		jwt.WithValidate(true),
 		jwt.WithIssuer(upstreamIss),
 		jwt.WithAudience(cfg.Audience),
+		jwt.WithAcceptableSkew(externalIDTokenClockSkew),
 	)
 	if err != nil {
 		// On unknown kid, refresh the JWKS once and retry — handles upstream
@@ -144,11 +152,23 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 				jwt.WithValidate(true),
 				jwt.WithIssuer(upstreamIss),
 				jwt.WithAudience(cfg.Audience),
+				jwt.WithAcceptableSkew(externalIDTokenClockSkew),
 			)
 		}
 		if err != nil {
 			return nil, oauthBadRequestCause("invalid_grant", "subject_token verification failed", err)
 		}
+	}
+
+	// jwx's validation only checks exp/nbf when present; RFC 7523 §3 requires
+	// both sub and exp on an assertion. Enforce their presence explicitly so a
+	// token without an expiry (replayable forever) or without a subject is
+	// rejected rather than silently accepted.
+	if _, ok := verified.Subject(); !ok {
+		return nil, oauthBadRequest("invalid_grant", "subject_token missing required sub claim")
+	}
+	if _, ok := verified.Expiration(); !ok {
+		return nil, oauthBadRequest("invalid_grant", "subject_token missing required exp claim")
 	}
 
 	// Stale-token cap. exp guards future-side; iat guards past-side. We
@@ -209,18 +229,35 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 		customClaims[k] = v
 	}
 
+	// Resolve the identity's credential policy when we have a real identity
+	// row, so issuance enforces the same policy ceiling (allowed scopes, max
+	// TTL, trust level, policy expiry) as every other grant. The synthetic
+	// carrier identity (no application_id) has no row, hence no policy. Mirrors
+	// ExternalPrincipalExchange — without this the federation path would be a
+	// policy-bypass hole.
+	var identityPolicyID string
+	if identity.ID != "" {
+		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, identity)
+		if err != nil {
+			return nil, oauthServerError("failed to resolve identity credential policy", err)
+		}
+		identityPolicyID = policy.ID
+	}
+
 	scopes := parseScopeString(req.Scope)
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:        identity,
-		GrantType:       domain.GrantTypeTokenExchange,
-		Scopes:          scopes,
-		UseRS256:        true,
-		SubjectOverride: userID,
-		UserEmail:       userEmail,
-		UserName:        userName,
-		ApplicationID:   req.ApplicationID,
-		TTL:             900, // 15 minutes — same short-lived posture as the broker path
-		CustomClaims:    customClaims,
+		Identity:          identity,
+		IdentityPolicyID:  identityPolicyID,
+		GrantType:         domain.GrantTypeTokenExchange,
+		Scopes:            scopes,
+		UseRS256:          true,
+		SubjectOverride:   userID,
+		UserEmail:         userEmail,
+		UserName:          userName,
+		ApplicationID:     req.ApplicationID,
+		TTL:               900, // 15 minutes — same short-lived posture as the broker path
+		CustomClaims:      customClaims,
+		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
 	})
 	if err != nil {
 		return nil, oauthServerError("failed to issue external id_token exchange token", err)
@@ -257,10 +294,21 @@ func (s *OAuthService) resolveExternalPrincipalIdentity(ctx context.Context, req
 	}
 	resolved, err := s.identitySvc.GetIdentity(ctx, req.ApplicationID, req.AccountID, req.ProjectID)
 	if err != nil {
-		return nil, oauthBadRequest("invalid_request", fmt.Sprintf("application_id %s not found or access denied", req.ApplicationID))
+		// Distinguish "row not found / wrong tenant" (client error, 400) from
+		// a transient infrastructure failure (server error, 500 — retriable).
+		// The repository wraps sql.ErrNoRows for both genuine-missing and
+		// IDOR-protected cross-tenant lookups; anything else is an infra
+		// problem the client can't act on. Mirrors ExternalPrincipalExchange.
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, oauthBadRequestCause("invalid_request", fmt.Sprintf("application_id %s not found or access denied", req.ApplicationID), err)
+		}
+		return nil, oauthServerError(fmt.Sprintf("failed to look up application_id %s", req.ApplicationID), err)
 	}
 	if !resolved.Status.IsUsable() {
 		return nil, oauthBadRequest("invalid_grant", "identity is suspended or deactivated")
+	}
+	if resolved.IsExpired() {
+		return nil, oauthBadRequest("invalid_grant", "identity_expired")
 	}
 	return resolved, nil
 }
@@ -290,6 +338,12 @@ func extractMappedClaimString(claims map[string]any, path string) (string, bool)
 		return strconv.FormatFloat(tv, 'f', -1, 64), true
 	case int64:
 		return strconv.FormatInt(tv, 10), true
+	case int:
+		return strconv.Itoa(tv), true
+	case json.Number:
+		// Present when the upstream claims were decoded with UseNumber();
+		// preserves the exact textual form without float rounding.
+		return tv.String(), true
 	}
 	return "", false
 }

--- a/internal/service/oauth_external_idp.go
+++ b/internal/service/oauth_external_idp.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v4/jws"
 	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/rs/zerolog/log"
 
@@ -129,14 +130,24 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 	}
 
 	// Verify signature, exp, nbf, iss, and aud against the configured IdP
-	// in one Parse call. WithKeySet picks the right key by kid+alg from
-	// the JWKS we cache for this issuer.
+	// in one Parse call. WithKeySet picks the right key by kid from the JWKS
+	// we cache for this issuer.
+	//
+	// WithInferAlgorithmFromKey is REQUIRED, not optional: jwx selects the
+	// verification alg from the JWK's `alg` member, but many production IdPs
+	// (Microsoft Entra ID is the canonical example) publish JWKS keys with no
+	// `alg` member at all. Without inference, jwx supplies no key for those and
+	// every verification fails — i.e. federation would silently never work
+	// against Entra. Inference is safe here because checkExternalIDTokenAlg has
+	// already pinned the token header alg to the asymmetric allow-list above,
+	// and jwx's infer path additionally rejects any header alg the key type
+	// cannot produce — so HS*/none still cannot slip through.
 	keySet := entry.JWKS.KeySet()
 	if keySet == nil || keySet.Len() == 0 {
 		return nil, oauthServerError(fmt.Sprintf("JWKS for issuer %s is empty", upstreamIss), nil)
 	}
 	verified, err := jwt.Parse([]byte(req.SubjectToken),
-		jwt.WithKeySet(keySet),
+		jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
 		jwt.WithValidate(true),
 		jwt.WithIssuer(upstreamIss),
 		jwt.WithAudience(cfg.Audience),
@@ -148,7 +159,7 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 		if kid := extractJWSKeyID(req.SubjectToken); kid != "" && entry.JWKS.RefreshIfMissing(ctx, kid) {
 			keySet = entry.JWKS.KeySet()
 			verified, err = jwt.Parse([]byte(req.SubjectToken),
-				jwt.WithKeySet(keySet),
+				jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
 				jwt.WithValidate(true),
 				jwt.WithIssuer(upstreamIss),
 				jwt.WithAudience(cfg.Audience),
@@ -231,10 +242,7 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 
 	// Resolve the identity's credential policy when we have a real identity
 	// row, so issuance enforces the same policy ceiling (allowed scopes, max
-	// TTL, trust level, policy expiry) as every other grant. The synthetic
-	// carrier identity (no application_id) has no row, hence no policy. Mirrors
-	// ExternalPrincipalExchange — without this the federation path would be a
-	// policy-bypass hole.
+	// TTL, trust level, policy expiry) as every other grant.
 	var identityPolicyID string
 	if identity.ID != "" {
 		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, identity)
@@ -246,18 +254,27 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 
 	scopes := parseScopeString(req.Scope)
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:          identity,
-		IdentityPolicyID:  identityPolicyID,
-		GrantType:         domain.GrantTypeTokenExchange,
-		Scopes:            scopes,
-		UseRS256:          true,
-		SubjectOverride:   userID,
-		UserEmail:         userEmail,
-		UserName:          userName,
-		ApplicationID:     req.ApplicationID,
-		TTL:               900, // 15 minutes — same short-lived posture as the broker path
-		CustomClaims:      customClaims,
-		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
+		Identity:         identity,
+		IdentityPolicyID: identityPolicyID,
+		// Govern the synthetic-carrier path (no application_id, so no identity
+		// row and no IdentityPolicyID above) by the tenant default policy.
+		// resolveIdentityPolicyID falls back to EnsureDefaultPolicy on the
+		// request's account_id/project_id, so requested scopes are gated by the
+		// tenant policy ceiling instead of passing through ungated. Without
+		// this, any holder of a valid upstream token could request arbitrary
+		// scopes on the no-application_id path — a weaker gate than the broker
+		// path, which is at least fronted by TrustedServiceValidator.
+		ResolveIdentityPolicy: true,
+		GrantType:             domain.GrantTypeTokenExchange,
+		Scopes:                scopes,
+		UseRS256:              true,
+		SubjectOverride:       userID,
+		UserEmail:             userEmail,
+		UserName:              userName,
+		ApplicationID:         req.ApplicationID,
+		TTL:                   900, // 15 minutes — same short-lived posture as the broker path
+		CustomClaims:          customClaims,
+		DPoPKeyThumbprint:     req.DPoPKeyThumbprint,
 	})
 	if err != nil {
 		return nil, oauthServerError("failed to issue external id_token exchange token", err)

--- a/internal/service/oauth_external_idp_test.go
+++ b/internal/service/oauth_external_idp_test.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
+)
+
+// TestExtractMappedClaimString covers the v1 claim-mapping shapes the three
+// reference IdPs (Okta, Entra, Google) emit. v1 is single-level only — no
+// JSONPath, no expressions.
+func TestExtractMappedClaimString(t *testing.T) {
+	t.Run("string sub from Okta", func(t *testing.T) {
+		got, ok := extractMappedClaimString(map[string]any{"sub": "00uABC"}, "sub")
+		if !ok || got != "00uABC" {
+			t.Fatalf("expected (00uABC, true), got (%q, %v)", got, ok)
+		}
+	})
+
+	t.Run("numeric oid from Entra is stringified", func(t *testing.T) {
+		got, ok := extractMappedClaimString(map[string]any{"oid": float64(42)}, "oid")
+		if !ok || got != "42" {
+			t.Fatalf("expected (42, true), got (%q, %v)", got, ok)
+		}
+	})
+
+	t.Run("large numeric subject avoids scientific notation", func(t *testing.T) {
+		// JSON unmarshals a 16-digit integer literal into float64. %v / %g
+		// would render this as 1.234567890123456e+15 and break downstream
+		// equality checks against the upstream's stable subject identifier.
+		got, ok := extractMappedClaimString(map[string]any{"sub": float64(1234567890123456)}, "sub")
+		if !ok {
+			t.Fatalf("expected ok=true for large numeric subject")
+		}
+		if got != "1234567890123456" {
+			t.Fatalf("expected plain decimal %q, got %q", "1234567890123456", got)
+		}
+	})
+
+	t.Run("missing path returns false", func(t *testing.T) {
+		_, ok := extractMappedClaimString(map[string]any{"sub": "x"}, "email")
+		if ok {
+			t.Fatalf("expected ok=false for missing claim")
+		}
+	})
+
+	t.Run("empty path returns false", func(t *testing.T) {
+		_, ok := extractMappedClaimString(map[string]any{"sub": "x"}, "")
+		if ok {
+			t.Fatalf("empty path means no mapping configured; should be ok=false")
+		}
+	})
+
+	t.Run("non-stringifiable value returns false", func(t *testing.T) {
+		_, ok := extractMappedClaimString(map[string]any{"sub": map[string]any{}}, "sub")
+		if ok {
+			t.Fatalf("nested object cannot be coerced to string in v1; should be ok=false")
+		}
+	})
+}
+
+// TestCheckExternalIDTokenAlg verifies that the algorithm gate refuses
+// none/HS* family tokens up front and respects the configured allow-list.
+//
+// We exercise it with crafted JWS strings rather than spinning up a real
+// signer — the function only reads the protected header.
+func TestCheckExternalIDTokenAlg(t *testing.T) {
+	// alg=none token: header={"alg":"none","typ":"JWT"}, no signature.
+	// Build by hand — base64url("{\"alg\":\"none\",\"typ\":\"JWT\"}") + ".eyJ9." (empty body, empty sig)
+	// We don't bother — jws.Parse rejects unsigned tokens.
+	// Instead we test alg=HS256 which has the same payload structure but is rejected.
+	// HS256 header: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+	hs256 := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ4In0.AAAA"
+	if err := checkExternalIDTokenAlg(hs256, []string{"RS256", "ES256"}); err == nil {
+		t.Fatalf("expected HS256 to be rejected as non-asymmetric, got nil")
+	}
+
+	// RS256 with explicit allow-list match — header eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9
+	rs256 := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ4In0.AAAA"
+	if err := checkExternalIDTokenAlg(rs256, []string{"RS256"}); err != nil {
+		t.Fatalf("expected RS256 to pass with allow-list [RS256], got %v", err)
+	}
+
+	// RS256 with an allow-list that excludes it.
+	if err := checkExternalIDTokenAlg(rs256, []string{"ES256"}); err == nil {
+		t.Fatalf("expected RS256 to be rejected when allow-list is [ES256]")
+	}
+
+	// Empty allow-list → defaults to the hard whitelist of asymmetric algs.
+	if err := checkExternalIDTokenAlg(rs256, nil); err != nil {
+		t.Fatalf("expected RS256 to pass with empty allow-list, got %v", err)
+	}
+}
+
+// TestExternalIDTokenExchange_UnknownIssuerWrapsSentinel verifies the dual
+// signaling path for the unknown-issuer case: the OAuth handler picks up the
+// error code via errors.As on *OAuthError, while service-layer callers can
+// branch with errors.Is(ErrUnknownExternalIssuer).
+func TestExternalIDTokenExchange_UnknownIssuerWrapsSentinel(t *testing.T) {
+	// Build a registry that knows iss=A but not iss=B.
+	jwks := newFakeJWKSServer(t, "kid-1")
+	defer jwks.Close()
+
+	cfg := domain.ExternalIssuerConfig{
+		Issuer:       "https://known.example.test",
+		JWKSURI:      jwks.URL(),
+		Audience:     "https://zeroid.example.test",
+		ClaimMapping: map[string]string{"user_id": "sub"},
+	}
+	cfg.Defaults()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate cfg: %v", err)
+	}
+	registry, err := NewExternalIssuerRegistry(
+		context.Background(),
+		[]domain.ExternalIssuerConfig{cfg},
+		authjwt.WithHTTPClient(insecureHTTPClient(2*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("NewExternalIssuerRegistry: %v", err)
+	}
+	defer registry.Close()
+
+	// Mint a JWT whose iss is *not* the configured one. Lookup should miss
+	// and the federation path should return before any signature work.
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tok, err := jwt.NewBuilder().
+		Issuer("https://stranger.example.test").
+		Subject("alice").
+		IssuedAt(time.Now()).
+		Expiration(time.Now().Add(5 * time.Minute)).
+		Build()
+	if err != nil {
+		t.Fatalf("build token: %v", err)
+	}
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), priv))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	svc := &OAuthService{externalIssuerRegistry: registry}
+	_, err = svc.externalIDTokenExchange(context.Background(), TokenRequest{
+		SubjectToken: string(signed),
+		AccountID:    "acct",
+		ProjectID:    "proj",
+	})
+	if err == nil {
+		t.Fatalf("expected error for unknown issuer, got nil")
+	}
+
+	// Handler path: errors.As on *OAuthError must yield invalid_request / 400.
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError in chain, got %T: %v", err, err)
+	}
+	if oauthErr.Code != "invalid_request" {
+		t.Errorf("Code = %q, want invalid_request", oauthErr.Code)
+	}
+	if oauthErr.HTTPStatus != http.StatusBadRequest {
+		t.Errorf("HTTPStatus = %d, want 400", oauthErr.HTTPStatus)
+	}
+
+	// Caller path: errors.Is on the sentinel must succeed.
+	if !errors.Is(err, ErrUnknownExternalIssuer) {
+		t.Errorf("expected errors.Is(err, ErrUnknownExternalIssuer) to be true; chain = %v", err)
+	}
+}

--- a/internal/service/oauth_external_idp_test.go
+++ b/internal/service/oauth_external_idp_test.go
@@ -113,10 +113,11 @@ func TestExternalIDTokenExchange_UnknownIssuerWrapsSentinel(t *testing.T) {
 	defer jwks.Close()
 
 	cfg := domain.ExternalIssuerConfig{
-		Issuer:       "https://known.example.test",
-		JWKSURI:      jwks.URL(),
-		Audience:     "https://zeroid.example.test",
-		ClaimMapping: map[string]string{"user_id": "sub"},
+		Issuer:          "https://known.example.test",
+		JWKSURI:         jwks.URL(),
+		Audience:        "https://zeroid.example.test",
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct"},
 	}
 	cfg.Defaults()
 	if err := cfg.Validate(); err != nil {

--- a/server.go
+++ b/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 	"github.com/highflame-ai/zeroid/internal/telemetry"
 	"github.com/highflame-ai/zeroid/internal/worker"
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
 )
 
 // middlewareHolder stores an optional middleware in a thread-safe way.
@@ -77,6 +78,12 @@ type Server struct {
 	backchannelSvc      *service.BackchannelService
 	jwksSvc             *signing.JWKSService
 	refreshTokenSvc     *service.RefreshTokenService
+
+	// External OIDC IdP federation (issue #88). Holds a JWKS client per
+	// configured trusted upstream issuer. Nil when no external_issuers are
+	// configured.
+	externalIssuerRegistry *service.ExternalIssuerRegistry
+
 	// revocationDispatcher fans out RevocationEvents
 	// to the deployer-supplied RevocationNotifier. Shared by credentialSvc and
 	// refreshTokenSvc so SetRevocationNotifier wires every revocation path.
@@ -102,9 +109,35 @@ type namedPrincipalResolver struct {
 	fn   PrincipalResolver
 }
 
+// ServerOption configures NewServer. Provided for narrow build-time
+// concerns that can't reasonably be expressed in Config (e.g. injecting a
+// custom HTTP client into the external-issuer JWKS fetch path for tests).
+type ServerOption func(*serverOptions)
+
+// serverOptions is the internal accumulator behind ServerOption.
+type serverOptions struct {
+	externalIssuerJWKSOpts []authjwt.JWKSOption
+}
+
+// WithExternalIssuerJWKSOption forwards an authjwt JWKS option to the
+// external-issuer registry built inside NewServer. Intended primarily for
+// tests that need to bypass TLS verification when pointing the registry at
+// a fake JWKS server (httptest.NewTLSServer); production deployers should
+// not need this.
+func WithExternalIssuerJWKSOption(opt authjwt.JWKSOption) ServerOption {
+	return func(o *serverOptions) {
+		o.externalIssuerJWKSOpts = append(o.externalIssuerJWKSOpts, opt)
+	}
+}
+
 // NewServer initializes all ZeroID subsystems: database, migrations, signing keys,
 // repositories, services, handlers, and the HTTP router.
-func NewServer(cfg Config) (*Server, error) {
+func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
+	options := serverOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	initLogging(cfg.Logging.Level)
 
 	if err := cfg.Validate(); err != nil {
@@ -237,6 +270,22 @@ func NewServer(cfg Config) (*Server, error) {
 	// forces allow_unauthenticated_token_inspection=false in production, so
 	// production is strict by default.
 	oauthSvc.SetRequireTokenInspectionAuth(!cfg.Token.AllowUnauthenticatedTokenInspection)
+
+	// Build the external-issuer registry when the deployer has configured
+	// trusted upstream IdPs. JWKS warm-up is best-effort (authjwt does not
+	// fail on an unreachable issuer, to survive transient IdP outages during
+	// deploy); an issuer that never loads fails closed at token-exchange time.
+	var externalIssuerRegistry *service.ExternalIssuerRegistry
+	if len(cfg.ExternalIssuers) > 0 {
+		registry, err := service.NewExternalIssuerRegistry(context.Background(), cfg.ExternalIssuers, options.externalIssuerJWKSOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize external OIDC issuer registry (issue #88): %w", err)
+		}
+		oauthSvc.SetExternalIssuerRegistry(registry)
+		externalIssuerRegistry = registry
+		log.Info().Int("count", len(cfg.ExternalIssuers)).Msg("Direct OIDC IdP federation enabled")
+	}
+
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
 	// DelegationService is read-only over credentialRepo / delegationRepo /
 	// identityRepo and has no service dependencies of its own.
@@ -399,26 +448,27 @@ func NewServer(cfg Config) (*Server, error) {
 	idleTimeout := parseDurationOrDefault(cfg.Server.IdleTimeout, 60*time.Second)
 
 	srv := &Server{
-		cfg:                  cfg,
-		db:                   db,
-		router:               r,
-		identitySvc:          identitySvc,
-		credentialSvc:        credentialSvc,
-		credentialPolicySvc:  credentialPolicySvc,
-		attestationSvc:       attestationSvc,
-		proofSvc:             proofSvc,
-		oauthSvc:             oauthSvc,
-		oauthClientSvc:       oauthClientSvc,
-		signalSvc:            signalSvc,
-		apiKeySvc:            apiKeySvc,
-		agentSvc:             agentSvc,
-		backchannelSvc:       backchannelSvc,
-		jwksSvc:              jwksSvc,
-		refreshTokenSvc:      refreshTokenSvc,
-		revocationDispatcher: revocationDispatcher,
-		cleanupWorker:        worker.NewCleanupWorker(db, backchannelRepo, time.Hour, time.Duration(cfg.Token.MaxTTL)*time.Second),
-		adminAuthState:       authState,
-		globalMWState:        globalMW,
+		cfg:                    cfg,
+		db:                     db,
+		router:                 r,
+		identitySvc:            identitySvc,
+		credentialSvc:          credentialSvc,
+		credentialPolicySvc:    credentialPolicySvc,
+		attestationSvc:         attestationSvc,
+		proofSvc:               proofSvc,
+		oauthSvc:               oauthSvc,
+		oauthClientSvc:         oauthClientSvc,
+		signalSvc:              signalSvc,
+		apiKeySvc:              apiKeySvc,
+		agentSvc:               agentSvc,
+		backchannelSvc:         backchannelSvc,
+		jwksSvc:                jwksSvc,
+		refreshTokenSvc:        refreshTokenSvc,
+		externalIssuerRegistry: externalIssuerRegistry,
+		revocationDispatcher:   revocationDispatcher,
+		cleanupWorker:          worker.NewCleanupWorker(db, backchannelRepo, time.Hour, time.Duration(cfg.Token.MaxTTL)*time.Second),
+		adminAuthState:         authState,
+		globalMWState:          globalMW,
 		http: &http.Server{
 			Addr:         ":" + cfg.Server.Port,
 			Handler:      r,
@@ -493,6 +543,10 @@ func (s *Server) Start() error {
 func (s *Server) Shutdown(ctx context.Context) error {
 	if s.workerCancel != nil {
 		s.workerCancel()
+	}
+
+	if s.externalIssuerRegistry != nil {
+		s.externalIssuerRegistry.Close()
 	}
 
 	// Cancel the CIBA backchannel service's lifecycle context so detached

--- a/tests/integration/external_idp_hardening_test.go
+++ b/tests/integration/external_idp_hardening_test.go
@@ -1,0 +1,372 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// This file hardens the direct-OIDC-federation e2e coverage beyond the single
+// ES256 happy path in external_idp_test.go. Every case drives the REAL
+// /oauth2/token HTTP endpoint of a real zeroid.NewServer (backed by the shared
+// testcontainers Postgres) against a fake upstream IdP served over TLS — i.e.
+// the full request path, not a unit shim.
+//
+// The headline case (TestExternalIDTokenFederation_NoAlgKeyAndAlgVariants) uses
+// an Entra-shaped JWKS key that OMITS the `alg` member. jwx selects the verify
+// algorithm from the key's `alg`; with no `alg` and without
+// WithInferAlgorithmFromKey, it supplies no key and verification fails. This
+// test therefore fails outright without the inference fix in
+// externalIDTokenExchange — it is the regression guard for the "works in tests,
+// silently broken against Entra/real IdPs" trap.
+
+// fakeRSAIdP is a fake upstream OIDC IdP that signs RS256/PS256 tokens and
+// publishes an RSA JWKS over TLS. includeAlg controls whether the published JWK
+// carries an `alg` member (real IdPs vary: Okta/Auth0/Google include it,
+// Microsoft Entra ID does not). It supports key rotation for the refresh test.
+type fakeRSAIdP struct {
+	srv    *httptest.Server
+	mu     sync.Mutex
+	priv   *rsa.PrivateKey
+	kid    string
+	keySet jwk.Set
+}
+
+func newFakeRSAIdP(t *testing.T, kid string, includeAlg bool) *fakeRSAIdP {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	idp := &fakeRSAIdP{
+		priv:   priv,
+		kid:    kid,
+		keySet: buildRSAJWKS(t, &priv.PublicKey, kid, includeAlg),
+	}
+	idp.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		idp.mu.Lock()
+		ks := idp.keySet
+		idp.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ks)
+	}))
+	return idp
+}
+
+func (i *fakeRSAIdP) JWKSURL() string { return i.srv.URL }
+func (i *fakeRSAIdP) Close()          { i.srv.Close() }
+
+// signKey/signKID return the current signing material under lock.
+func (i *fakeRSAIdP) signKey() (*rsa.PrivateKey, string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.priv, i.kid
+}
+
+// sign mints an RS256 token with the current key/kid.
+func (i *fakeRSAIdP) sign(t *testing.T, claims map[string]any) string {
+	key, kid := i.signKey()
+	return signRSAToken(t, jwa.RS256(), key, kid, claims)
+}
+
+// rotate swaps in a fresh key under a new kid and serves only the new JWKS,
+// mimicking an upstream key rotation. The registry's cached JWKS (holding the
+// old kid) must refetch on demand to verify a token signed with the new key.
+func (i *fakeRSAIdP) rotate(t *testing.T, newKid string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	i.mu.Lock()
+	i.priv = priv
+	i.kid = newKid
+	i.keySet = buildRSAJWKS(t, &priv.PublicKey, newKid, true)
+	i.mu.Unlock()
+}
+
+func buildRSAJWKS(t *testing.T, pub *rsa.PublicKey, kid string, includeAlg bool) jwk.Set {
+	t.Helper()
+	set := jwk.NewSet()
+	k, err := jwk.Import[jwk.Key](pub)
+	require.NoError(t, err)
+	require.NoError(t, k.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, k.Set(jwk.KeyUsageKey, jwk.ForSignature))
+	if includeAlg {
+		require.NoError(t, k.Set(jwk.AlgorithmKey, jwa.RS256()))
+	}
+	require.NoError(t, set.AddKey(k))
+	return set
+}
+
+// signRSAToken hand-signs a token with an explicit alg/key/kid so tests can
+// forge mismatches (e.g. sign with an attacker key while advertising the real
+// kid, or sign PS256 against an RSA key).
+func signRSAToken(t *testing.T, alg jwa.SignatureAlgorithm, key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	t.Helper()
+	tok := jwt.New()
+	for k, v := range claims {
+		require.NoError(t, tok.Set(k, v))
+	}
+	hdr := jws.NewHeaders()
+	require.NoError(t, hdr.Set(jws.KeyIDKey, kid))
+	require.NoError(t, hdr.Set(jws.TypeKey, "JWT"))
+	signed, err := jwt.Sign(tok, jwt.WithKey(alg, key, jws.WithProtectedHeaders(hdr)))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+func federationExchangeBody(idToken, accountID, projectID string) map[string]any {
+	return map[string]any{
+		"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":      idToken,
+		"subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+		"account_id":         accountID,
+		"project_id":         projectID,
+	}
+}
+
+// TestExternalIDTokenFederation_NoAlgKeyAndAlgVariants is the P1-A regression
+// guard: it federates against an IdP whose JWKS key omits `alg` (Entra-shaped),
+// across RS256 and PS256 tokens. Without WithInferAlgorithmFromKey these all
+// fail with "no key in the key set was usable".
+func TestExternalIDTokenFederation_NoAlgKeyAndAlgVariants(t *testing.T) {
+	iss := "https://noalg.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "noalg-kid-1", false /* includeAlg — Entra omits it */)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub", "email": "email"},
+		AllowedAccounts: []string{"acct-fed-001"},
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	validClaims := func() map[string]any {
+		now := time.Now()
+		return map[string]any{
+			"iss":   iss,
+			"aud":   aud,
+			"sub":   "entra-user-oid-1",
+			"email": "carol@example.com",
+			"iat":   now.Unix(),
+			"exp":   now.Add(5 * time.Minute).Unix(),
+		}
+	}
+
+	t.Run("RS256 token with no-alg JWKS key verifies and emits user_id_iss", func(t *testing.T) {
+		idToken := idp.sign(t, validClaims())
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"no-alg JWKS key must verify (requires WithInferAlgorithmFromKey); body=%s", resp.RawBody)
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		require.Equal(t, iss, claims["user_id_iss"])
+		require.Equal(t, "external_id_token", claims["token_exchange"])
+		require.Equal(t, "entra-user-oid-1", claims["sub"])
+	})
+
+	t.Run("PS256 token with no-alg JWKS key verifies", func(t *testing.T) {
+		key, kid := idp.signKey()
+		idToken := signRSAToken(t, jwa.PS256(), key, kid, validClaims())
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"PS256 over a no-alg RSA key must verify via inference; body=%s", resp.RawBody)
+	})
+}
+
+// TestExternalIDTokenFederation_CrossTenantRejected is the P1-B regression
+// guard: an upstream token is bound to ZeroID-the-RP via aud, but NOT to a
+// ZeroID tenant. Only allowed_accounts binds it. A request that presents a
+// valid token under a tenant not in allowed_accounts must be rejected before
+// any token is minted.
+func TestExternalIDTokenFederation_CrossTenantRejected(t *testing.T) {
+	iss := "https://tenant.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "tenant-kid-1", true)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct-fed-001"}, // matches fedCfg.AccountID; "acct-evil" is not listed
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	now := time.Now()
+	idToken := idp.sign(t, map[string]any{
+		"iss": iss, "aud": aud, "sub": "user-x",
+		"iat": now.Unix(), "exp": now.Add(5 * time.Minute).Unix(),
+	})
+
+	t.Run("allowed tenant succeeds", func(t *testing.T) {
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+	})
+
+	t.Run("disallowed tenant is rejected (no cross-tenant minting)", func(t *testing.T) {
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, "acct-evil", "proj-evil"))
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+			"a token must not be exchangeable under a tenant not in allowed_accounts; body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken, "no token may be minted for a disallowed tenant")
+	})
+}
+
+// TestExternalIDTokenFederation_VerificationNegatives drives the core
+// verification rules: aud binding, exp/iat freshness, signature integrity,
+// required-claim presence, and the unknown-issuer guard. All must fail closed
+// with a 400 and no minted token. The baseline confirms the same server mints
+// on a clean token, so each rejection is attributable to the single mutation.
+func TestExternalIDTokenFederation_VerificationNegatives(t *testing.T) {
+	iss := "https://neg.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "neg-kid-1", true)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct-fed-001"},
+		// MaxTokenAge left at the 10m default; the stale-iat case exceeds it.
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	base := func() map[string]any {
+		now := time.Now()
+		return map[string]any{
+			"iss": iss, "aud": aud, "sub": "user-neg",
+			"iat": now.Unix(), "exp": now.Add(5 * time.Minute).Unix(),
+		}
+	}
+
+	// Baseline: a clean token mints, so every failure below is the mutation's
+	// doing and not a misconfigured server.
+	t.Run("baseline clean token mints", func(t *testing.T) {
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idp.sign(t, base()), fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+	})
+
+	cases := []struct {
+		name  string
+		token func(t *testing.T) string
+	}{
+		{"wrong audience", func(t *testing.T) string {
+			c := base()
+			c["aud"] = "https://some.other.rp"
+			return idp.sign(t, c)
+		}},
+		{"expired exp", func(t *testing.T) string {
+			c := base()
+			c["exp"] = time.Now().Add(-2 * time.Minute).Unix() // beyond the 60s skew
+			return idp.sign(t, c)
+		}},
+		{"stale iat beyond max_token_age", func(t *testing.T) string {
+			now := time.Now()
+			c := base()
+			c["iat"] = now.Add(-20 * time.Minute).Unix() // > 10m default cap
+			c["exp"] = now.Add(5 * time.Minute).Unix()   // still unexpired
+			return idp.sign(t, c)
+		}},
+		{"missing iat", func(t *testing.T) string {
+			c := base()
+			delete(c, "iat")
+			return idp.sign(t, c)
+		}},
+		{"missing exp", func(t *testing.T) string {
+			c := base()
+			delete(c, "exp")
+			return idp.sign(t, c)
+		}},
+		{"missing sub", func(t *testing.T) string {
+			c := base()
+			delete(c, "sub")
+			return idp.sign(t, c)
+		}},
+		{"bad signature (attacker key, real kid)", func(t *testing.T) string {
+			attacker, err := rsa.GenerateKey(rand.Reader, 2048)
+			require.NoError(t, err)
+			_, kid := idp.signKey()
+			return signRSAToken(t, jwa.RS256(), attacker, kid, base())
+		}},
+		{"unknown issuer", func(t *testing.T) string {
+			c := base()
+			c["iss"] = "https://stranger.idp.test" // not configured → invalid_request
+			return idp.sign(t, c)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" rejected", func(t *testing.T) {
+			resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(tc.token(t), fedCfg.AccountID, fedCfg.ProjectID))
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+				"%s must be rejected with 400; body=%s", tc.name, resp.RawBody)
+			require.Empty(t, resp.AccessToken, "%s must not mint a token", tc.name)
+		})
+	}
+}
+
+// TestExternalIDTokenFederation_KeyRotation proves the on-demand JWKS refresh:
+// the registry warms up with kid-1, the upstream rotates to kid-2, and a token
+// signed with kid-2 must still verify (the verifier refetches the JWKS once on
+// an unknown kid and retries) — no ZeroID restart required.
+func TestExternalIDTokenFederation_KeyRotation(t *testing.T) {
+	iss := "https://rotate.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "rot-kid-1", true)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct-fed-001"},
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	mk := func() map[string]any {
+		now := time.Now()
+		return map[string]any{
+			"iss": iss, "aud": aud, "sub": "user-rot",
+			"iat": now.Unix(), "exp": now.Add(5 * time.Minute).Unix(),
+		}
+	}
+
+	// Sanity: kid-1 (already warm in the cache) verifies.
+	resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idp.sign(t, mk()), fedCfg.AccountID, fedCfg.ProjectID))
+	require.Equal(t, http.StatusOK, resp.StatusCode, "pre-rotation token must verify; body=%s", resp.RawBody)
+
+	// Upstream rotates to a brand-new key+kid the cache has never seen.
+	idp.rotate(t, "rot-kid-2")
+
+	resp = postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idp.sign(t, mk()), fedCfg.AccountID, fedCfg.ProjectID))
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"post-rotation token must verify after on-demand JWKS refresh; body=%s", resp.RawBody)
+	claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+	require.Equal(t, iss, claims["user_id_iss"])
+}

--- a/tests/integration/external_idp_helpers_test.go
+++ b/tests/integration/external_idp_helpers_test.go
@@ -1,0 +1,79 @@
+package integration_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+
+	"github.com/lestrrat-go/jwx/v4/jws"
+)
+
+// sharedDBURL is the DSN of the shared TestMain Postgres container. It is
+// captured on first use by the federation test helpers — we copy it from
+// the bun.DB handle's underlying connector. Set in TestMain before any
+// per-test code runs.
+var sharedDBURL string
+
+// federationKeyPaths holds the temp PEM file paths for the federation
+// server's signing keys. Generated once on first federation-test access so
+// every federation-server instance reuses the same keys (which is fine —
+// no other test reads from these key files).
+var fedKeyPaths struct {
+	privPath string
+	pubPath  string
+	rsaPriv  string
+	rsaPub   string
+}
+
+// initFederationKeyMaterial generates and writes the temp PEM files used
+// by every federation server constructed in these tests. Called lazily from
+// the federation tests themselves (TestMain has no hook).
+func initFederationKeyMaterial() error {
+	if fedKeyPaths.privPath != "" {
+		return nil
+	}
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+	privPath, pubPath, _, err := writeKeyFiles(privKey)
+	if err != nil {
+		return err
+	}
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+	rsaPriv, rsaPub, _, err := writeRSAKeyFiles(rsaKey)
+	if err != nil {
+		return err
+	}
+	fedKeyPaths.privPath = privPath
+	fedKeyPaths.pubPath = pubPath
+	fedKeyPaths.rsaPriv = rsaPriv
+	fedKeyPaths.rsaPub = rsaPub
+	return nil
+}
+
+// jwsHeadersForKID returns a jws header object carrying kid + typ — used by
+// the fake upstream IdP to mint tokens whose protected header announces the
+// signing key the registry must look up.
+func jwsHeadersForKID(kid string) (jws.Headers, error) {
+	hdr := jws.NewHeaders()
+	if err := hdr.Set(jws.KeyIDKey, kid); err != nil {
+		return nil, err
+	}
+	if err := hdr.Set(jws.TypeKey, "JWT"); err != nil {
+		return nil, err
+	}
+	return hdr, nil
+}
+
+// jwtDecodeSegment base64url-decodes a JWT payload segment. Mirrors what
+// jwt.Parse would do internally without running any signature checks —
+// callers in this package only need the claim map for assertions.
+func jwtDecodeSegment(seg string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(seg)
+}

--- a/tests/integration/external_idp_test.go
+++ b/tests/integration/external_idp_test.go
@@ -1,0 +1,318 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	zeroid "github.com/highflame-ai/zeroid"
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
+)
+
+// TestExternalIDTokenFederation_EndToEnd covers the two manual smoke items
+// in PR #124's test plan:
+//
+//   - Item 2: configure one external issuer, post an Okta-shaped ID token,
+//     observe `user_id_iss` on the issued token.
+//   - Item 3: with the same server, omit subject_token_type and confirm
+//     dispatch still routes to the broker path (proven by the broker
+//     succeeding and emitting token_exchange=external_principal on the
+//     issued JWT — a structural fingerprint that survives error-message
+//     wording changes).
+//
+// The federation server is a SECOND zeroid.NewServer instance pointed at
+// the same Postgres as the shared TestMain server — adding external_issuers
+// to the shared cfg would touch every other test, so we keep this one
+// isolated. The fake upstream IdP runs as an httptest.NewTLSServer and the
+// registry's HTTP client is overridden via the new
+// zeroid.WithExternalIssuerJWKSOption hook so it can talk to the test cert.
+func TestExternalIDTokenFederation_EndToEnd(t *testing.T) {
+	upstreamIss := "https://upstream.idp.test"
+	federationAud := "https://zeroid.federation.test"
+
+	// Stand up a fake upstream IdP with one ES256 key.
+	upstream := newFakeUpstreamIdP(t)
+	defer upstream.Close()
+
+	// Build a federation-configured server alongside the shared one.
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:   upstreamIss,
+		JWKSURI:  upstream.JWKSURL(),
+		Audience: federationAud,
+		ClaimMapping: map[string]string{
+			"user_id": "sub",
+			"email":   "email",
+		},
+		PropagateClaims: []string{"auth_time", "acr", "amr"},
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	t.Run("federation happy path emits user_id_iss", func(t *testing.T) {
+		// Mint an Okta-shaped ID token. Okta uses `sub` as a stable string
+		// identifier and emits `auth_time`/`amr` from the authentication event.
+		now := time.Now()
+		idToken := upstream.SignToken(t, map[string]any{
+			"iss":       upstreamIss,
+			"aud":       federationAud,
+			"sub":       "00uABCDE12345",
+			"email":     "alice@example.com",
+			"iat":       now.Unix(),
+			"exp":       now.Add(5 * time.Minute).Unix(),
+			"auth_time": now.Add(-30 * time.Second).Unix(),
+			"amr":       []string{"pwd", "mfa"},
+			"acr":       "urn:okta:app:mfa:factor:push",
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+			"subject_token":      idToken,
+			"subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+			"account_id":         fedCfg.AccountID,
+			"project_id":         fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode, "federation /oauth2/token must return 200; body=%s", resp.RawBody)
+
+		issuedClaims := decodeIssuedTokenClaims(t, resp.AccessToken)
+
+		// The headline assertion: user_id_iss is the upstream IdP's iss,
+		// giving downstream consumers IdP-granular provenance.
+		require.Equal(t, upstreamIss, issuedClaims["user_id_iss"],
+			"issued token must carry user_id_iss = upstream iss")
+
+		// The federation path emits token_exchange=external_id_token, which
+		// distinguishes it from the broker's external_principal value.
+		require.Equal(t, "external_id_token", issuedClaims["token_exchange"])
+
+		// Honest claim propagation: auth_time/amr/acr were on the upstream,
+		// so they should be on the issued token. The federation path never
+		// default-fills these — we already verified absence in earlier unit
+		// tests; this test verifies presence-when-upstream-set.
+		require.Contains(t, issuedClaims, "auth_time")
+		require.Contains(t, issuedClaims, "amr")
+		require.Equal(t, "urn:okta:app:mfa:factor:push", issuedClaims["acr"])
+
+		// Subject identifier flows through claim_mapping: user_id is mapped
+		// to "sub", so the issued JWT's `sub` claim is the upstream `sub`.
+		// (`user_id` itself isn't emitted as a JWT claim — it's on the API
+		// response struct only, mirroring the broker path's behavior.)
+		require.Equal(t, "00uABCDE12345", issuedClaims["sub"])
+		require.Equal(t, "alice@example.com", issuedClaims["user_email"])
+	})
+
+	t.Run("broker dispatch unchanged when subject_token_type is omitted", func(t *testing.T) {
+		// Same federation-configured server, but with a TrustedServiceValidator
+		// wired so the broker arm can actually succeed. Dispatch must NOT
+		// reach the federation path; it must reach ExternalPrincipalExchange.
+		// We assert on a *structural* fingerprint — the issued JWT's
+		// `token_exchange` claim — rather than an error-message substring,
+		// so the test cannot silently degrade if wording changes.
+		fedSrv.SetTrustedServiceValidator(func(_ context.Context) (string, error) {
+			return "test-broker", nil
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+			"subject_token": "opaque-broker-presented-token",
+			"account_id":    fedCfg.AccountID,
+			"project_id":    fedCfg.ProjectID,
+			"user_id":       "alice",
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"broker path with TrustedServiceValidator must succeed; body=%s", resp.RawBody)
+
+		issuedClaims := decodeIssuedTokenClaims(t, resp.AccessToken)
+
+		// The structural fingerprint: broker arm stamps "external_principal",
+		// federation arm stamps "external_id_token". Asserting the broker
+		// value (and explicitly *not* the federation value) proves dispatch
+		// routed to the broker even without inspecting any error message.
+		require.Equal(t, "external_principal", issuedClaims["token_exchange"],
+			"broker fingerprint missing — dispatch may have leaked into the federation path")
+		require.NotEqual(t, "external_id_token", issuedClaims["token_exchange"],
+			"federation-path token_exchange value leaked — dispatch routed wrong")
+	})
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type fakeUpstreamIdP struct {
+	srv    *httptest.Server
+	priv   *ecdsa.PrivateKey
+	keyID  string
+	keySet jwk.Set
+	hits   atomic.Int64
+}
+
+func newFakeUpstreamIdP(t *testing.T) *fakeUpstreamIdP {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	keyID := "upstream-key-1"
+	keySet := jwk.NewSet()
+	pub, err := jwk.Import[jwk.Key](&priv.PublicKey)
+	require.NoError(t, err)
+	require.NoError(t, pub.Set(jwk.KeyIDKey, keyID))
+	require.NoError(t, pub.Set(jwk.AlgorithmKey, jwa.ES256()))
+	require.NoError(t, pub.Set(jwk.KeyUsageKey, jwk.ForSignature))
+	require.NoError(t, keySet.AddKey(pub))
+
+	idp := &fakeUpstreamIdP{priv: priv, keyID: keyID, keySet: keySet}
+	idp.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idp.hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(idp.keySet)
+	}))
+	return idp
+}
+
+func (i *fakeUpstreamIdP) JWKSURL() string { return i.srv.URL }
+func (i *fakeUpstreamIdP) Close()          { i.srv.Close() }
+
+// SignToken serialises the given claim map as an ES256 JWT. We use a hand
+// rolled token rather than jwt.NewBuilder because we want full control over
+// claim shape (e.g. amr as a string slice, auth_time as a unix int) to mimic
+// real-world IdP outputs.
+func (i *fakeUpstreamIdP) SignToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	tok := jwt.New()
+	for k, v := range claims {
+		require.NoError(t, tok.Set(k, v))
+	}
+	hdr, err := jwsHeadersForKID(i.keyID)
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok,
+		jwt.WithKey(jwa.ES256(), i.priv, jws.WithProtectedHeaders(hdr)),
+	)
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// federationServerCfg captures the bits the test needs to drive the server.
+type federationServerCfg struct {
+	AccountID string
+	ProjectID string
+}
+
+// newFederationServer spins up a second zeroid.NewServer wired to the same
+// Postgres as the shared TestMain server but with the given external_issuer
+// configured. The fake JWKS runs over TLS, so we use
+// WithExternalIssuerJWKSOption + an insecure HTTP client to let the registry
+// reach it without trusting the test cert chain.
+func newFederationServer(t *testing.T, issuer domain.ExternalIssuerConfig) (*zeroid.Server, *httptest.Server, federationServerCfg) {
+	t.Helper()
+	require.NoError(t, initFederationKeyMaterial(), "init federation key material")
+
+	cfg := zeroid.Config{
+		Server: zeroid.ServerConfig{
+			Port:                   "0",
+			Env:                    "test",
+			ShutdownTimeoutSeconds: 5,
+		},
+		Database: zeroid.DatabaseConfig{
+			URL:          sharedDBURL,
+			MaxOpenConns: 5,
+			MaxIdleConns: 2,
+		},
+		Keys: zeroid.KeysConfig{
+			PrivateKeyPath:    fedKeyPaths.privPath,
+			PublicKeyPath:     fedKeyPaths.pubPath,
+			KeyID:             "fed-test-key-1",
+			RSAPrivateKeyPath: fedKeyPaths.rsaPriv,
+			RSAPublicKeyPath:  fedKeyPaths.rsaPub,
+			RSAKeyID:          "fed-test-rsa-1",
+		},
+		Token: zeroid.TokenConfig{
+			Issuer:         "https://federation.zeroid.test",
+			DefaultTTL:     3600,
+			MaxTTL:         90 * 24 * 3600,
+			HMACSecret:     testHMACSecret,
+			AuthCodeIssuer: "https://federation.zeroid.test",
+		},
+		Telemetry:       zeroid.TelemetryConfig{Enabled: false},
+		Logging:         zeroid.LoggingConfig{Level: "warn"},
+		WIMSEDomain:     testWIMSE,
+		ExternalIssuers: []domain.ExternalIssuerConfig{issuer},
+	}
+
+	insecure := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}, //nolint:gosec
+	}
+	srv, err := zeroid.NewServer(cfg, zeroid.WithExternalIssuerJWKSOption(authjwt.WithHTTPClient(insecure)))
+	require.NoError(t, err, "build federation server")
+
+	httpSrv := httptest.NewServer(srv.Router())
+
+	return srv, httpSrv, federationServerCfg{
+		AccountID: "acct-fed-001",
+		ProjectID: "proj-fed-001",
+	}
+}
+
+// tokenResponse decodes the relevant fields off /oauth2/token responses.
+type tokenResponse struct {
+	StatusCode  int
+	AccessToken string
+	RawBody     string
+}
+
+func postFederation(t *testing.T, baseURL string, body map[string]any) tokenResponse {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/oauth2/token", strings.NewReader(string(b)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	var raw map[string]any
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&raw); err != nil {
+		// Best-effort: the body might not be JSON on certain server errors.
+		return tokenResponse{StatusCode: resp.StatusCode, RawBody: fmt.Sprintf("%v", err)}
+	}
+	at, _ := raw["access_token"].(string)
+	rawBytes, _ := json.Marshal(raw)
+	return tokenResponse{
+		StatusCode:  resp.StatusCode,
+		AccessToken: at,
+		RawBody:     string(rawBytes),
+	}
+}
+
+// decodeIssuedTokenClaims base64url-decodes the JWT payload section without
+// verifying — we only need the claim map for assertions, and the issuer
+// (the federation server we just built) is trusted by the test scope.
+func decodeIssuedTokenClaims(t *testing.T, tokenStr string) map[string]any {
+	t.Helper()
+	require.NotEmpty(t, tokenStr, "access_token must be non-empty")
+	parts := strings.Split(tokenStr, ".")
+	require.Len(t, parts, 3, "JWT must have 3 parts")
+	payload, err := jwtDecodeSegment(parts[1])
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(payload, &m))
+	return m
+}

--- a/tests/integration/external_idp_test.go
+++ b/tests/integration/external_idp_test.go
@@ -60,6 +60,7 @@ func TestExternalIDTokenFederation_EndToEnd(t *testing.T) {
 			"user_id": "sub",
 			"email":   "email",
 		},
+		AllowedAccounts: []string{"acct-fed-001"},
 		PropagateClaims: []string{"auth_time", "acr", "amr"},
 	})
 	defer fedHTTPSrv.Close()

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -170,6 +170,7 @@ func runTests(m *testing.M) int {
 		fmt.Fprintf(os.Stderr, "get connection string: %v\n", err)
 		return 1
 	}
+	sharedDBURL = dbURL // used by federation-test helpers (external_idp_test.go).
 
 	// Generate the server's ECDSA P-256 key pair and write to temp files.
 	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/zeroid.yaml
+++ b/zeroid.yaml
@@ -112,3 +112,21 @@ backchannel:
   # this false (see GHSA-599q-j34m-33vc).
   # Env: ZEROID_BACKCHANNEL_ALLOW_PRIVATE_ENDPOINTS
   allow_private_notification_endpoints: false
+
+# Direct OIDC IdP federation (issue #88).
+# Each entry registers a trusted upstream issuer for RFC 8693 token exchange
+# with subject_token_type=urn:ietf:params:oauth:token-type:id_token.
+# When empty (default), only the broker path remains available.
+# external_issuers:
+#   - issuer:           "https://auth.example.okta.com"
+#     jwks_uri:         "https://auth.example.okta.com/.well-known/jwks.json"
+#     audience:         "https://zeroid.example.com"
+#     algorithms:       ["RS256", "ES256"]
+#     max_token_age:    10m
+#     jwks_cache_ttl:   5m
+#     claim_mapping:
+#       user_id:        sub
+#       email:          email
+#     allowed_accounts: []   # empty = any tenant
+#     propagate_claims: ["auth_time", "acr", "amr"]
+#     allow_private_endpoints: false  # true ONLY for an internal/VPN IdP or localhost dev — relaxes the SSRF guard on the jwks_uri fetch

--- a/zeroid.yaml
+++ b/zeroid.yaml
@@ -127,6 +127,6 @@ backchannel:
 #     claim_mapping:
 #       user_id:        sub
 #       email:          email
-#     allowed_accounts: []   # empty = any tenant
+#     allowed_accounts: ["acct_123"]   # REQUIRED, non-empty: the tenants this IdP serves. An empty list is rejected at startup (it would let a token issued for one tenant be exchanged under another)
 #     propagate_claims: ["auth_time", "acr", "amr"]
 #     allow_private_endpoints: false  # true ONLY for an internal/VPN IdP or localhost dev — relaxes the SSRF guard on the jwks_uri fetch


### PR DESCRIPTION
Closes #88. Reimplements the stale, conflicting #124 on current `main`.

## Summary

Adds a **direct OIDC IdP federation** path to token exchange: `grant_type=token-exchange` with `subject_token_type=urn:ietf:params:oauth:token-type:id_token` routes to a new verifier that checks the upstream IdP's signature against a deployer-configured JWKS — instead of the trusted-service broker. Issued tokens carry `user_id_iss` (IdP-granular provenance, reconstructable from the token alone) plus optional `auth_time`/`acr`/`amr` propagation. The broker path is unchanged and remains the fallback.

This is the spec-aligned preferred path per RFC 8693 (`id_token` subject type), RFC 9068 (auth-context claims), and NIST SP 800-63C §4.1 (assertions must name the IdP that authenticated the subject).

## What's here

- `domain/external_issuer.go` — `external_issuers` config type + validation (https-only, required `audience`, `claim_mapping.user_id` required, `propagate_claims` ⊆ {auth_time,acr,amr})
- `internal/service/external_issuer_registry.go` — per-issuer JWKS registry over `authjwt.JWKSClient`
- `internal/service/oauth_external_idp.go` — `externalIDTokenExchange`: iss lookup → alg allowlist → signature/iss/aud/exp/nbf verify → `iat` max-age cap → claim mapping → mint
- `config.go` / `server.go` / `zeroid.yaml` — wiring + `WithExternalIssuerJWKSOption` (test seam for injecting an HTTP client)
- `user_id_iss` added to `reservedClaims` (callers cannot spoof IdP provenance)
- docs + unit tests + end-to-end integration tests

## Deliberate divergences from #124 (main moved since May)

- **`token.base_url` removed on main** (folded into `issuer`) — dropped from the federation test config.
- **`authjwt.NewJWKSClient` is now non-fatal on an unreachable JWKS** (best-effort warm-up + lazy `EnsureLoaded` + background refresh — a deliberate platform decision to survive transient cross-service startup races). For *external* IdPs, tying ZeroID boot to Okta/Entra being momentarily reachable is worse than lazy+fail-closed. So:
  - the registry no longer fails startup on an unreachable issuer;
  - `externalIDTokenExchange` calls `EnsureLoaded` and **fails closed** at request time if keys never load;
  - the unit test was rewritten (`TestExternalIssuerRegistry_ToleratesUnreachableJWKSAtStartup`) to pin this contract.

## Carried-over review fixes from #124

`strconv.FormatFloat`/`FormatInt` for numeric subject IDs (no scientific-notation corruption from Entra-shaped `sub`); `ErrUnknownExternalIssuer` sentinel wrapped onto the `*OAuthError` cause; single-sourced `reservedClaims` blocklist; structural (not error-substring) assertion in the broker-unchanged test.

## Test

`GOEXPERIMENT=jsonv2 go build ./...` ✅ · `go vet ./...` ✅ · gofmt clean ✅
External-issuer unit tests ✅ · integration `TestExternalIDTokenFederation_EndToEnd` (happy path emits `user_id_iss` + broker dispatch unchanged) ✅

## Not in scope

Interactive OIDC redirect (deployer's job), SAML, OIDF trust chains. **ID-JAG / MCP enterprise-managed authorization** is a distinct grant (jwt-bearer redemption, `typ=oauth-id-jag+jwt`, jti single-use, client_id binding) that builds *on* this registry — tracked as a separate follow-up.

Credit: original implementation by @safayavatsal in #124.