### PR TITLE
fix: production-harden direct OIDC IdP federation (#88)

### DIFF
--- a/domain/external_issuer.go
+++ b/domain/external_issuer.go
@@ -58,9 +58,16 @@ type ExternalIssuerConfig struct {
 	//	  email:   email
 	ClaimMapping map[string]string `koanf:"claim_mapping"`
 
-	// AllowedAccounts limits the tenants that may use this issuer. When
-	// non-empty, the request's account_id must appear in this list. Empty
-	// means any tenant may use it.
+	// AllowedAccounts is the REQUIRED, non-empty list of tenants permitted to
+	// exchange tokens from this issuer. The request's account_id must appear
+	// here. It is the only thing that binds an upstream ID token to a ZeroID
+	// tenant: the token's aud binds it to ZeroID-the-RP, not to a specific
+	// account, and account_id is caller-supplied on the (public) token
+	// endpoint — so a globally-trusted issuer with no tenant binding would let
+	// a token validly issued for tenant A's user be exchanged under tenant B.
+	// Validate() rejects an empty list (fail closed): the deployer must declare
+	// which tenants each IdP serves. For a single-tenant deployment, list that
+	// one account explicitly.
 	AllowedAccounts []string `koanf:"allowed_accounts"`
 
 	// PropagateClaims is the explicit allow-list of upstream claims to
@@ -117,6 +124,20 @@ func (e *ExternalIssuerConfig) Validate() error {
 	if _, ok := e.ClaimMapping["user_id"]; !ok {
 		return fmt.Errorf("external_issuer %s: claim_mapping.user_id is required (need a stable subject identifier)", e.Issuer)
 	}
+	// allowed_accounts is required and non-empty: it is the only binding of an
+	// upstream token to a ZeroID tenant. An empty list would mean "any tenant
+	// may exchange this IdP's tokens", which lets a token issued for one tenant
+	// be replayed under another (the upstream aud only binds to ZeroID-the-RP,
+	// not to an account_id). Fail closed — force the deployer to declare the
+	// tenants each issuer serves.
+	if len(e.AllowedAccounts) == 0 {
+		return fmt.Errorf("external_issuer %s: allowed_accounts is required and must be non-empty (it binds this IdP's tokens to specific tenants; an empty list would let a token issued for one tenant be exchanged under another)", e.Issuer)
+	}
+	for _, acct := range e.AllowedAccounts {
+		if acct == "" {
+			return fmt.Errorf("external_issuer %s: allowed_accounts must not contain empty entries", e.Issuer)
+		}
+	}
 	// Only RS256/ES256/PS256 are supported by the verifier (jwtalg's asymmetric
 	// allow-list). Reject unsupported entries at config load instead of failing
 	// every exchange at runtime.
@@ -154,11 +175,10 @@ func (e *ExternalIssuerConfig) Defaults() {
 }
 
 // AccountAllowed reports whether the given tenant is permitted to exchange
-// tokens issued by this IdP. Empty AllowedAccounts means any tenant.
+// tokens issued by this IdP. Fail closed: an empty AllowedAccounts denies all
+// tenants. Validate() already rejects an empty list at config load, so this is
+// defense-in-depth against a registry built from unvalidated config.
 func (e *ExternalIssuerConfig) AccountAllowed(accountID string) bool {
-	if len(e.AllowedAccounts) == 0 {
-		return true
-	}
 	for _, a := range e.AllowedAccounts {
 		if a == accountID {
 			return true

--- a/domain/external_issuer_test.go
+++ b/domain/external_issuer_test.go
@@ -12,10 +12,11 @@ import (
 func TestExternalIssuerConfigValidate(t *testing.T) {
 	good := func() ExternalIssuerConfig {
 		return ExternalIssuerConfig{
-			Issuer:       "https://auth.example.okta.com",
-			JWKSURI:      "https://auth.example.okta.com/.well-known/jwks.json",
-			Audience:     "https://zeroid.example.com",
-			ClaimMapping: map[string]string{"user_id": "sub"},
+			Issuer:          "https://auth.example.okta.com",
+			JWKSURI:         "https://auth.example.okta.com/.well-known/jwks.json",
+			Audience:        "https://zeroid.example.com",
+			ClaimMapping:    map[string]string{"user_id": "sub"},
+			AllowedAccounts: []string{"acct-1"},
 		}
 	}
 
@@ -30,6 +31,10 @@ func TestExternalIssuerConfigValidate(t *testing.T) {
 		{name: "missing jwks_uri", mutate: func(c *ExternalIssuerConfig) { c.JWKSURI = "" }, wantErr: "jwks_uri is required"},
 		{name: "missing audience", mutate: func(c *ExternalIssuerConfig) { c.Audience = "" }, wantErr: "audience is required"},
 		{name: "missing user_id mapping", mutate: func(c *ExternalIssuerConfig) { c.ClaimMapping = map[string]string{} }, wantErr: "claim_mapping.user_id is required"},
+		{name: "missing allowed_accounts", mutate: func(c *ExternalIssuerConfig) { c.AllowedAccounts = nil }, wantErr: "allowed_accounts is required"},
+		{name: "empty allowed_accounts entry", mutate: func(c *ExternalIssuerConfig) {
+			c.AllowedAccounts = []string{""}
+		}, wantErr: "must not contain empty entries"},
 		{name: "unsupported propagate claim", mutate: func(c *ExternalIssuerConfig) {
 			c.PropagateClaims = []string{"groups"}
 		}, wantErr: "propagate_claims entry"},
@@ -81,10 +86,11 @@ func TestExternalIssuerConfigDefaults(t *testing.T) {
 func TestExternalIssuerConfigValidateRejectsUnsupportedAlg(t *testing.T) {
 	base := func() ExternalIssuerConfig {
 		return ExternalIssuerConfig{
-			Issuer:       "https://idp.example.com",
-			JWKSURI:      "https://idp.example.com/jwks",
-			Audience:     "https://zeroid.example.com",
-			ClaimMapping: map[string]string{"user_id": "sub"},
+			Issuer:          "https://idp.example.com",
+			JWKSURI:         "https://idp.example.com/jwks",
+			Audience:        "https://zeroid.example.com",
+			ClaimMapping:    map[string]string{"user_id": "sub"},
+			AllowedAccounts: []string{"acct-1"},
 		}
 	}
 
@@ -108,10 +114,10 @@ func TestExternalIssuerConfigValidateRejectsUnsupportedAlg(t *testing.T) {
 }
 
 func TestExternalIssuerConfigAccountAllowed(t *testing.T) {
-	t.Run("empty allow-list permits any tenant", func(t *testing.T) {
+	t.Run("empty allow-list denies all tenants (fail closed)", func(t *testing.T) {
 		cfg := ExternalIssuerConfig{}
-		if !cfg.AccountAllowed("any-tenant") {
-			t.Fatalf("empty AllowedAccounts must permit any tenant")
+		if cfg.AccountAllowed("any-tenant") {
+			t.Fatalf("empty AllowedAccounts must deny all tenants (fail closed)")
 		}
 	})
 	t.Run("non-empty allow-list gates membership", func(t *testing.T) {

--- a/internal/service/external_issuer_registry_test.go
+++ b/internal/service/external_issuer_registry_test.go
@@ -80,10 +80,11 @@ func TestExternalIssuerRegistry_LifecycleAndLookup(t *testing.T) {
 	defer jwks.Close()
 
 	cfg := domain.ExternalIssuerConfig{
-		Issuer:       "https://auth.example.test",
-		JWKSURI:      jwks.URL(),
-		Audience:     "https://zeroid.example.test",
-		ClaimMapping: map[string]string{"user_id": "sub"},
+		Issuer:          "https://auth.example.test",
+		JWKSURI:         jwks.URL(),
+		Audience:        "https://zeroid.example.test",
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct"},
 	}
 	cfg.Defaults()
 	if err := cfg.Validate(); err != nil {

--- a/internal/service/oauth_external_idp.go
+++ b/internal/service/oauth_external_idp.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v4/jws"
 	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/rs/zerolog/log"
 
@@ -129,14 +130,24 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 	}
 
 	// Verify signature, exp, nbf, iss, and aud against the configured IdP
-	// in one Parse call. WithKeySet picks the right key by kid+alg from
-	// the JWKS we cache for this issuer.
+	// in one Parse call. WithKeySet picks the right key by kid from the JWKS
+	// we cache for this issuer.
+	//
+	// WithInferAlgorithmFromKey is REQUIRED, not optional: jwx selects the
+	// verification alg from the JWK's `alg` member, but many production IdPs
+	// (Microsoft Entra ID is the canonical example) publish JWKS keys with no
+	// `alg` member at all. Without inference, jwx supplies no key for those and
+	// every verification fails — i.e. federation would silently never work
+	// against Entra. Inference is safe here because checkExternalIDTokenAlg has
+	// already pinned the token header alg to the asymmetric allow-list above,
+	// and jwx's infer path additionally rejects any header alg the key type
+	// cannot produce — so HS*/none still cannot slip through.
 	keySet := entry.JWKS.KeySet()
 	if keySet == nil || keySet.Len() == 0 {
 		return nil, oauthServerError(fmt.Sprintf("JWKS for issuer %s is empty", upstreamIss), nil)
 	}
 	verified, err := jwt.Parse([]byte(req.SubjectToken),
-		jwt.WithKeySet(keySet),
+		jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
 		jwt.WithValidate(true),
 		jwt.WithIssuer(upstreamIss),
 		jwt.WithAudience(cfg.Audience),
@@ -148,7 +159,7 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 		if kid := extractJWSKeyID(req.SubjectToken); kid != "" && entry.JWKS.RefreshIfMissing(ctx, kid) {
 			keySet = entry.JWKS.KeySet()
 			verified, err = jwt.Parse([]byte(req.SubjectToken),
-				jwt.WithKeySet(keySet),
+				jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
 				jwt.WithValidate(true),
 				jwt.WithIssuer(upstreamIss),
 				jwt.WithAudience(cfg.Audience),
@@ -231,10 +242,7 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 
 	// Resolve the identity's credential policy when we have a real identity
 	// row, so issuance enforces the same policy ceiling (allowed scopes, max
-	// TTL, trust level, policy expiry) as every other grant. The synthetic
-	// carrier identity (no application_id) has no row, hence no policy. Mirrors
-	// ExternalPrincipalExchange — without this the federation path would be a
-	// policy-bypass hole.
+	// TTL, trust level, policy expiry) as every other grant.
 	var identityPolicyID string
 	if identity.ID != "" {
 		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, identity)
@@ -246,18 +254,27 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 
 	scopes := parseScopeString(req.Scope)
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
-		Identity:          identity,
-		IdentityPolicyID:  identityPolicyID,
-		GrantType:         domain.GrantTypeTokenExchange,
-		Scopes:            scopes,
-		UseRS256:          true,
-		SubjectOverride:   userID,
-		UserEmail:         userEmail,
-		UserName:          userName,
-		ApplicationID:     req.ApplicationID,
-		TTL:               900, // 15 minutes — same short-lived posture as the broker path
-		CustomClaims:      customClaims,
-		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
+		Identity:         identity,
+		IdentityPolicyID: identityPolicyID,
+		// Govern the synthetic-carrier path (no application_id, so no identity
+		// row and no IdentityPolicyID above) by the tenant default policy.
+		// resolveIdentityPolicyID falls back to EnsureDefaultPolicy on the
+		// request's account_id/project_id, so requested scopes are gated by the
+		// tenant policy ceiling instead of passing through ungated. Without
+		// this, any holder of a valid upstream token could request arbitrary
+		// scopes on the no-application_id path — a weaker gate than the broker
+		// path, which is at least fronted by TrustedServiceValidator.
+		ResolveIdentityPolicy: true,
+		GrantType:             domain.GrantTypeTokenExchange,
+		Scopes:                scopes,
+		UseRS256:              true,
+		SubjectOverride:       userID,
+		UserEmail:             userEmail,
+		UserName:              userName,
+		ApplicationID:         req.ApplicationID,
+		TTL:                   900, // 15 minutes — same short-lived posture as the broker path
+		CustomClaims:          customClaims,
+		DPoPKeyThumbprint:     req.DPoPKeyThumbprint,
 	})
 	if err != nil {
 		return nil, oauthServerError("failed to issue external id_token exchange token", err)

--- a/internal/service/oauth_external_idp_test.go
+++ b/internal/service/oauth_external_idp_test.go
@@ -113,10 +113,11 @@ func TestExternalIDTokenExchange_UnknownIssuerWrapsSentinel(t *testing.T) {
 	defer jwks.Close()
 
 	cfg := domain.ExternalIssuerConfig{
-		Issuer:       "https://known.example.test",
-		JWKSURI:      jwks.URL(),
-		Audience:     "https://zeroid.example.test",
-		ClaimMapping: map[string]string{"user_id": "sub"},
+		Issuer:          "https://known.example.test",
+		JWKSURI:         jwks.URL(),
+		Audience:        "https://zeroid.example.test",
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct"},
 	}
 	cfg.Defaults()
 	if err := cfg.Validate(); err != nil {

--- a/tests/integration/external_idp_hardening_test.go
+++ b/tests/integration/external_idp_hardening_test.go
@@ -1,0 +1,372 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwk"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// This file hardens the direct-OIDC-federation e2e coverage beyond the single
+// ES256 happy path in external_idp_test.go. Every case drives the REAL
+// /oauth2/token HTTP endpoint of a real zeroid.NewServer (backed by the shared
+// testcontainers Postgres) against a fake upstream IdP served over TLS — i.e.
+// the full request path, not a unit shim.
+//
+// The headline case (TestExternalIDTokenFederation_NoAlgKeyAndAlgVariants) uses
+// an Entra-shaped JWKS key that OMITS the `alg` member. jwx selects the verify
+// algorithm from the key's `alg`; with no `alg` and without
+// WithInferAlgorithmFromKey, it supplies no key and verification fails. This
+// test therefore fails outright without the inference fix in
+// externalIDTokenExchange — it is the regression guard for the "works in tests,
+// silently broken against Entra/real IdPs" trap.
+
+// fakeRSAIdP is a fake upstream OIDC IdP that signs RS256/PS256 tokens and
+// publishes an RSA JWKS over TLS. includeAlg controls whether the published JWK
+// carries an `alg` member (real IdPs vary: Okta/Auth0/Google include it,
+// Microsoft Entra ID does not). It supports key rotation for the refresh test.
+type fakeRSAIdP struct {
+	srv    *httptest.Server
+	mu     sync.Mutex
+	priv   *rsa.PrivateKey
+	kid    string
+	keySet jwk.Set
+}
+
+func newFakeRSAIdP(t *testing.T, kid string, includeAlg bool) *fakeRSAIdP {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	idp := &fakeRSAIdP{
+		priv:   priv,
+		kid:    kid,
+		keySet: buildRSAJWKS(t, &priv.PublicKey, kid, includeAlg),
+	}
+	idp.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		idp.mu.Lock()
+		ks := idp.keySet
+		idp.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(ks)
+	}))
+	return idp
+}
+
+func (i *fakeRSAIdP) JWKSURL() string { return i.srv.URL }
+func (i *fakeRSAIdP) Close()          { i.srv.Close() }
+
+// signKey/signKID return the current signing material under lock.
+func (i *fakeRSAIdP) signKey() (*rsa.PrivateKey, string) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.priv, i.kid
+}
+
+// sign mints an RS256 token with the current key/kid.
+func (i *fakeRSAIdP) sign(t *testing.T, claims map[string]any) string {
+	key, kid := i.signKey()
+	return signRSAToken(t, jwa.RS256(), key, kid, claims)
+}
+
+// rotate swaps in a fresh key under a new kid and serves only the new JWKS,
+// mimicking an upstream key rotation. The registry's cached JWKS (holding the
+// old kid) must refetch on demand to verify a token signed with the new key.
+func (i *fakeRSAIdP) rotate(t *testing.T, newKid string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	i.mu.Lock()
+	i.priv = priv
+	i.kid = newKid
+	i.keySet = buildRSAJWKS(t, &priv.PublicKey, newKid, true)
+	i.mu.Unlock()
+}
+
+func buildRSAJWKS(t *testing.T, pub *rsa.PublicKey, kid string, includeAlg bool) jwk.Set {
+	t.Helper()
+	set := jwk.NewSet()
+	k, err := jwk.Import[jwk.Key](pub)
+	require.NoError(t, err)
+	require.NoError(t, k.Set(jwk.KeyIDKey, kid))
+	require.NoError(t, k.Set(jwk.KeyUsageKey, jwk.ForSignature))
+	if includeAlg {
+		require.NoError(t, k.Set(jwk.AlgorithmKey, jwa.RS256()))
+	}
+	require.NoError(t, set.AddKey(k))
+	return set
+}
+
+// signRSAToken hand-signs a token with an explicit alg/key/kid so tests can
+// forge mismatches (e.g. sign with an attacker key while advertising the real
+// kid, or sign PS256 against an RSA key).
+func signRSAToken(t *testing.T, alg jwa.SignatureAlgorithm, key *rsa.PrivateKey, kid string, claims map[string]any) string {
+	t.Helper()
+	tok := jwt.New()
+	for k, v := range claims {
+		require.NoError(t, tok.Set(k, v))
+	}
+	hdr := jws.NewHeaders()
+	require.NoError(t, hdr.Set(jws.KeyIDKey, kid))
+	require.NoError(t, hdr.Set(jws.TypeKey, "JWT"))
+	signed, err := jwt.Sign(tok, jwt.WithKey(alg, key, jws.WithProtectedHeaders(hdr)))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+func federationExchangeBody(idToken, accountID, projectID string) map[string]any {
+	return map[string]any{
+		"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token":      idToken,
+		"subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+		"account_id":         accountID,
+		"project_id":         projectID,
+	}
+}
+
+// TestExternalIDTokenFederation_NoAlgKeyAndAlgVariants is the P1-A regression
+// guard: it federates against an IdP whose JWKS key omits `alg` (Entra-shaped),
+// across RS256 and PS256 tokens. Without WithInferAlgorithmFromKey these all
+// fail with "no key in the key set was usable".
+func TestExternalIDTokenFederation_NoAlgKeyAndAlgVariants(t *testing.T) {
+	iss := "https://noalg.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "noalg-kid-1", false /* includeAlg — Entra omits it */)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub", "email": "email"},
+		AllowedAccounts: []string{"acct-fed-001"},
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	validClaims := func() map[string]any {
+		now := time.Now()
+		return map[string]any{
+			"iss":   iss,
+			"aud":   aud,
+			"sub":   "entra-user-oid-1",
+			"email": "carol@example.com",
+			"iat":   now.Unix(),
+			"exp":   now.Add(5 * time.Minute).Unix(),
+		}
+	}
+
+	t.Run("RS256 token with no-alg JWKS key verifies and emits user_id_iss", func(t *testing.T) {
+		idToken := idp.sign(t, validClaims())
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"no-alg JWKS key must verify (requires WithInferAlgorithmFromKey); body=%s", resp.RawBody)
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		require.Equal(t, iss, claims["user_id_iss"])
+		require.Equal(t, "external_id_token", claims["token_exchange"])
+		require.Equal(t, "entra-user-oid-1", claims["sub"])
+	})
+
+	t.Run("PS256 token with no-alg JWKS key verifies", func(t *testing.T) {
+		key, kid := idp.signKey()
+		idToken := signRSAToken(t, jwa.PS256(), key, kid, validClaims())
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"PS256 over a no-alg RSA key must verify via inference; body=%s", resp.RawBody)
+	})
+}
+
+// TestExternalIDTokenFederation_CrossTenantRejected is the P1-B regression
+// guard: an upstream token is bound to ZeroID-the-RP via aud, but NOT to a
+// ZeroID tenant. Only allowed_accounts binds it. A request that presents a
+// valid token under a tenant not in allowed_accounts must be rejected before
+// any token is minted.
+func TestExternalIDTokenFederation_CrossTenantRejected(t *testing.T) {
+	iss := "https://tenant.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "tenant-kid-1", true)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct-fed-001"}, // matches fedCfg.AccountID; "acct-evil" is not listed
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	now := time.Now()
+	idToken := idp.sign(t, map[string]any{
+		"iss": iss, "aud": aud, "sub": "user-x",
+		"iat": now.Unix(), "exp": now.Add(5 * time.Minute).Unix(),
+	})
+
+	t.Run("allowed tenant succeeds", func(t *testing.T) {
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+	})
+
+	t.Run("disallowed tenant is rejected (no cross-tenant minting)", func(t *testing.T) {
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idToken, "acct-evil", "proj-evil"))
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+			"a token must not be exchangeable under a tenant not in allowed_accounts; body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken, "no token may be minted for a disallowed tenant")
+	})
+}
+
+// TestExternalIDTokenFederation_VerificationNegatives drives the core
+// verification rules: aud binding, exp/iat freshness, signature integrity,
+// required-claim presence, and the unknown-issuer guard. All must fail closed
+// with a 400 and no minted token. The baseline confirms the same server mints
+// on a clean token, so each rejection is attributable to the single mutation.
+func TestExternalIDTokenFederation_VerificationNegatives(t *testing.T) {
+	iss := "https://neg.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "neg-kid-1", true)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct-fed-001"},
+		// MaxTokenAge left at the 10m default; the stale-iat case exceeds it.
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	base := func() map[string]any {
+		now := time.Now()
+		return map[string]any{
+			"iss": iss, "aud": aud, "sub": "user-neg",
+			"iat": now.Unix(), "exp": now.Add(5 * time.Minute).Unix(),
+		}
+	}
+
+	// Baseline: a clean token mints, so every failure below is the mutation's
+	// doing and not a misconfigured server.
+	t.Run("baseline clean token mints", func(t *testing.T) {
+		resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idp.sign(t, base()), fedCfg.AccountID, fedCfg.ProjectID))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+	})
+
+	cases := []struct {
+		name  string
+		token func(t *testing.T) string
+	}{
+		{"wrong audience", func(t *testing.T) string {
+			c := base()
+			c["aud"] = "https://some.other.rp"
+			return idp.sign(t, c)
+		}},
+		{"expired exp", func(t *testing.T) string {
+			c := base()
+			c["exp"] = time.Now().Add(-2 * time.Minute).Unix() // beyond the 60s skew
+			return idp.sign(t, c)
+		}},
+		{"stale iat beyond max_token_age", func(t *testing.T) string {
+			now := time.Now()
+			c := base()
+			c["iat"] = now.Add(-20 * time.Minute).Unix() // > 10m default cap
+			c["exp"] = now.Add(5 * time.Minute).Unix()   // still unexpired
+			return idp.sign(t, c)
+		}},
+		{"missing iat", func(t *testing.T) string {
+			c := base()
+			delete(c, "iat")
+			return idp.sign(t, c)
+		}},
+		{"missing exp", func(t *testing.T) string {
+			c := base()
+			delete(c, "exp")
+			return idp.sign(t, c)
+		}},
+		{"missing sub", func(t *testing.T) string {
+			c := base()
+			delete(c, "sub")
+			return idp.sign(t, c)
+		}},
+		{"bad signature (attacker key, real kid)", func(t *testing.T) string {
+			attacker, err := rsa.GenerateKey(rand.Reader, 2048)
+			require.NoError(t, err)
+			_, kid := idp.signKey()
+			return signRSAToken(t, jwa.RS256(), attacker, kid, base())
+		}},
+		{"unknown issuer", func(t *testing.T) string {
+			c := base()
+			c["iss"] = "https://stranger.idp.test" // not configured → invalid_request
+			return idp.sign(t, c)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+" rejected", func(t *testing.T) {
+			resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(tc.token(t), fedCfg.AccountID, fedCfg.ProjectID))
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+				"%s must be rejected with 400; body=%s", tc.name, resp.RawBody)
+			require.Empty(t, resp.AccessToken, "%s must not mint a token", tc.name)
+		})
+	}
+}
+
+// TestExternalIDTokenFederation_KeyRotation proves the on-demand JWKS refresh:
+// the registry warms up with kid-1, the upstream rotates to kid-2, and a token
+// signed with kid-2 must still verify (the verifier refetches the JWKS once on
+// an unknown kid and retries) — no ZeroID restart required.
+func TestExternalIDTokenFederation_KeyRotation(t *testing.T) {
+	iss := "https://rotate.idp.test"
+	aud := "https://zeroid.federation.test"
+
+	idp := newFakeRSAIdP(t, "rot-kid-1", true)
+	defer idp.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         idp.JWKSURL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		AllowedAccounts: []string{"acct-fed-001"},
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	mk := func() map[string]any {
+		now := time.Now()
+		return map[string]any{
+			"iss": iss, "aud": aud, "sub": "user-rot",
+			"iat": now.Unix(), "exp": now.Add(5 * time.Minute).Unix(),
+		}
+	}
+
+	// Sanity: kid-1 (already warm in the cache) verifies.
+	resp := postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idp.sign(t, mk()), fedCfg.AccountID, fedCfg.ProjectID))
+	require.Equal(t, http.StatusOK, resp.StatusCode, "pre-rotation token must verify; body=%s", resp.RawBody)
+
+	// Upstream rotates to a brand-new key+kid the cache has never seen.
+	idp.rotate(t, "rot-kid-2")
+
+	resp = postFederation(t, fedHTTPSrv.URL, federationExchangeBody(idp.sign(t, mk()), fedCfg.AccountID, fedCfg.ProjectID))
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"post-rotation token must verify after on-demand JWKS refresh; body=%s", resp.RawBody)
+	claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+	require.Equal(t, iss, claims["user_id_iss"])
+}

--- a/tests/integration/external_idp_test.go
+++ b/tests/integration/external_idp_test.go
@@ -60,6 +60,7 @@ func TestExternalIDTokenFederation_EndToEnd(t *testing.T) {
 			"user_id": "sub",
 			"email":   "email",
 		},
+		AllowedAccounts: []string{"acct-fed-001"},
 		PropagateClaims: []string{"auth_time", "acr", "amr"},
 	})
 	defer fedHTTPSrv.Close()

--- a/zeroid.yaml
+++ b/zeroid.yaml
@@ -127,6 +127,6 @@ backchannel:
 #     claim_mapping:
 #       user_id:        sub
 #       email:          email
-#     allowed_accounts: []   # empty = any tenant
+#     allowed_accounts: ["acct_123"]   # REQUIRED, non-empty: the tenants this IdP serves. An empty list is rejected at startup (it would let a token issued for one tenant be exchanged under another)
 #     propagate_claims: ["auth_time", "acr", "amr"]
 #     allow_private_endpoints: false  # true ONLY for an internal/VPN IdP or localhost dev — relaxes the SSRF guard on the jwks_uri fetch


### PR DESCRIPTION
Stacked on #211 (base = `feat/direct-oidc-idp-federation`). Production-hardening for the direct OIDC IdP federation path, from a deep review of #211. Three fixes + an e2e test matrix. No change to the broker path.

## P1-A — federation was silently broken against Microsoft Entra ID
jwx v4's `WithKeySet` selects the verification algorithm from the **JWK's `alg` member**. Entra (and other IdPs) publish JWKS keys with **no `alg`**, so `selectKey` supplies no key and every `jwt.Parse` fails with *"no key in the key set was usable."* The suite passed only because the fakes always set `alg`.

Fix: pass `jws.WithInferAlgorithmFromKey(true)` to both Parse calls. Safe — `checkExternalIDTokenAlg` already pins the token header alg to the asymmetric allow-list before Parse, and jwx's infer path rejects any header alg the key type cannot produce, so HS*/`none` still cannot slip through.

**Proven:** the new no-`alg` test is red without this fix (`subject_token verification failed`) and green with it.

## P1-B — cross-tenant token acceptance (fail closed)
The registry is global and an upstream token is bound to ZeroID-the-RP via `aud`, **not** to a ZeroID tenant; `account_id` is caller-supplied on the public token endpoint. With `allowed_accounts` empty (the old default = "any tenant"), a token validly issued for tenant A could be exchanged under `account_id=B`.

Fix: `Validate()` now requires a non-empty `allowed_accounts`; `AccountAllowed` also fails closed on empty (defense in depth). `zeroid.yaml` example + tests updated.

## P1-C — scope-ceiling bypass on the synthetic-carrier path
With no `application_id`, issuance used a rowless synthetic identity with no `IdentityPolicyID`, so requested `scopes` passed through ungated — a weaker gate than the broker path (which is fronted by `TrustedServiceValidator`).

Fix: set `ResolveIdentityPolicy: true` so `resolveIdentityPolicyID` → `EnsureDefaultPolicy(account, project)` governs scopes by the tenant default policy.

## e2e test matrix — `tests/integration/external_idp_hardening_test.go`
Drives the real `/oauth2/token` endpoint of a real `zeroid.NewServer` (testcontainers Postgres) against a fake TLS IdP:
- **no-`alg` JWKS key (Entra-shaped)** — RS256 + PS256 happy paths (P1-A regression guard)
- **cross-tenant** — allowed tenant mints; disallowed tenant → 400, no token (P1-B)
- **verification negatives** — wrong `aud`, expired `exp`, stale `iat` > `max_token_age`, missing `iat`/`exp`/`sub`, bad signature (attacker key + real `kid`), unknown issuer
- **key rotation** — upstream rotates `kid`; token verifies after on-demand JWKS refresh

## Test
`GOEXPERIMENT=jsonv2 go build ./...` ✅ · `go vet ./...` ✅ · gofmt clean ✅
domain + service unit tests ✅ · full integration package green (75s) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)