### PR TITLE
feat: accept MCP ID-JAG via jwt-bearer and mint audience-restricted token (ADR 0010)

### DIFF
--- a/internal/handler/wellknown.go
+++ b/internal/handler/wellknown.go
@@ -125,6 +125,15 @@ func (a *API) oauthMetadataOp(_ context.Context, _ *struct{}) (*OAuthMetadataOut
 			"api_key",
 			"urn:openid:params:grant-type:ciba",
 		},
+		// MCP Enterprise-Managed Authorization (ADR 0010 D6): advertise the
+		// ID-JAG authorization grant profile so EMA-capable clients discover
+		// that this AS accepts an Identity Assertion Authorization Grant
+		// (presented via the jwt-bearer grant above). Distinct from
+		// grant_types_supported — the profile names *how* the jwt-bearer grant
+		// is used, not a new grant_type.
+		"authorization_grant_profiles_supported": []string{
+			"urn:ietf:params:oauth:grant-profile:id-jag",
+		},
 		"jwks_uri":               a.issuer + "/.well-known/jwks.json",
 		"introspection_endpoint": a.issuer + "/oauth2/token/introspect",
 		"revocation_endpoint":    a.issuer + "/oauth2/token/revoke",

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -53,6 +53,15 @@ type OAuthService struct {
 	// backchannelSvc handles the urn:openid:params:grant-type:ciba grant.
 	// Wired after construction via SetBackchannelService.
 	backchannelSvc *BackchannelService
+	// idJAGReplayStore is the single-use ledger for redeemed MCP ID-JAG jti
+	// values (ADR 0010 D2a). The ID-JAG path consumes the jti here LAST (after
+	// every other check passes) so a replayed ID-JAG is rejected with
+	// invalid_grant. Wired after construction via SetIDJAGReplayStore. Nil when
+	// ID-JAG federation is not configured; idJAGBearer already fails closed in
+	// that case (no external issuers → no ID-JAG path), so a nil store can never
+	// silently skip replay protection while ID-JAG is actually in use — but the
+	// handler also guards against nil defensively (fail closed).
+	idJAGReplayStore IDJAGReplayStore
 	// requireTokenInspectionAuth, when true, makes the introspection (RFC 7662)
 	// and revocation (RFC 7009) endpoints reject anonymous callers — a caller
 	// MUST present client credentials. When false the endpoints accept-and-
@@ -64,6 +73,18 @@ type OAuthService struct {
 
 // CustomGrantHandler implements a custom OAuth2 grant type.
 type CustomGrantHandler func(ctx context.Context, req TokenRequest) (*domain.AccessToken, error)
+
+// IDJAGReplayStore is the durable single-use ledger for redeemed MCP ID-JAG jti
+// values (ADR 0010 D2a). Insert records a previously-unredeemed jti and MUST
+// return a replay sentinel (postgres.ErrIDJAGReplay) when the jti is already
+// present. The check-and-insert must be atomic (a unique-constraint violation
+// is the replay signal) — a non-atomic read-then-write is a TOCTOU bug that
+// defeats the single-use guarantee. The concrete impl is
+// postgres.IDJAGReplayStore; an interface here keeps the service testable and
+// the dependency narrow.
+type IDJAGReplayStore interface {
+	Insert(ctx context.Context, jti string, expiresAt time.Time) error
+}
 
 // Default token TTLs (used when per-client TTL is not configured).
 const (
@@ -157,6 +178,14 @@ func (s *OAuthService) SetTrustedServiceValidator(v trustedServiceValidatorFunc)
 // BackchannelService for the CIBA grant.
 func (s *OAuthService) SetBackchannelService(bc *BackchannelService) {
 	s.backchannelSvc = bc
+}
+
+// SetIDJAGReplayStore wires the single-use ledger for redeemed MCP ID-JAG jti
+// values (ADR 0010 D2a). Required whenever ID-JAG federation is enabled — the
+// idJAGBearer path consumes jti against this store as its final gate. Wired in
+// server.go alongside the external-issuer registry.
+func (s *OAuthService) SetIDJAGReplayStore(store IDJAGReplayStore) {
+	s.idJAGReplayStore = store
 }
 
 // SetRequireTokenInspectionAuth toggles strict client authentication on the

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -342,6 +342,18 @@ func (s *OAuthService) jwtBearer(ctx context.Context, req TokenRequest) (*domain
 		return nil, oauthBadRequest(oautherror.InvalidRequest, "subject (assertion JWT) is required for jwt_bearer grant")
 	}
 
+	// MCP Enterprise-Managed-Authorization ID-JAG (ADR 0010 D2): an assertion
+	// whose JWS typ header is oauth-id-jag+jwt is an Identity Assertion
+	// Authorization Grant signed by a corporate IdP — it MUST be validated
+	// against that IdP's JWKS (the #88 external-issuer substrate), NOT this
+	// path's registered-per-identity public key. Branch before any NHI-specific
+	// work so the two validation modes stay cleanly separate (D2: the branch
+	// must be unambiguous). Every other (non-ID-JAG) assertion keeps the exact
+	// NHI self-signed behavior below.
+	if isIDJAGAssertion(req.Subject) {
+		return s.idJAGBearer(ctx, req)
+	}
+
 	// Reject alg=none / HS* before any further work — JWT-SVID §3.
 	if err := jwtalg.Validate(req.Subject); err != nil {
 		return nil, oauthBadRequestCause(oautherror.InvalidGrant, "assertion JWT uses an unsupported algorithm", err)

--- a/internal/service/oauth_external_idp.go
+++ b/internal/service/oauth_external_idp.go
@@ -111,86 +111,15 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 		return nil, oauthBadRequest("invalid_request", fmt.Sprintf("account %s is not allowed to use issuer %s", req.AccountID, upstreamIss))
 	}
 
-	// Algorithm allowlist gate. Read the JWS header before signature
-	// verification — defense-in-depth against alg confusion. Any alg outside
-	// the configured set (or outside the small whitelist of secure asymmetric
-	// algs we actually support) is rejected.
-	if err := checkExternalIDTokenAlg(req.SubjectToken, cfg.Algorithms); err != nil {
-		return nil, oauthBadRequestCause("invalid_grant", "subject_token uses a disallowed algorithm", err)
-	}
-
-	// Ensure the issuer's JWKS is loaded. authjwt warms up best-effort at
-	// startup and refreshes in the background (it deliberately does not fail
-	// construction on an unreachable JWKS, to survive transient IdP blips).
-	// This synchronous load covers the case where the startup warm-up failed,
-	// so the first request self-heals rather than failing. A genuinely
-	// unreachable IdP returns an error here and we fail closed.
-	if err := entry.JWKS.EnsureLoaded(ctx); err != nil {
-		return nil, oauthServerError(fmt.Sprintf("failed to load JWKS for issuer %s", upstreamIss), err)
-	}
-
-	// Verify signature, exp, nbf, iss, and aud against the configured IdP
-	// in one Parse call. WithKeySet picks the right key by kid from the JWKS
-	// we cache for this issuer.
-	//
-	// WithInferAlgorithmFromKey is REQUIRED, not optional: jwx selects the
-	// verification alg from the JWK's `alg` member, but many production IdPs
-	// (Microsoft Entra ID is the canonical example) publish JWKS keys with no
-	// `alg` member at all. Without inference, jwx supplies no key for those and
-	// every verification fails — i.e. federation would silently never work
-	// against Entra. Inference is safe here because checkExternalIDTokenAlg has
-	// already pinned the token header alg to the asymmetric allow-list above,
-	// and jwx's infer path additionally rejects any header alg the key type
-	// cannot produce — so HS*/none still cannot slip through.
-	keySet := entry.JWKS.KeySet()
-	if keySet == nil || keySet.Len() == 0 {
-		return nil, oauthServerError(fmt.Sprintf("JWKS for issuer %s is empty", upstreamIss), nil)
-	}
-	verified, err := jwt.Parse([]byte(req.SubjectToken),
-		jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
-		jwt.WithValidate(true),
-		jwt.WithIssuer(upstreamIss),
-		jwt.WithAudience(cfg.Audience),
-		jwt.WithAcceptableSkew(externalIDTokenClockSkew),
-	)
+	// Verify the upstream ID token against its configured IdP — signature
+	// (JWKS), iss, aud, exp/nbf, alg allow-list, MaxTokenAge, and the
+	// presence of sub/exp/iat. This is the #88 federation substrate, shared
+	// verbatim with the ID-JAG jwt-bearer path (validateExternalAssertion).
+	// "subject_token" is the field name in the error strings because that is
+	// what an id_token-exchange caller presents.
+	verified, err := s.validateExternalAssertion(ctx, req.SubjectToken, entry, "subject_token")
 	if err != nil {
-		// On unknown kid, refresh the JWKS once and retry — handles upstream
-		// key rotation without requiring a server restart.
-		if kid := extractJWSKeyID(req.SubjectToken); kid != "" && entry.JWKS.RefreshIfMissing(ctx, kid) {
-			keySet = entry.JWKS.KeySet()
-			verified, err = jwt.Parse([]byte(req.SubjectToken),
-				jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
-				jwt.WithValidate(true),
-				jwt.WithIssuer(upstreamIss),
-				jwt.WithAudience(cfg.Audience),
-				jwt.WithAcceptableSkew(externalIDTokenClockSkew),
-			)
-		}
-		if err != nil {
-			return nil, oauthBadRequestCause("invalid_grant", "subject_token verification failed", err)
-		}
-	}
-
-	// jwx's validation only checks exp/nbf when present; RFC 7523 §3 requires
-	// both sub and exp on an assertion. Enforce their presence explicitly so a
-	// token without an expiry (replayable forever) or without a subject is
-	// rejected rather than silently accepted.
-	if _, ok := verified.Subject(); !ok {
-		return nil, oauthBadRequest("invalid_grant", "subject_token missing required sub claim")
-	}
-	if _, ok := verified.Expiration(); !ok {
-		return nil, oauthBadRequest("invalid_grant", "subject_token missing required exp claim")
-	}
-
-	// Stale-token cap. exp guards future-side; iat guards past-side. We
-	// require iat present and not older than max_token_age — the upstream
-	// signed it for a fresh authentication, not a replay from days ago.
-	iat, iatPresent := verified.IssuedAt()
-	if !iatPresent || iat.IsZero() {
-		return nil, oauthBadRequest("invalid_grant", "subject_token missing iat claim")
-	}
-	if age := time.Since(iat); age > cfg.MaxTokenAge {
-		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("subject_token age %s exceeds max_token_age %s", age.Round(time.Second), cfg.MaxTokenAge))
+		return nil, err
 	}
 
 	// Claim mapping. user_id is required (validated at config load); other
@@ -294,6 +223,113 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 	return accessToken, nil
 }
 
+// validateExternalAssertion runs the #88 external-IdP validation substrate
+// against a single externally-signed assertion: the JWS algorithm allow-list
+// gate, a synchronous best-effort JWKS load, full signature + iss + aud +
+// exp/nbf verification (with a one-shot JWKS refresh + retry on an unknown
+// kid to absorb upstream key rotation), and the RFC 7523 §3 presence checks
+// for sub/exp plus the iat-based MaxTokenAge stale-token cap.
+//
+// It is the single security-critical verification routine shared by BOTH
+// external-IdP ingestion paths:
+//   - externalIDTokenExchange (RFC 8693 subject_token_type=id_token, #88)
+//   - idJAGBearer (RFC 7523 jwt-bearer carrying an MCP ID-JAG, ADR 0010)
+//
+// so neither path can drift from the other. The issuer lookup and the
+// AllowedAccounts tenant binding stay in each caller, because their OAuth
+// error-code semantics differ (id_token: invalid_request for an unconfigured
+// issuer; ID-JAG: invalid_grant, fail-closed). fieldName names the assertion
+// in error strings ("subject_token" vs "assertion") so callers surface the
+// right wire field. On success the verified token is returned for claim
+// mapping; on any failure an *OAuthError shaped for direct return.
+func (s *OAuthService) validateExternalAssertion(ctx context.Context, assertion string, entry *ExternalIssuerEntry, fieldName string) (jwt.Token, error) {
+	cfg := entry.Config
+
+	// Algorithm allowlist gate. Read the JWS header before signature
+	// verification — defense-in-depth against alg confusion. Any alg outside
+	// the configured set (or outside the small whitelist of secure asymmetric
+	// algs we actually support) is rejected.
+	if err := checkExternalIDTokenAlg(assertion, cfg.Algorithms); err != nil {
+		return nil, oauthBadRequestCause("invalid_grant", fmt.Sprintf("%s uses a disallowed algorithm", fieldName), err)
+	}
+
+	// Ensure the issuer's JWKS is loaded. authjwt warms up best-effort at
+	// startup and refreshes in the background (it deliberately does not fail
+	// construction on an unreachable JWKS, to survive transient IdP blips).
+	// This synchronous load covers the case where the startup warm-up failed,
+	// so the first request self-heals rather than failing. A genuinely
+	// unreachable IdP returns an error here and we fail closed.
+	if err := entry.JWKS.EnsureLoaded(ctx); err != nil {
+		return nil, oauthServerError(fmt.Sprintf("failed to load JWKS for issuer %s", cfg.Issuer), err)
+	}
+
+	// Verify signature, exp, nbf, iss, and aud against the configured IdP
+	// in one Parse call. WithKeySet picks the right key by kid from the JWKS
+	// we cache for this issuer.
+	//
+	// WithInferAlgorithmFromKey is REQUIRED, not optional: jwx selects the
+	// verification alg from the JWK's `alg` member, but many production IdPs
+	// (Microsoft Entra ID is the canonical example) publish JWKS keys with no
+	// `alg` member at all. Without inference, jwx supplies no key for those and
+	// every verification fails — i.e. federation would silently never work
+	// against Entra. Inference is safe here because checkExternalIDTokenAlg has
+	// already pinned the token header alg to the asymmetric allow-list above,
+	// and jwx's infer path additionally rejects any header alg the key type
+	// cannot produce — so HS*/none still cannot slip through.
+	keySet := entry.JWKS.KeySet()
+	if keySet == nil || keySet.Len() == 0 {
+		return nil, oauthServerError(fmt.Sprintf("JWKS for issuer %s is empty", cfg.Issuer), nil)
+	}
+	verified, err := jwt.Parse([]byte(assertion),
+		jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
+		jwt.WithValidate(true),
+		jwt.WithIssuer(cfg.Issuer),
+		jwt.WithAudience(cfg.Audience),
+		jwt.WithAcceptableSkew(externalIDTokenClockSkew),
+	)
+	if err != nil {
+		// On unknown kid, refresh the JWKS once and retry — handles upstream
+		// key rotation without requiring a server restart.
+		if kid := extractJWSKeyID(assertion); kid != "" && entry.JWKS.RefreshIfMissing(ctx, kid) {
+			keySet = entry.JWKS.KeySet()
+			verified, err = jwt.Parse([]byte(assertion),
+				jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true)),
+				jwt.WithValidate(true),
+				jwt.WithIssuer(cfg.Issuer),
+				jwt.WithAudience(cfg.Audience),
+				jwt.WithAcceptableSkew(externalIDTokenClockSkew),
+			)
+		}
+		if err != nil {
+			return nil, oauthBadRequestCause("invalid_grant", fmt.Sprintf("%s verification failed", fieldName), err)
+		}
+	}
+
+	// jwx's validation only checks exp/nbf when present; RFC 7523 §3 requires
+	// both sub and exp on an assertion. Enforce their presence explicitly so a
+	// token without an expiry (replayable forever) or without a subject is
+	// rejected rather than silently accepted.
+	if _, ok := verified.Subject(); !ok {
+		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("%s missing required sub claim", fieldName))
+	}
+	if _, ok := verified.Expiration(); !ok {
+		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("%s missing required exp claim", fieldName))
+	}
+
+	// Stale-token cap. exp guards future-side; iat guards past-side. We
+	// require iat present and not older than max_token_age — the upstream
+	// signed it for a fresh authentication, not a replay from days ago.
+	iat, iatPresent := verified.IssuedAt()
+	if !iatPresent || iat.IsZero() {
+		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("%s missing iat claim", fieldName))
+	}
+	if age := time.Since(iat); age > cfg.MaxTokenAge {
+		return nil, oauthBadRequest("invalid_grant", fmt.Sprintf("%s age %s exceeds max_token_age %s", fieldName, age.Round(time.Second), cfg.MaxTokenAge))
+	}
+
+	return verified, nil
+}
+
 // resolveExternalPrincipalIdentity factors out the identity-resolution step
 // shared between the broker and direct-federation paths. ApplicationID, when
 // provided, must resolve to an active identity in the caller's tenant; this
@@ -365,6 +401,40 @@ func extractMappedClaimString(claims map[string]any, path string) (string, bool)
 	return "", false
 }
 
+// extractMappedClaimStrings reads a claim that may be either a space-delimited
+// string (the standard `scope` shape, RFC 8693) or a JSON array (the shape some
+// IdPs emit for multi-valued claims like groups / privilege_scope). Returns
+// ok=false when the path is empty (no mapping configured) or the claim is
+// absent; an empty/whitespace-only value yields (nil-or-empty, true). Each
+// element is coerced via extractMappedClaimString's single-value rules so
+// numeric entries are stringified consistently with the rest of the mapping
+// surface.
+func extractMappedClaimStrings(claims map[string]any, path string) ([]string, bool) {
+	if path == "" {
+		return nil, false
+	}
+	v, ok := claims[path]
+	if !ok {
+		return nil, false
+	}
+	switch tv := v.(type) {
+	case string:
+		// Space-delimited (scope-style). strings.Fields drops empties.
+		return parseScopeString(tv), true
+	case []string:
+		return tv, true
+	case []any:
+		out := make([]string, 0, len(tv))
+		for _, e := range tv {
+			if s, ok := extractMappedClaimString(map[string]any{"_": e}, "_"); ok {
+				out = append(out, s)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
 // checkExternalIDTokenAlg enforces the JWT-SVID §3 asymmetric allow-list
 // (via jwtalg.Validate — also rejects alg=none and HS*) and then narrows
 // further if the deployer configured a per-issuer allow-list. Runs before
@@ -411,6 +481,7 @@ func readJWSAlg(tokenStr string) string {
 type jwtHeader struct {
 	Alg string `json:"alg"`
 	Kid string `json:"kid"`
+	Typ string `json:"typ"`
 }
 
 // tokenClaimsAsMap materializes every claim on a v4 jwt.Token into a plain

--- a/internal/service/oauth_external_idp.go
+++ b/internal/service/oauth_external_idp.go
@@ -435,6 +435,37 @@ func extractMappedClaimStrings(claims map[string]any, path string) ([]string, bo
 	return nil, false
 }
 
+// extractResourceClaim reads the ID-JAG `resource` claim, which per RFC 8707 is
+// EITHER a single resource URI (string) OR an array of them. Unlike a scope
+// claim, a string value is a SINGLE resource — it is NOT space-delimited — so it
+// is taken atomically rather than split on whitespace (a resource URI may
+// legitimately contain encoded content; splitting it would forge bogus
+// audiences). Returns ok=false when the claim is absent; blank entries dropped.
+func extractResourceClaim(claims map[string]any) ([]string, bool) {
+	v, ok := claims["resource"]
+	if !ok {
+		return nil, false
+	}
+	switch tv := v.(type) {
+	case string:
+		if s := strings.TrimSpace(tv); s != "" {
+			return []string{s}, true
+		}
+		return nil, true
+	case []string:
+		return tv, true
+	case []any:
+		out := make([]string, 0, len(tv))
+		for _, e := range tv {
+			if s, ok := extractMappedClaimString(map[string]any{"_": e}, "_"); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out, true
+	}
+	return nil, false
+}
+
 // checkExternalIDTokenAlg enforces the JWT-SVID §3 asymmetric allow-list
 // (via jwtalg.Validate — also rejects alg=none and HS*) and then narrows
 // further if the deployer configured a per-issuer allow-list. Runs before

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -1,0 +1,242 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+)
+
+// idJAGTyp is the JWS `typ` header value that identifies an assertion as an
+// MCP Enterprise-Managed-Authorization ID-JAG (Identity Assertion Authorization
+// Grant), per the ext-auth STABLE spec
+// (draft-ietf-oauth-identity-assertion-authz-grant §4.4.1 / ADR 0010). The
+// jwt-bearer grant branches on this value: an assertion carrying it is an
+// ID-JAG signed by a corporate IdP and MUST be validated against that IdP's
+// JWKS via the #88 external-issuer substrate, NOT the NHI self-signed
+// registered-key path.
+const idJAGTyp = "oauth-id-jag+jwt"
+
+// idJAGGrantProfile is the authorization grant profile URN ZeroID advertises in
+// the AS metadata's authorization_grant_profiles_supported field (ADR 0010 D6).
+const idJAGGrantProfile = "urn:ietf:params:oauth:grant-profile:id-jag"
+
+// isIDJAGAssertion reports whether the compact JWS in assertion carries the
+// ID-JAG typ header. An unreadable header returns false — such an assertion
+// falls through to the NHI self-signed jwt-bearer path, which then rejects it
+// during its own parse/validate (fail closed; never silently treated as
+// external).
+func isIDJAGAssertion(assertion string) bool {
+	hdr, ok := decodeJWTHeader(assertion)
+	if !ok {
+		return false
+	}
+	return hdr.Typ == idJAGTyp
+}
+
+// idJAGBearer mints an audience-restricted ZeroID access token from an MCP
+// ID-JAG presented at POST /oauth2/token with
+// grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer (ADR 0010 D2-D4).
+//
+// ZeroID plays the MCP Authorization Server role: the corporate IdP (Okta /
+// Entra) has already evaluated admission policy and minted the ID-JAG carrying
+// the target MCP server (`resource`) and the IdP-scoped `scope`. ZeroID
+// validates the ID-JAG against that IdP's JWKS (reusing validateExternalAssertion
+// — the same #88 substrate the id_token-exchange path uses), maps the external
+// identity to a Highflame principal, and mints a ZeroID access token
+// audience-restricted to `resource`. The ID-JAG terminates here; only the minted
+// ZeroID token travels downstream to Firehog/Shield (ADR 0010 D5).
+//
+// Fail closed (OAuth invalid_grant, never mint) when: the issuer is not a
+// configured external issuer, the AllowedAccounts tenant binding does not permit
+// the request, signature/claim validation fails, the external identity cannot be
+// mapped, or the `resource` audience claim is absent (D3, D4).
+func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*domain.AccessToken, error) {
+	if s.externalIssuerRegistry == nil || !s.externalIssuerRegistry.HasAny() {
+		// No external issuers configured → ID-JAG federation is disabled. The
+		// IdP is the trust anchor; without one there is nothing to validate the
+		// ID-JAG against, so fail closed rather than fall back to any other path.
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG federation is not configured (no external issuers)")
+	}
+	// account_id / project_id are caller-supplied form fields (same as the
+	// id_token-exchange path) — they are the tenant the AllowedAccounts binding
+	// gates against. Tenant cannot be derived from the ID-JAG: it is born at the
+	// corporate IdP, which has no notion of a Highflame tenant.
+	if req.AccountID == "" || req.ProjectID == "" {
+		return nil, oauthBadRequest(oautherror.InvalidRequest, "account_id and project_id are required for the ID-JAG jwt-bearer grant")
+	}
+
+	// Peek at the assertion to extract iss without verifying — we need iss to
+	// look up which IdP's JWKS to validate against. (typ was already confirmed
+	// as oauth-id-jag+jwt by the caller's isIDJAGAssertion branch.)
+	peeked, err := jwt.ParseInsecure([]byte(req.Subject))
+	if err != nil {
+		return nil, oauthBadRequestCause(oautherror.InvalidGrant, "ID-JAG assertion is malformed", err)
+	}
+	upstreamIss, ok := peeked.Issuer()
+	if !ok || upstreamIss == "" {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG assertion missing iss claim")
+	}
+
+	entry := s.externalIssuerRegistry.Lookup(upstreamIss)
+	if entry == nil {
+		// Unknown issuer. Unlike the id_token-exchange path (which classifies
+		// this as invalid_request because the token may be valid against its
+		// real IdP and the failure is purely a deployer-config gap), ADR 0010
+		// D3 mandates fail-closed with invalid_grant for the ID-JAG path: an
+		// ID-JAG from an unconfigured IdP cannot be mapped to a Highflame
+		// principal, so the grant is invalid. Wrap the sentinel so callers can
+		// still errors.Is it for logging/branching.
+		return nil, oauthBadRequestCause(
+			oautherror.InvalidGrant,
+			fmt.Sprintf("issuer %s is not a configured external issuer", upstreamIss),
+			fmt.Errorf("%w: %s", ErrUnknownExternalIssuer, upstreamIss),
+		)
+	}
+	cfg := entry.Config
+
+	// Tenant binding — the only thing that ties an upstream ID-JAG to a
+	// Highflame tenant. AllowedAccounts is required+non-empty at config load;
+	// a request whose account_id is not listed fails closed (D3).
+	if !cfg.AccountAllowed(req.AccountID) {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, fmt.Sprintf("account %s is not allowed to use issuer %s", req.AccountID, upstreamIss))
+	}
+
+	// Verify the ID-JAG against its IdP — signature (JWKS), iss, aud, exp/nbf,
+	// alg allow-list, MaxTokenAge, sub/exp/iat presence. Shared verbatim with
+	// the id_token-exchange path (validateExternalAssertion); "assertion" names
+	// the wire field for ID-JAG callers.
+	verified, err := s.validateExternalAssertion(ctx, req.Subject, entry, "assertion")
+	if err != nil {
+		return nil, err
+	}
+
+	rawClaims := tokenClaimsAsMap(verified)
+
+	// Identity mapping (D3). user_id is required (validated at config load);
+	// resolve the external subject through ClaimMapping. Fail closed when it is
+	// absent or empty — an unmappable identity must never mint a token (an
+	// admitted-but-unidentifiable agent matches no Cedar policy).
+	userID, ok := extractMappedClaimString(rawClaims, cfg.ClaimMapping["user_id"])
+	if !ok || userID == "" {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, fmt.Sprintf("ID-JAG missing claim %q (mapped to user_id) — cannot map to a Highflame principal", cfg.ClaimMapping["user_id"]))
+	}
+	userEmail, _ := extractMappedClaimString(rawClaims, cfg.ClaimMapping["email"])
+	userName, _ := extractMappedClaimString(rawClaims, cfg.ClaimMapping["name"])
+
+	// Audience restriction (D4, MUST). The minted token's aud is the ID-JAG's
+	// `resource` claim — the target MCP server. Fail closed if absent/empty: an
+	// unbound MCP access token could be replayed against any resource server
+	// (RFC 8707). `resource` is a standard string claim on the ID-JAG, not a
+	// ClaimMapping target — the spec names it directly.
+	resource, ok := extractMappedClaimString(rawClaims, "resource")
+	if !ok || resource == "" {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG missing required resource claim — cannot audience-restrict the minted token")
+	}
+
+	// Resolve the application identity if requested (IDOR-guarded, same as the
+	// id_token-exchange path); otherwise synthesize a service identity for the
+	// external principal.
+	identity, err := s.resolveExternalPrincipalIdentity(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map IdP group/role claims into Cedar principal attributes (D3). These are
+	// OPTIONAL — present only when the ID-JAG carries the claim AND ClaimMapping
+	// routes it. role and privilege_scope are reservedClaims (an untrusted
+	// caller can never inject them via additional_claims), but here ZeroID
+	// itself sources them from the IdP-verified ID-JAG, so we set them directly
+	// into CustomClaims (which bypasses the additional_claims blocklist by
+	// design — same pattern the trusted broker path uses for role/privilege_scope).
+	customClaims := map[string]any{
+		"token_exchange": "id_jag",
+		"user_id_iss":    upstreamIss,
+	}
+	if role, ok := extractMappedClaimString(rawClaims, cfg.ClaimMapping["role"]); ok && role != "" {
+		customClaims["role"] = role
+	}
+	if ps, ok := extractMappedClaimStrings(rawClaims, cfg.ClaimMapping["privilege_scope"]); ok && len(ps) > 0 {
+		customClaims["privilege_scope"] = ps
+	}
+	// trust_level, when the IdP supplies it via ClaimMapping, overrides the
+	// synthetic identity's default so the minted trust_level claim reflects the
+	// IdP's assessment (e.g. an Okta group → verified_third_party).
+	if tl, ok := extractMappedClaimString(rawClaims, cfg.ClaimMapping["trust_level"]); ok && tl != "" {
+		identity.TrustLevel = domain.TrustLevel(tl)
+	}
+
+	// Honest propagation of RFC 9068 authentication-context claims — only
+	// forward auth_time/acr/amr when the deployer asked for them AND the ID-JAG
+	// actually set them. Never default-fill.
+	for _, claim := range cfg.PropagateClaims {
+		if v, present := rawClaims[claim]; present {
+			customClaims[claim] = v
+		}
+	}
+
+	// Resolve the identity's credential policy when we have a real identity row
+	// so issuance enforces the same policy ceiling (allowed scopes, max TTL,
+	// trust level, policy expiry) as every other grant.
+	var identityPolicyID string
+	if identity.ID != "" {
+		policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, identity)
+		if err != nil {
+			return nil, oauthServerError("failed to resolve identity credential policy", err)
+		}
+		identityPolicyID = policy.ID
+	}
+
+	// Scopes come from the ID-JAG's `scope` claim — the IdP already evaluated
+	// policy and scoped the grant (ADR 0010). The minted token's scopes are
+	// that set, gated through the identity-policy ceiling as defense in depth
+	// (a real identity row enforces it via IssueCredential; the synthetic
+	// service-identity carrier is governed by the tenant default policy through
+	// ResolveIdentityPolicy below). The `scope` claim may be a space-delimited
+	// string (standard) or a string array — extractMappedClaimStrings handles both.
+	scopes, _ := extractMappedClaimStrings(rawClaims, "scope")
+
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+		Identity:         identity,
+		IdentityPolicyID: identityPolicyID,
+		// Govern the synthetic-carrier path (no application_id → no identity row
+		// and no IdentityPolicyID) by the tenant default policy, mirroring the
+		// id_token-exchange path. Without this, any holder of a valid ID-JAG
+		// could request arbitrary scopes ungated on the no-application_id path.
+		ResolveIdentityPolicy: true,
+		GrantType:             domain.GrantTypeJWTBearer,
+		Scopes:                scopes,
+		// Audience-restrict to the ID-JAG resource (D4). IssueCredential stamps
+		// this verbatim as the aud claim instead of defaulting to the issuer URL.
+		Audience:          []string{resource},
+		UseRS256:          true,
+		SubjectOverride:   userID,
+		UserEmail:         userEmail,
+		UserName:          userName,
+		ApplicationID:     req.ApplicationID,
+		TTL:               900, // 15 minutes — short-lived, matching the external-IdP paths
+		CustomClaims:      customClaims,
+		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	accessToken.AccountID = req.AccountID
+	accessToken.ProjectID = req.ProjectID
+	accessToken.UserID = userID
+
+	log.Info().
+		Str("upstream_iss", upstreamIss).
+		Str("account_id", req.AccountID).
+		Str("project_id", req.ProjectID).
+		Str("user_id", userID).
+		Str("resource", resource).
+		Msg("ID-JAG jwt-bearer exchange succeeded")
+
+	return accessToken, nil
+}

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -129,12 +129,14 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 	userName, _ := extractMappedClaimString(rawClaims, cfg.ClaimMapping["name"])
 
 	// Audience restriction (D4, MUST). The minted token's aud is the ID-JAG's
-	// `resource` claim — the target MCP server. Fail closed if absent/empty: an
-	// unbound MCP access token could be replayed against any resource server
-	// (RFC 8707). `resource` is a standard string claim on the ID-JAG, not a
-	// ClaimMapping target — the spec names it directly.
-	resource, ok := extractMappedClaimString(rawClaims, "resource")
-	if !ok || resource == "" {
+	// `resource` claim — the target MCP server(s). Fail closed if absent/empty:
+	// an unbound MCP access token could be replayed against any resource server.
+	// Per RFC 8707 `resource` may be a single string or an array (some IdPs emit
+	// even a single resource as a one-element array), so accept both shapes and
+	// audience-restrict to the full set the IdP authorized. `resource` is a
+	// standard claim named directly by the spec, not a ClaimMapping target.
+	resources, ok := extractMappedClaimStrings(rawClaims, "resource")
+	if !ok || len(resources) == 0 {
 		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG missing required resource claim — cannot audience-restrict the minted token")
 	}
 
@@ -191,14 +193,20 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		identityPolicyID = policy.ID
 	}
 
-	// Scopes come from the ID-JAG's `scope` claim — the IdP already evaluated
+	// Scopes come from the ID-JAG's scope claim — the IdP already evaluated
 	// policy and scoped the grant (ADR 0010). The minted token's scopes are
 	// that set, gated through the identity-policy ceiling as defense in depth
 	// (a real identity row enforces it via IssueCredential; the synthetic
 	// service-identity carrier is governed by the tenant default policy through
-	// ResolveIdentityPolicy below). The `scope` claim may be a space-delimited
-	// string (standard) or a string array — extractMappedClaimStrings handles both.
-	scopes, _ := extractMappedClaimStrings(rawClaims, "scope")
+	// ResolveIdentityPolicy below). The value may be a space-delimited string
+	// (standard) or an array — extractMappedClaimStrings handles both. The claim
+	// NAME is configurable via ClaimMapping["scope"] (some IdPs emit it under a
+	// non-standard name, e.g. Microsoft Entra's `scp`), defaulting to "scope".
+	scopeClaim := cfg.ClaimMapping["scope"]
+	if scopeClaim == "" {
+		scopeClaim = "scope"
+	}
+	scopes, _ := extractMappedClaimStrings(rawClaims, scopeClaim)
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:         identity,
@@ -210,9 +218,9 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		ResolveIdentityPolicy: true,
 		GrantType:             domain.GrantTypeJWTBearer,
 		Scopes:                scopes,
-		// Audience-restrict to the ID-JAG resource (D4). IssueCredential stamps
-		// this verbatim as the aud claim instead of defaulting to the issuer URL.
-		Audience:          []string{resource},
+		// Audience-restrict to the ID-JAG resource(s) (D4). IssueCredential stamps
+		// these verbatim as the aud claim instead of defaulting to the issuer URL.
+		Audience:          resources,
 		UseRS256:          true,
 		SubjectOverride:   userID,
 		UserEmail:         userEmail,
@@ -235,7 +243,7 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		Str("account_id", req.AccountID).
 		Str("project_id", req.ProjectID).
 		Str("user_id", userID).
-		Str("resource", resource).
+		Strs("resources", resources).
 		Msg("ID-JAG jwt-bearer exchange succeeded")
 
 	return accessToken, nil

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/lestrrat-go/jwx/v4/jwt"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/oautherror"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
 // idJAGTyp is the JWS `typ` header value that identifies an assertion as an
@@ -106,6 +108,24 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		return nil, oauthBadRequest(oautherror.InvalidGrant, fmt.Sprintf("account %s is not allowed to use issuer %s", req.AccountID, upstreamIss))
 	}
 
+	// Confidential-client authentication (ADR 0010 D2b). A leaked ID-JAG must
+	// not be redeemable by another party: the draft (with §9.1) requires
+	// redemption to come from an authenticated confidential client. Require
+	// client_id (no client auth presented → invalid_client) and verify the
+	// secret via the same path client_credentials uses, mirroring its sentinel
+	// mapping. The client_id-binding half of D2b runs after the ID-JAG is
+	// verified (we need its client_id claim).
+	if req.ClientID == "" {
+		return nil, oauthUnauthorized("ID-JAG redemption requires confidential client authentication", nil)
+	}
+	authedClient, err := s.oauthClientSvc.VerifyClientSecret(ctx, req.ClientID, req.ClientSecret)
+	if err != nil {
+		if errors.Is(err, ErrOAuthClientNotFound) || errors.Is(err, ErrInvalidClientSecret) {
+			return nil, oauthUnauthorized("invalid client credentials", err)
+		}
+		return nil, oauthUnauthorized("client verification failed", err)
+	}
+
 	// Verify the ID-JAG against its IdP — signature (JWKS), iss, aud, exp/nbf,
 	// alg allow-list, MaxTokenAge, sub/exp/iat presence. Shared verbatim with
 	// the id_token-exchange path (validateExternalAssertion); "assertion" names
@@ -116,6 +136,18 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 	}
 
 	rawClaims := tokenClaimsAsMap(verified)
+
+	// client_id binding (ADR 0010 D2b). Signature validity alone is not enough:
+	// the ID-JAG's `client_id` claim MUST equal the authenticated client, so a
+	// stolen-but-validly-signed ID-JAG cannot be redeemed by a different client
+	// at the mint boundary. This binding (not the signature) is the control.
+	idJAGClientID, _ := extractMappedClaimString(rawClaims, "client_id")
+	if idJAGClientID == "" {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG missing client_id claim")
+	}
+	if idJAGClientID != authedClient.ClientID {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG client_id does not match the authenticated client")
+	}
 
 	// Identity mapping (D3). user_id is required (validated at config load);
 	// resolve the external subject through ClaimMapping. Fail closed when it is
@@ -208,6 +240,34 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		scopeClaim = "scope"
 	}
 	scopes, _ := extractMappedClaimStrings(rawClaims, scopeClaim)
+
+	// Single-use enforcement (ADR 0010 D2a) — CONSUMED LAST, only after every
+	// other check (D2b client auth + client_id binding, ID-JAG validation,
+	// identity mapping, resource, policy resolution) has passed and immediately
+	// before issuance. A request that fails an earlier check must NOT consume the
+	// jti, or an attacker could burn a victim's single-use grant by deliberately
+	// failing a later-but-not-last check. The store INSERT is the atomic
+	// check-and-mark: a replay surfaces as ErrIDJAGReplay.
+	if s.idJAGReplayStore == nil {
+		// Fail closed: ID-JAG is single-use and we cannot enforce that without a
+		// replay store. Never mint while replay protection is unavailable.
+		return nil, oauthServerError("ID-JAG replay store is not configured", nil)
+	}
+	jti, ok := verified.JwtID()
+	if !ok || jti == "" {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG missing jti — single-use grants require jti")
+	}
+	// expires_at is the ID-JAG's own exp: past it the grant fails its exp check
+	// before the jti is consulted, so the row is no longer load-bearing and the
+	// cleanup worker may reap it. validateExternalAssertion already required exp
+	// to be present, so this lookup succeeds.
+	jtiExpiry, _ := verified.Expiration()
+	if err := s.idJAGReplayStore.Insert(ctx, jti, jtiExpiry); err != nil {
+		if errors.Is(err, postgres.ErrIDJAGReplay) {
+			return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG has already been redeemed")
+		}
+		return nil, oauthServerError("failed to record ID-JAG single-use jti", err)
+	}
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:         identity,

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -131,11 +131,12 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 	// Audience restriction (D4, MUST). The minted token's aud is the ID-JAG's
 	// `resource` claim — the target MCP server(s). Fail closed if absent/empty:
 	// an unbound MCP access token could be replayed against any resource server.
-	// Per RFC 8707 `resource` may be a single string or an array (some IdPs emit
-	// even a single resource as a one-element array), so accept both shapes and
-	// audience-restrict to the full set the IdP authorized. `resource` is a
-	// standard claim named directly by the spec, not a ClaimMapping target.
-	resources, ok := extractMappedClaimStrings(rawClaims, "resource")
+	// Per RFC 8707 `resource` is a single URI string OR an array of them — a
+	// string is ONE resource (taken atomically, NOT space-split like `scope`).
+	// extractResourceClaim handles both shapes; we audience-restrict to the full
+	// set the IdP authorized. `resource` is a standard claim named directly by
+	// the spec, not a ClaimMapping target.
+	resources, ok := extractResourceClaim(rawClaims)
 	if !ok || len(resources) == 0 {
 		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG missing required resource claim — cannot audience-restrict the minted token")
 	}

--- a/internal/service/oauth_id_jag_test.go
+++ b/internal/service/oauth_id_jag_test.go
@@ -126,6 +126,34 @@ func TestExtractMappedClaimStrings(t *testing.T) {
 	})
 }
 
+// TestExtractResourceClaim verifies the ID-JAG `resource` claim is read per
+// RFC 8707: a string is ONE resource taken ATOMICALLY (never space-split like a
+// scope string), and an array is multi-valued. This is the bug-guard for the
+// audience-restriction path (D4) — splitting a string resource would forge
+// bogus audiences.
+func TestExtractResourceClaim(t *testing.T) {
+	t.Run("string resource is atomic, not space-split", func(t *testing.T) {
+		// A scope-style split would wrongly yield two entries here.
+		got, ok := extractResourceClaim(map[string]any{"resource": "https://mcp.example.com/a b"})
+		if !ok || len(got) != 1 || got[0] != "https://mcp.example.com/a b" {
+			t.Fatalf("string resource must be a single atomic value, got %v (ok=%v)", got, ok)
+		}
+	})
+
+	t.Run("array resource preserved", func(t *testing.T) {
+		got, ok := extractResourceClaim(map[string]any{"resource": []any{"https://a", "https://b"}})
+		if !ok || len(got) != 2 || got[0] != "https://a" || got[1] != "https://b" {
+			t.Fatalf("array resource must be preserved, got %v (ok=%v)", got, ok)
+		}
+	})
+
+	t.Run("absent resource returns false", func(t *testing.T) {
+		if _, ok := extractResourceClaim(map[string]any{}); ok {
+			t.Fatalf("expected ok=false when resource is absent")
+		}
+	})
+}
+
 // idJAGTestRegistry builds a single-issuer registry pointed at a fake JWKS,
 // returning the registry plus the upstream signer so a test can mint a
 // validly-signed ID-JAG.

--- a/internal/service/oauth_id_jag_test.go
+++ b/internal/service/oauth_id_jag_test.go
@@ -1,0 +1,350 @@
+package service
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
+)
+
+// signWithTyp serialises the given claim map as an ES256 JWT whose protected
+// header carries the supplied typ — used to mint ID-JAG-shaped (typ:
+// oauth-id-jag+jwt) and ordinary assertions for the typ-branch tests.
+func signWithTyp(t *testing.T, priv *ecdsa.PrivateKey, kid, typ string, claims map[string]any) string {
+	t.Helper()
+	tok := jwt.New()
+	for k, v := range claims {
+		if err := tok.Set(k, v); err != nil {
+			t.Fatalf("set claim %q: %v", k, err)
+		}
+	}
+	hdr := jws.NewHeaders()
+	if kid != "" {
+		_ = hdr.Set(jws.KeyIDKey, kid)
+	}
+	if typ != "" {
+		_ = hdr.Set(jws.TypeKey, typ)
+	}
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), priv, jws.WithProtectedHeaders(hdr)))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return string(signed)
+}
+
+// TestIsIDJAGAssertion verifies the typ-branch discriminator: only an assertion
+// whose JWS typ header is exactly oauth-id-jag+jwt routes to the ID-JAG path.
+// Everything else (a JWT typ, no typ, a malformed token) stays on the NHI
+// self-signed path. This is the gate the whole ADR 0010 D2 branch hinges on.
+func TestIsIDJAGAssertion(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	base := map[string]any{"iss": "https://idp.test", "sub": "alice"}
+
+	t.Run("typ oauth-id-jag+jwt is an ID-JAG", func(t *testing.T) {
+		tok := signWithTyp(t, priv, "kid", idJAGTyp, base)
+		if !isIDJAGAssertion(tok) {
+			t.Fatalf("expected oauth-id-jag+jwt assertion to be detected as ID-JAG")
+		}
+	})
+
+	t.Run("typ JWT is NOT an ID-JAG (NHI path)", func(t *testing.T) {
+		tok := signWithTyp(t, priv, "kid", "JWT", base)
+		if isIDJAGAssertion(tok) {
+			t.Fatalf("a typ=JWT assertion must NOT be treated as an ID-JAG")
+		}
+	})
+
+	t.Run("no typ header is NOT an ID-JAG (NHI path)", func(t *testing.T) {
+		tok := signWithTyp(t, priv, "kid", "", base)
+		if isIDJAGAssertion(tok) {
+			t.Fatalf("an assertion without a typ header must NOT be treated as an ID-JAG")
+		}
+	})
+
+	t.Run("garbage is NOT an ID-JAG", func(t *testing.T) {
+		if isIDJAGAssertion("not-a-jwt") {
+			t.Fatalf("a malformed assertion must NOT be treated as an ID-JAG")
+		}
+		if isIDJAGAssertion("") {
+			t.Fatalf("an empty assertion must NOT be treated as an ID-JAG")
+		}
+	})
+}
+
+// TestExtractMappedClaimStrings covers the two multi-valued claim shapes the
+// ID-JAG path reads: a space-delimited `scope` string and an array-valued
+// claim (groups / privilege_scope). Numeric array entries are stringified.
+func TestExtractMappedClaimStrings(t *testing.T) {
+	t.Run("space-delimited scope string", func(t *testing.T) {
+		got, ok := extractMappedClaimStrings(map[string]any{"scope": "read write admin"}, "scope")
+		if !ok {
+			t.Fatalf("expected ok=true")
+		}
+		if len(got) != 3 || got[0] != "read" || got[2] != "admin" {
+			t.Fatalf("expected [read write admin], got %v", got)
+		}
+	})
+
+	t.Run("string array", func(t *testing.T) {
+		got, ok := extractMappedClaimStrings(map[string]any{"groups": []any{"eng", "admin"}}, "groups")
+		if !ok || len(got) != 2 || got[0] != "eng" || got[1] != "admin" {
+			t.Fatalf("expected [eng admin], got %v (ok=%v)", got, ok)
+		}
+	})
+
+	t.Run("numeric array entries stringified", func(t *testing.T) {
+		got, ok := extractMappedClaimStrings(map[string]any{"ids": []any{float64(1), float64(2)}}, "ids")
+		if !ok || len(got) != 2 || got[0] != "1" || got[1] != "2" {
+			t.Fatalf("expected [1 2], got %v (ok=%v)", got, ok)
+		}
+	})
+
+	t.Run("missing claim returns false", func(t *testing.T) {
+		if _, ok := extractMappedClaimStrings(map[string]any{"scope": "x"}, "groups"); ok {
+			t.Fatalf("expected ok=false for missing claim")
+		}
+	})
+
+	t.Run("empty path returns false", func(t *testing.T) {
+		if _, ok := extractMappedClaimStrings(map[string]any{"scope": "x"}, ""); ok {
+			t.Fatalf("expected ok=false for empty path (no mapping configured)")
+		}
+	})
+}
+
+// idJAGTestRegistry builds a single-issuer registry pointed at a fake JWKS,
+// returning the registry plus the upstream signer so a test can mint a
+// validly-signed ID-JAG.
+func idJAGTestRegistry(t *testing.T, accountID string) (*ExternalIssuerRegistry, *fakeJWKSServer, string, string) {
+	t.Helper()
+	const kid = "idjag-kid-1"
+	jwks := newFakeJWKSServer(t, kid)
+	t.Cleanup(jwks.Close)
+
+	const iss = "https://corp-idp.example.test"
+	const aud = "https://zeroid.example.test"
+	cfg := domain.ExternalIssuerConfig{
+		Issuer:          iss,
+		JWKSURI:         jwks.URL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "sub", "email": "email"},
+		AllowedAccounts: []string{accountID},
+	}
+	cfg.Defaults()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate cfg: %v", err)
+	}
+	registry, err := NewExternalIssuerRegistry(
+		context.Background(),
+		[]domain.ExternalIssuerConfig{cfg},
+		authjwt.WithHTTPClient(insecureHTTPClient(2*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("NewExternalIssuerRegistry: %v", err)
+	}
+	t.Cleanup(registry.Close)
+	return registry, jwks, iss, aud
+}
+
+// signIDJAG mints a validly-signed ID-JAG (typ oauth-id-jag+jwt) against the
+// fake JWKS server's current key.
+func signIDJAG(t *testing.T, jwks *fakeJWKSServer, claims map[string]any) string {
+	t.Helper()
+	return signWithTyp(t, jwks.curPriv, "idjag-kid-1", idJAGTyp, claims)
+}
+
+// requireInvalidGrant asserts the error carries an *OAuthError with code
+// invalid_grant / 400 — the fail-closed contract for the ID-JAG path.
+func requireInvalidGrant(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected invalid_grant error, got nil")
+	}
+	var oauthErr *OAuthError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("expected *OAuthError in chain, got %T: %v", err, err)
+	}
+	if oauthErr.Code != "invalid_grant" {
+		t.Errorf("Code = %q, want invalid_grant; err=%v", oauthErr.Code, err)
+	}
+	if oauthErr.HTTPStatus != http.StatusBadRequest {
+		t.Errorf("HTTPStatus = %d, want 400", oauthErr.HTTPStatus)
+	}
+}
+
+// The following tests exercise idJAGBearer's fail-closed gates that fire BEFORE
+// any token mint — so they need only a registry, no DB / CredentialService.
+// The end-to-end happy path (mapped claims + aud==resource) is covered by the
+// integration test (tests/integration/id_jag_test.go) where a full server with
+// a real DB is available.
+
+func TestIDJAGBearer_UnknownIssuer_InvalidGrant(t *testing.T) {
+	const acct = "acct-idjag"
+	registry, _, _, aud := idJAGTestRegistry(t, acct)
+
+	// Sign an ID-JAG whose iss is NOT the configured issuer. Lookup misses →
+	// fail closed with invalid_grant (NOT invalid_request — that is the
+	// id_token-exchange semantics; ADR 0010 D3 mandates invalid_grant here).
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	now := time.Now()
+	stranger := signWithTyp(t, priv, "kid", idJAGTyp, map[string]any{
+		"iss":      "https://stranger.example.test",
+		"sub":      "alice",
+		"aud":      aud,
+		"resource": "https://mcp.example.test",
+		"iat":      now.Unix(),
+		"exp":      now.Add(5 * time.Minute).Unix(),
+	})
+
+	svc := &OAuthService{externalIssuerRegistry: registry}
+	_, err := svc.idJAGBearer(context.Background(), TokenRequest{
+		Subject:   stranger,
+		AccountID: acct,
+		ProjectID: "proj",
+	})
+	requireInvalidGrant(t, err)
+	if !errors.Is(err, ErrUnknownExternalIssuer) {
+		t.Errorf("expected errors.Is(err, ErrUnknownExternalIssuer); chain=%v", err)
+	}
+}
+
+func TestIDJAGBearer_BadSignature_InvalidGrant(t *testing.T) {
+	const acct = "acct-idjag"
+	registry, _, iss, aud := idJAGTestRegistry(t, acct)
+
+	// Sign with a DIFFERENT key than the JWKS publishes → signature verify fails.
+	wrongKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	now := time.Now()
+	forged := signWithTyp(t, wrongKey, "idjag-kid-1", idJAGTyp, map[string]any{
+		"iss":      iss,
+		"sub":      "alice",
+		"aud":      aud,
+		"resource": "https://mcp.example.test",
+		"iat":      now.Unix(),
+		"exp":      now.Add(5 * time.Minute).Unix(),
+	})
+
+	svc := &OAuthService{externalIssuerRegistry: registry}
+	_, err := svc.idJAGBearer(context.Background(), TokenRequest{
+		Subject:   forged,
+		AccountID: acct,
+		ProjectID: "proj",
+	})
+	requireInvalidGrant(t, err)
+}
+
+func TestIDJAGBearer_TenantBindingFailure_InvalidGrant(t *testing.T) {
+	const acct = "acct-idjag"
+	registry, jwks, iss, aud := idJAGTestRegistry(t, acct)
+
+	now := time.Now()
+	idjag := signIDJAG(t, jwks, map[string]any{
+		"iss":      iss,
+		"sub":      "alice",
+		"aud":      aud,
+		"resource": "https://mcp.example.test",
+		"iat":      now.Unix(),
+		"exp":      now.Add(5 * time.Minute).Unix(),
+	})
+
+	svc := &OAuthService{externalIssuerRegistry: registry}
+	// account_id NOT in AllowedAccounts → fail closed before any verification.
+	_, err := svc.idJAGBearer(context.Background(), TokenRequest{
+		Subject:   idjag,
+		AccountID: "acct-not-allowed",
+		ProjectID: "proj",
+	})
+	requireInvalidGrant(t, err)
+}
+
+func TestIDJAGBearer_MissingResource_InvalidGrant(t *testing.T) {
+	const acct = "acct-idjag"
+	registry, jwks, iss, aud := idJAGTestRegistry(t, acct)
+
+	now := time.Now()
+	// A perfectly valid, correctly-signed ID-JAG that simply omits `resource`.
+	// The audience-restriction MUST (D4) makes this fail closed: there is no
+	// MCP server to bind the minted token's aud to.
+	noResource := signIDJAG(t, jwks, map[string]any{
+		"iss": iss,
+		"sub": "alice",
+		"aud": aud,
+		"iat": now.Unix(),
+		"exp": now.Add(5 * time.Minute).Unix(),
+	})
+
+	svc := &OAuthService{externalIssuerRegistry: registry}
+	_, err := svc.idJAGBearer(context.Background(), TokenRequest{
+		Subject:   noResource,
+		AccountID: acct,
+		ProjectID: "proj",
+	})
+	requireInvalidGrant(t, err)
+}
+
+func TestIDJAGBearer_UnmappableIdentity_InvalidGrant(t *testing.T) {
+	const acct = "acct-idjag"
+	_, _, iss, aud := idJAGTestRegistry(t, acct)
+
+	now := time.Now()
+	// The ID-JAG is validly signed and carries `sub` (so the RFC 7523 §3
+	// presence check passes), but ClaimMapping routes user_id to
+	// "preferred_username", which the assertion does NOT carry → the external
+	// identity cannot be mapped → fail closed (D3). This isolates the *mapping*
+	// failure from the presence check (which also requires `sub`).
+	const kid = "idjag-kid-2"
+	jwks2 := newFakeJWKSServer(t, kid)
+	t.Cleanup(jwks2.Close)
+	cfg := domain.ExternalIssuerConfig{
+		Issuer:          iss + "-2",
+		JWKSURI:         jwks2.URL(),
+		Audience:        aud,
+		ClaimMapping:    map[string]string{"user_id": "preferred_username"},
+		AllowedAccounts: []string{acct},
+	}
+	cfg.Defaults()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate cfg: %v", err)
+	}
+	registry2, err := NewExternalIssuerRegistry(
+		context.Background(),
+		[]domain.ExternalIssuerConfig{cfg},
+		authjwt.WithHTTPClient(insecureHTTPClient(2*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	t.Cleanup(registry2.Close)
+
+	// Has sub (so presence check passes) but NO preferred_username (so mapping fails).
+	idjag := signWithTyp(t, jwks2.curPriv, kid, idJAGTyp, map[string]any{
+		"iss":      iss + "-2",
+		"sub":      "opaque-subject",
+		"aud":      aud,
+		"resource": "https://mcp.example.test",
+		"iat":      now.Unix(),
+		"exp":      now.Add(5 * time.Minute).Unix(),
+	})
+
+	svc := &OAuthService{externalIssuerRegistry: registry2}
+	_, err = svc.idJAGBearer(context.Background(), TokenRequest{
+		Subject:   idjag,
+		AccountID: acct,
+		ProjectID: "proj",
+	})
+	requireInvalidGrant(t, err)
+}

--- a/internal/service/oauth_id_jag_test.go
+++ b/internal/service/oauth_id_jag_test.go
@@ -195,30 +195,53 @@ func signIDJAG(t *testing.T, jwks *fakeJWKSServer, claims map[string]any) string
 	return signWithTyp(t, jwks.curPriv, "idjag-kid-1", idJAGTyp, claims)
 }
 
-// requireInvalidGrant asserts the error carries an *OAuthError with code
-// invalid_grant / 400 — the fail-closed contract for the ID-JAG path.
-func requireInvalidGrant(t *testing.T, err error) {
+// requireOAuthError asserts the error carries an *OAuthError with the given code
+// and HTTP status — the fail-closed contract for the ID-JAG path.
+func requireOAuthError(t *testing.T, err error, wantCode string, wantStatus int) {
 	t.Helper()
 	if err == nil {
-		t.Fatalf("expected invalid_grant error, got nil")
+		t.Fatalf("expected %s error, got nil", wantCode)
 	}
 	var oauthErr *OAuthError
 	if !errors.As(err, &oauthErr) {
 		t.Fatalf("expected *OAuthError in chain, got %T: %v", err, err)
 	}
-	if oauthErr.Code != "invalid_grant" {
-		t.Errorf("Code = %q, want invalid_grant; err=%v", oauthErr.Code, err)
+	if oauthErr.Code != wantCode {
+		t.Errorf("Code = %q, want %s; err=%v", oauthErr.Code, wantCode, err)
 	}
-	if oauthErr.HTTPStatus != http.StatusBadRequest {
-		t.Errorf("HTTPStatus = %d, want 400", oauthErr.HTTPStatus)
+	if oauthErr.HTTPStatus != wantStatus {
+		t.Errorf("HTTPStatus = %d, want %d", oauthErr.HTTPStatus, wantStatus)
 	}
+}
+
+// requireInvalidGrant asserts the error is invalid_grant / 400.
+func requireInvalidGrant(t *testing.T, err error) {
+	t.Helper()
+	requireOAuthError(t, err, "invalid_grant", http.StatusBadRequest)
+}
+
+// requireInvalidClient asserts the error is invalid_client / 401 — the D2b
+// confidential-client-auth fail-closed contract.
+func requireInvalidClient(t *testing.T, err error) {
+	t.Helper()
+	requireOAuthError(t, err, "invalid_client", http.StatusUnauthorized)
 }
 
 // The following tests exercise idJAGBearer's fail-closed gates that fire BEFORE
 // any token mint — so they need only a registry, no DB / CredentialService.
-// The end-to-end happy path (mapped claims + aud==resource) is covered by the
-// integration test (tests/integration/id_jag_test.go) where a full server with
-// a real DB is available.
+//
+// Gate order (idJAGBearer): external-issuers configured → tenant fields present
+// → issuer lookup → tenant binding (AllowedAccounts) → D2b confidential client
+// auth → ID-JAG signature/claim validation → D2b client_id binding → identity
+// mapping → resource (D4) → … → D2a single-use jti (consumed LAST). The
+// UnknownIssuer and TenantBinding gates fire BEFORE client auth, so those tests
+// need no client. Everything from ID-JAG validation onward (bad signature,
+// missing resource, unmappable identity, client_id binding, jti replay) is now
+// gated behind D2b client auth, which requires a real oauth_clients row — so the
+// fail-closed coverage for those gates lives in the integration suite
+// (tests/integration/id_jag_test.go) where a full server with a real DB is
+// available. The unit tests here pin the DB-free gates plus the D2b client-auth
+// gate itself.
 
 func TestIDJAGBearer_UnknownIssuer_InvalidGrant(t *testing.T) {
 	const acct = "acct-idjag"
@@ -250,14 +273,18 @@ func TestIDJAGBearer_UnknownIssuer_InvalidGrant(t *testing.T) {
 	}
 }
 
-func TestIDJAGBearer_BadSignature_InvalidGrant(t *testing.T) {
+// TestIDJAGBearer_NoClientAuth_InvalidClient pins the D2b confidential-client
+// gate: a redemption that presents NO client_id is rejected with invalid_client
+// (401) BEFORE any ID-JAG validation or mint. Fail-closed proof that a leaked
+// ID-JAG cannot be redeemed without authenticating a confidential client. This
+// gate fires after the tenant binding and before ID-JAG signature validation, so
+// it needs only a registry (no DB).
+func TestIDJAGBearer_NoClientAuth_InvalidClient(t *testing.T) {
 	const acct = "acct-idjag"
-	registry, _, iss, aud := idJAGTestRegistry(t, acct)
+	registry, jwks, iss, aud := idJAGTestRegistry(t, acct)
 
-	// Sign with a DIFFERENT key than the JWKS publishes → signature verify fails.
-	wrongKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	now := time.Now()
-	forged := signWithTyp(t, wrongKey, "idjag-kid-1", idJAGTyp, map[string]any{
+	idjag := signIDJAG(t, jwks, map[string]any{
 		"iss":      iss,
 		"sub":      "alice",
 		"aud":      aud,
@@ -267,12 +294,13 @@ func TestIDJAGBearer_BadSignature_InvalidGrant(t *testing.T) {
 	})
 
 	svc := &OAuthService{externalIssuerRegistry: registry}
+	// No ClientID presented → invalid_client, before any signature/JWKS work.
 	_, err := svc.idJAGBearer(context.Background(), TokenRequest{
-		Subject:   forged,
+		Subject:   idjag,
 		AccountID: acct,
 		ProjectID: "proj",
 	})
-	requireInvalidGrant(t, err)
+	requireInvalidClient(t, err)
 }
 
 func TestIDJAGBearer_TenantBindingFailure_InvalidGrant(t *testing.T) {
@@ -299,80 +327,12 @@ func TestIDJAGBearer_TenantBindingFailure_InvalidGrant(t *testing.T) {
 	requireInvalidGrant(t, err)
 }
 
-func TestIDJAGBearer_MissingResource_InvalidGrant(t *testing.T) {
-	const acct = "acct-idjag"
-	registry, jwks, iss, aud := idJAGTestRegistry(t, acct)
-
-	now := time.Now()
-	// A perfectly valid, correctly-signed ID-JAG that simply omits `resource`.
-	// The audience-restriction MUST (D4) makes this fail closed: there is no
-	// MCP server to bind the minted token's aud to.
-	noResource := signIDJAG(t, jwks, map[string]any{
-		"iss": iss,
-		"sub": "alice",
-		"aud": aud,
-		"iat": now.Unix(),
-		"exp": now.Add(5 * time.Minute).Unix(),
-	})
-
-	svc := &OAuthService{externalIssuerRegistry: registry}
-	_, err := svc.idJAGBearer(context.Background(), TokenRequest{
-		Subject:   noResource,
-		AccountID: acct,
-		ProjectID: "proj",
-	})
-	requireInvalidGrant(t, err)
-}
-
-func TestIDJAGBearer_UnmappableIdentity_InvalidGrant(t *testing.T) {
-	const acct = "acct-idjag"
-	_, _, iss, aud := idJAGTestRegistry(t, acct)
-
-	now := time.Now()
-	// The ID-JAG is validly signed and carries `sub` (so the RFC 7523 §3
-	// presence check passes), but ClaimMapping routes user_id to
-	// "preferred_username", which the assertion does NOT carry → the external
-	// identity cannot be mapped → fail closed (D3). This isolates the *mapping*
-	// failure from the presence check (which also requires `sub`).
-	const kid = "idjag-kid-2"
-	jwks2 := newFakeJWKSServer(t, kid)
-	t.Cleanup(jwks2.Close)
-	cfg := domain.ExternalIssuerConfig{
-		Issuer:          iss + "-2",
-		JWKSURI:         jwks2.URL(),
-		Audience:        aud,
-		ClaimMapping:    map[string]string{"user_id": "preferred_username"},
-		AllowedAccounts: []string{acct},
-	}
-	cfg.Defaults()
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("validate cfg: %v", err)
-	}
-	registry2, err := NewExternalIssuerRegistry(
-		context.Background(),
-		[]domain.ExternalIssuerConfig{cfg},
-		authjwt.WithHTTPClient(insecureHTTPClient(2*time.Second)),
-	)
-	if err != nil {
-		t.Fatalf("registry: %v", err)
-	}
-	t.Cleanup(registry2.Close)
-
-	// Has sub (so presence check passes) but NO preferred_username (so mapping fails).
-	idjag := signWithTyp(t, jwks2.curPriv, kid, idJAGTyp, map[string]any{
-		"iss":      iss + "-2",
-		"sub":      "opaque-subject",
-		"aud":      aud,
-		"resource": "https://mcp.example.test",
-		"iat":      now.Unix(),
-		"exp":      now.Add(5 * time.Minute).Unix(),
-	})
-
-	svc := &OAuthService{externalIssuerRegistry: registry2}
-	_, err = svc.idJAGBearer(context.Background(), TokenRequest{
-		Subject:   idjag,
-		AccountID: acct,
-		ProjectID: "proj",
-	})
-	requireInvalidGrant(t, err)
-}
+// NOTE: the deep-gate fail-closed unit tests that previously lived here —
+// bad signature, missing resource (D4), and unmappable identity (D3) — exercised
+// gates that now sit BEHIND the D2b confidential-client-auth gate. Driving them
+// requires a real oauth_clients row (VerifyClientSecret), which the DB-free
+// service unit harness cannot provide. Their fail-closed coverage moved to the
+// integration suite (tests/integration/id_jag_test.go: "bad signature fails
+// closed", "missing resource fails closed", plus the D2a replay / missing-jti
+// and D2b bad-secret / client_id-mismatch cases), where a full server with a
+// real DB authenticates the client first and then reaches each deeper gate.

--- a/internal/store/postgres/id_jag_jti.go
+++ b/internal/store/postgres/id_jag_jti.go
@@ -1,0 +1,71 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// ErrIDJAGReplay is returned by IDJAGReplayStore.Insert when the jti is already
+// present (SQLSTATE 23505 on the primary key). An MCP ID-JAG is a single-use
+// authorization grant (ADR 0010 D2a); a second redemption of the same jti is a
+// replay and the caller MUST reject the grant (OAuth invalid_grant).
+//
+// Defined as a package sentinel (not reusing dpop.ErrReplay) so the ID-JAG
+// redemption path can errors.Is it independently of the DPoP proof path — the
+// two replay domains are distinct (a grant jti vs a proof jti) even though the
+// storage shape is identical.
+var ErrIDJAGReplay = errors.New("id-jag jti has already been redeemed")
+
+// idJAGJTIRow is the bun model for the id_jag_jti replay-prevention table.
+// Schema is defined in migrations/034_id_jag_jti.up.sql; this struct must stay
+// in sync with the column definitions there.
+type idJAGJTIRow struct {
+	bun.BaseModel `bun:"table:id_jag_jti"`
+	JTI           string    `bun:"jti,pk"`
+	ExpiresAt     time.Time `bun:"expires_at"`
+}
+
+// IDJAGReplayStore is the Postgres-backed single-use ledger for redeemed ID-JAG
+// jti values (ADR 0010 D2a). One row per redeemed jti, primary-keyed; a
+// unique-constraint violation on INSERT is the atomic replay signal.
+//
+// Mirrors DPoPReplayStore verbatim — same single-use replay-table shape. Expired
+// rows are pruned by internal/worker/cleanup.go; this store doesn't run its own
+// pruner — the worker handles it for every table at once.
+type IDJAGReplayStore struct {
+	db *bun.DB
+}
+
+// NewIDJAGReplayStore wires an IDJAGReplayStore against the given bun.DB. The
+// db must have the id_jag_jti table available (migration 034_id_jag_jti.up.sql).
+func NewIDJAGReplayStore(db *bun.DB) *IDJAGReplayStore {
+	return &IDJAGReplayStore{db: db}
+}
+
+// Insert records a previously-unredeemed jti. Returns ErrIDJAGReplay on
+// SQLSTATE 23505 (unique constraint violation — the jti is already in the table
+// and the redemption is a replay). Other DB errors are returned as-is so the
+// caller can map them to a 5xx response rather than a (mis-classified) replay.
+//
+// The check-and-insert is atomic: concurrent Insert calls for the same jti
+// result in exactly one nil return and every other return being ErrIDJAGReplay.
+//
+// expiresAt should be the ID-JAG's own exp — the instant after which the entry
+// may be safely garbage-collected, because a grant that old would fail its exp
+// check before the jti is ever consulted.
+func (s *IDJAGReplayStore) Insert(ctx context.Context, jti string, expiresAt time.Time) error {
+	row := &idJAGJTIRow{JTI: jti, ExpiresAt: expiresAt}
+	_, err := s.db.NewInsert().Model(row).Exec(ctx)
+	if err == nil {
+		return nil
+	}
+	// isDuplicateKeyError is defined in dpop_replay.go (same package) — reuse it
+	// rather than re-declaring the SQLSTATE 23505 check.
+	if isDuplicateKeyError(err) {
+		return ErrIDJAGReplay
+	}
+	return err
+}

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -142,6 +142,21 @@ func (w *CleanupWorker) RunOnce(ctx context.Context) {
 		log.Info().Int64("count", n).Msg("Cleanup: deleted expired dpop jti records")
 	}
 
+	// ID-JAG redeemed jti records (ADR 0010 D2a) are only needed within the
+	// grant's own freshness window: past expires_at (the ID-JAG exp) the grant
+	// would fail its exp check before the jti is ever consulted, so the row is
+	// no longer load-bearing. Purge expired rows to bound table growth under
+	// high ID-JAG redemption volume — same single-use sweep as dpop_jti above.
+	idJAGRes, err := w.db.NewDelete().
+		TableExpr("id_jag_jti").
+		Where("expires_at < ?", now).
+		Exec(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Cleanup: failed to delete expired id_jag jti records")
+	} else if n, err := idJAGRes.RowsAffected(); err == nil && n > 0 {
+		log.Info().Int64("count", n).Msg("Cleanup: deleted expired id_jag jti records")
+	}
+
 	// Refresh tokens: under rotation every refresh inserts a successor row and
 	// revokes its predecessor, so the table grows linearly with token traffic
 	// if never swept. Delete rows whose expires_at is past the reuse-detection

--- a/migrations/034_id_jag_jti.down.sql
+++ b/migrations/034_id_jag_jti.down.sql
@@ -1,0 +1,12 @@
+-- 034_id_jag_jti.down.sql
+-- Drops the ID-JAG single-use replay-prevention store (ADR 0010 D2a).
+--
+-- DESTROYS REPLAY STATE: after this down runs, every ID-JAG `jti` redeemed
+-- before the rollback is forgotten, so a captured-but-already-redeemed ID-JAG
+-- that is still within its exp window could be replayed once. Treat as
+-- emergency-only.
+
+SET LOCAL lock_timeout = '3s';
+
+DROP INDEX IF EXISTS idx_id_jag_jti_expires_at;
+DROP TABLE IF EXISTS id_jag_jti;

--- a/migrations/034_id_jag_jti.up.sql
+++ b/migrations/034_id_jag_jti.up.sql
@@ -1,0 +1,34 @@
+-- 034_id_jag_jti.up.sql
+-- ID-JAG single-use replay-prevention store (ADR 0010 D2a).
+--
+-- An MCP ID-JAG (Identity Assertion Authorization Grant) is a single-use
+-- authorization grant — auth-code-like, not a reusable bearer token. Its `jti`
+-- MUST be consumed exactly once: a second redemption of the same `jti` is a
+-- replay and MUST be rejected (OAuth invalid_grant).
+--
+-- id_jag_jti: redeemed-jti ledger.
+--   INSERT fails on duplicate primary key (SQLSTATE 23505) → replay detected
+--   without a pre-check query (atomic check-and-insert; no TOCTOU).
+--   expires_at is the ID-JAG's own exp; rows outside that window are purged by
+--   the cleanup worker since a grant that old would fail its exp check before
+--   the jti is ever consumed.
+--
+--   Schema mirrors dpop_jti (migration 025_dpop) verbatim — same single-use
+--   replay-table shape, same storage tuning. Storage parameters: lowered
+--   autovacuum_vacuum_scale_factor (default 0.2) to keep dead tuples reaped at
+--   5% rather than waiting for 20% bloat — this table sees high INSERT-then-
+--   DELETE churn with no UPDATEs, exactly the workload where 0.05 helps most.
+--   fillfactor=90 leaves some page headroom for the rare row-version update.
+--
+-- Lock posture: CREATE TABLE / CREATE INDEX are on a brand-new empty table so
+-- there is no concurrent-rebuild concern. lock_timeout below scopes any
+-- blocking-acquire to a safe failure path.
+
+SET LOCAL lock_timeout = '3s';
+
+CREATE TABLE IF NOT EXISTS id_jag_jti (
+    jti        VARCHAR(512) PRIMARY KEY,
+    expires_at TIMESTAMPTZ NOT NULL
+) WITH (fillfactor = 90, autovacuum_vacuum_scale_factor = 0.05);
+
+CREATE INDEX IF NOT EXISTS idx_id_jag_jti_expires_at ON id_jag_jti (expires_at);

--- a/server.go
+++ b/server.go
@@ -286,6 +286,15 @@ func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
 		log.Info().Int("count", len(cfg.ExternalIssuers)).Msg("Direct OIDC IdP federation enabled")
 	}
 
+	// ID-JAG single-use replay store (ADR 0010 D2a). Wired unconditionally — the
+	// idJAGBearer path consumes the ID-JAG jti against this store as its final
+	// gate, and ID-JAG redemption is only reachable when external issuers are
+	// configured anyway. Wiring it always (not only when ExternalIssuers is
+	// non-empty) guarantees the path can never run with a nil store and silently
+	// skip replay protection. Backed by the id_jag_jti table (migration 034),
+	// swept by the cleanup worker.
+	oauthSvc.SetIDJAGReplayStore(postgres.NewIDJAGReplayStore(db))
+
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
 	// DelegationService is read-only over credentialRepo / delegationRepo /
 	// identityRepo and has no service dependencies of its own.

--- a/tests/integration/discovery_compliance_test.go
+++ b/tests/integration/discovery_compliance_test.go
@@ -127,3 +127,36 @@ func TestRFC8414_S3_WellKnownPathIsExact(t *testing.T) {
 	assert.True(t, strings.HasPrefix(contentType, "application/json"),
 		"AS metadata MUST be served as application/json; got %q", contentType)
 }
+
+// ── ADR 0010 — MCP Enterprise-Managed Authorization (ID-JAG) ────────────────
+
+// TestADR0010_IDJAGGrantProfileAdvertised verifies the AS metadata advertises
+// the ID-JAG authorization grant profile (ADR 0010 D6). EMA-capable MCP clients
+// read authorization_grant_profiles_supported to discover that this AS accepts
+// an Identity Assertion Authorization Grant via the jwt-bearer grant.
+func TestADR0010_IDJAGGrantProfileAdvertised(t *testing.T) {
+	body := fetchASMetadata(t)
+
+	// jwt-bearer (the grant the ID-JAG is presented through) must still be listed.
+	grants, _ := body["grant_types_supported"].([]any)
+	foundJWTBearer := false
+	for _, g := range grants {
+		if s, _ := g.(string); s == "urn:ietf:params:oauth:grant-type:jwt-bearer" {
+			foundJWTBearer = true
+		}
+	}
+	require.True(t, foundJWTBearer,
+		"grant_types_supported MUST still advertise jwt-bearer (the ID-JAG presentation grant)")
+
+	// The new field: the ID-JAG grant profile URN.
+	profiles, ok := body["authorization_grant_profiles_supported"].([]any)
+	require.True(t, ok, "authorization_grant_profiles_supported MUST be present (ADR 0010 D6)")
+	found := false
+	for _, p := range profiles {
+		if s, _ := p.(string); s == "urn:ietf:params:oauth:grant-profile:id-jag" {
+			found = true
+		}
+	}
+	require.True(t, found,
+		"authorization_grant_profiles_supported MUST advertise the ID-JAG grant profile")
+}

--- a/tests/integration/external_idp_helpers_test.go
+++ b/tests/integration/external_idp_helpers_test.go
@@ -6,8 +6,12 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
+	"testing"
 
+	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jws"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/require"
 )
 
 // sharedDBURL is the DSN of the shared TestMain Postgres container. It is
@@ -61,14 +65,58 @@ func initFederationKeyMaterial() error {
 // the fake upstream IdP to mint tokens whose protected header announces the
 // signing key the registry must look up.
 func jwsHeadersForKID(kid string) (jws.Headers, error) {
+	return jwsHeadersForKIDTyp(kid, "JWT")
+}
+
+// jwsHeadersForKIDTyp is jwsHeadersForKID with an explicit typ — used to mint
+// MCP ID-JAG assertions (typ: oauth-id-jag+jwt) whose protected header drives
+// the ZeroID jwt-bearer typ-branch (ADR 0010 D2).
+func jwsHeadersForKIDTyp(kid, typ string) (jws.Headers, error) {
 	hdr := jws.NewHeaders()
 	if err := hdr.Set(jws.KeyIDKey, kid); err != nil {
 		return nil, err
 	}
-	if err := hdr.Set(jws.TypeKey, "JWT"); err != nil {
+	if err := hdr.Set(jws.TypeKey, typ); err != nil {
 		return nil, err
 	}
 	return hdr, nil
+}
+
+// SignTokenWithTyp mints an ES256 JWT against the fake upstream IdP's published
+// key with an explicit JWS typ header. Used to forge ID-JAG-shaped assertions
+// (typ: oauth-id-jag+jwt) the federation server will validate against the IdP's
+// JWKS.
+func (i *fakeUpstreamIdP) SignTokenWithTyp(t *testing.T, typ string, claims map[string]any) string {
+	t.Helper()
+	tok := jwt.New()
+	for k, v := range claims {
+		require.NoError(t, tok.Set(k, v))
+	}
+	hdr, err := jwsHeadersForKIDTyp(i.keyID, typ)
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), i.priv, jws.WithProtectedHeaders(hdr)))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+// signForeignIDJAG mints an ID-JAG-shaped assertion signed by a fresh key that
+// no configured upstream JWKS publishes — used to prove a bad signature fails
+// closed at the MAS. It reuses the fake IdP's published kid in the header so
+// the verifier picks that key from the JWKS and the signature check (not a
+// missing-key error) is what rejects it.
+func signForeignIDJAG(t *testing.T, typ string, claims map[string]any) string {
+	t.Helper()
+	foreign, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tok := jwt.New()
+	for k, v := range claims {
+		require.NoError(t, tok.Set(k, v))
+	}
+	hdr, err := jwsHeadersForKIDTyp("upstream-key-1", typ)
+	require.NoError(t, err)
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), foreign, jws.WithProtectedHeaders(hdr)))
+	require.NoError(t, err)
+	return string(signed)
 }
 
 // jwtDecodeSegment base64url-decodes a JWT payload segment. Mirrors what

--- a/tests/integration/external_idp_test.go
+++ b/tests/integration/external_idp_test.go
@@ -273,7 +273,10 @@ func newFederationServer(t *testing.T, issuer domain.ExternalIssuerConfig) (*zer
 type tokenResponse struct {
 	StatusCode  int
 	AccessToken string
-	RawBody     string
+	// Error is the RFC 6749 §5.2 error code on a failed token response (e.g.
+	// invalid_grant). Empty on success.
+	Error   string
+	RawBody string
 }
 
 func postFederation(t *testing.T, baseURL string, body map[string]any) tokenResponse {
@@ -295,10 +298,12 @@ func postFederation(t *testing.T, baseURL string, body map[string]any) tokenResp
 		return tokenResponse{StatusCode: resp.StatusCode, RawBody: fmt.Sprintf("%v", err)}
 	}
 	at, _ := raw["access_token"].(string)
+	errCode, _ := raw["error"].(string)
 	rawBytes, _ := json.Marshal(raw)
 	return tokenResponse{
 		StatusCode:  resp.StatusCode,
 		AccessToken: at,
+		Error:       errCode,
 		RawBody:     string(rawBytes),
 	}
 }

--- a/tests/integration/id_jag_test.go
+++ b/tests/integration/id_jag_test.go
@@ -1,0 +1,226 @@
+package integration_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// idJAGTyp mirrors service.idJAGTyp — the JWS typ header that marks an
+// assertion as an MCP ID-JAG. Re-declared here (the const is unexported in the
+// service package) so the integration test pins the exact wire value.
+const idJAGTyp = "oauth-id-jag+jwt"
+
+// TestIDJAG_EndToEnd exercises the ADR 0010 MCP Authorization Server leg: an
+// MCP ID-JAG (typ oauth-id-jag+jwt) presented at POST /oauth2/token via
+// grant_type=jwt-bearer is validated against the corporate IdP's JWKS (the #88
+// substrate), mapped to a Highflame principal, and minted into a ZeroID access
+// token audience-restricted to the ID-JAG's `resource`.
+//
+// The IdP-facing setup (fake upstream IdP + federation-configured second
+// server) reuses the same harness the id_token-exchange federation test uses;
+// the only difference on the wire is grant_type=jwt-bearer + subject=<ID-JAG>
+// instead of token-exchange + subject_token=<id_token>.
+func TestIDJAG_EndToEnd(t *testing.T) {
+	upstreamIss := "https://corp-idp.idjag.test"
+	federationAud := "https://zeroid.idjag.test"
+	const mcpResource = "https://mcp-server.idjag.test"
+
+	upstream := newFakeUpstreamIdP(t)
+	defer upstream.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:   upstreamIss,
+		JWKSURI:  upstream.JWKSURL(),
+		Audience: federationAud,
+		ClaimMapping: map[string]string{
+			"user_id": "sub",
+			"email":   "email",
+			// Map an IdP group/role claim into a Highflame Cedar attribute (D3):
+			// the upstream emits `roles` → minted token carries a `role` claim.
+			"role": "idp_role",
+		},
+		AllowedAccounts: []string{"acct-fed-001"},
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	// signIDJAG mints a validly-signed ID-JAG against the fake upstream IdP.
+	signIDJAG := func(t *testing.T, claims map[string]any) string {
+		t.Helper()
+		// Force the ID-JAG typ header on the upstream-signed token.
+		return upstream.SignTokenWithTyp(t, idJAGTyp, claims)
+	}
+
+	t.Run("happy path: mapped claims and aud==resource", func(t *testing.T) {
+		now := time.Now()
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uMCPAGENT01",
+			"email":    "agent@corp.example.com",
+			"idp_role": "engineering",
+			"resource": mcpResource,
+			"scope":    "tools:read tools:exec",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":    idjag,
+			"account_id": fedCfg.AccountID,
+			"project_id": fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"ID-JAG jwt-bearer must return 200; body=%s", resp.RawBody)
+
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+
+		// D4 — audience restriction MUST: minted aud == ID-JAG resource.
+		require.Equal(t, []any{mcpResource}, claims["aud"],
+			"minted token aud must equal the ID-JAG resource claim")
+
+		// D3 — identity mapping: sub mapped from the ID-JAG sub; email mapped;
+		// IdP group/role mapped into the `role` Cedar attribute.
+		require.Equal(t, "00uMCPAGENT01", claims["sub"])
+		require.Equal(t, "agent@corp.example.com", claims["user_email"])
+		require.Equal(t, "engineering", claims["role"])
+
+		// IdP provenance + structural fingerprint distinguishing this path.
+		require.Equal(t, upstreamIss, claims["user_id_iss"])
+		require.Equal(t, "id_jag", claims["token_exchange"])
+
+		// Tenant binding stamped from the request (gated by AllowedAccounts).
+		require.Equal(t, fedCfg.AccountID, claims["account_id"])
+		require.Equal(t, fedCfg.ProjectID, claims["project_id"])
+
+		// Scopes flow from the ID-JAG `scope` claim (IdP already scoped it).
+		require.ElementsMatch(t, []any{"tools:read", "tools:exec"}, claims["scopes"])
+	})
+
+	t.Run("missing resource fails closed (invalid_grant)", func(t *testing.T) {
+		now := time.Now()
+		idjag := signIDJAG(t, map[string]any{
+			"iss":   upstreamIss,
+			"aud":   federationAud,
+			"sub":   "00uNORESOURCE",
+			"scope": "tools:read",
+			"iat":   now.Unix(),
+			"exp":   now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":    idjag,
+			"account_id": fedCfg.AccountID,
+			"project_id": fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken, "no token may be minted without an audience binding")
+	})
+
+	t.Run("tenant binding failure fails closed (invalid_grant)", func(t *testing.T) {
+		now := time.Now()
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uWRONGTENANT",
+			"resource": mcpResource,
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":    idjag,
+			"account_id": "acct-not-in-allowlist",
+			"project_id": fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken)
+	})
+
+	t.Run("bad signature fails closed (invalid_grant)", func(t *testing.T) {
+		now := time.Now()
+		// Sign with a foreign key the upstream JWKS does not publish.
+		forged := signForeignIDJAG(t, idJAGTyp, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uFORGED",
+			"resource": mcpResource,
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":    forged,
+			"account_id": fedCfg.AccountID,
+			"project_id": fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken)
+	})
+
+	t.Run("unknown issuer fails closed (invalid_grant)", func(t *testing.T) {
+		now := time.Now()
+		// Validly signed by the upstream key, but with an iss the federation
+		// server has not configured.
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      "https://stranger.idjag.test",
+			"aud":      federationAud,
+			"sub":      "00uSTRANGER",
+			"resource": mcpResource,
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":    idjag,
+			"account_id": fedCfg.AccountID,
+			"project_id": fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken)
+	})
+}
+
+// TestIDJAG_NHISelfSignedRegression is the load-bearing regression: a normal
+// NHI self-signed jwt-bearer assertion (typ JWT, signed by the identity's
+// registered key) MUST still succeed after the typ-branch was added. This runs
+// against the SHARED TestMain server — the same path every existing NHI test
+// uses — so it proves the ID-JAG branch did not perturb the registered-key path.
+func TestIDJAG_NHISelfSignedRegression(t *testing.T) {
+	agentKey := generateKey(t)
+	ext := uid("idjag-nhi-regress")
+	identity := registerIdentity(t, ext, []string{"data:read"}, ecPublicKeyPEM(t, agentKey))
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    buildAssertion(t, agentKey, identity.WIMSEURI),
+		"scope":      "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"a self-signed NHI jwt-bearer assertion must still mint a token after the ID-JAG typ-branch")
+
+	body := decode(t, resp)
+	accessTok, _ := body["access_token"].(string)
+	require.NotEmpty(t, accessTok, "NHI jwt-bearer must return an access token")
+
+	// Structural proof this went through the NHI path, not the ID-JAG path:
+	// sub is the agent's WIMSE URI (NHI), and there is NO id_jag fingerprint.
+	claims := decodeIssuedTokenClaims(t, accessTok)
+	require.Equal(t, identity.WIMSEURI, claims["sub"], "NHI token sub must be the agent WIMSE URI")
+	require.NotEqual(t, "id_jag", claims["token_exchange"], "NHI token must not carry the ID-JAG fingerprint")
+}

--- a/tests/integration/id_jag_test.go
+++ b/tests/integration/id_jag_test.go
@@ -26,6 +26,13 @@ const idJAGTyp = "oauth-id-jag+jwt"
 // server) reuses the same harness the id_token-exchange federation test uses;
 // the only difference on the wire is grant_type=jwt-bearer + subject=<ID-JAG>
 // instead of token-exchange + subject_token=<id_token>.
+//
+// Per ADR 0010 D2a/D2b, redemption now also REQUIRES an authenticated
+// confidential client whose client_id equals the ID-JAG's client_id claim, and
+// a single-use jti. The harness registers a confidential client (visible to the
+// federation server via the shared DB, since OAuth-client lookup is global) and
+// every signed ID-JAG carries that client_id + a UNIQUE jti so independent
+// subtests don't collide on the replay table.
 func TestIDJAG_EndToEnd(t *testing.T) {
 	upstreamIss := "https://corp-idp.idjag.test"
 	federationAud := "https://zeroid.idjag.test"
@@ -50,11 +57,37 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 	defer fedHTTPSrv.Close()
 	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
 
-	// signIDJAG mints a validly-signed ID-JAG against the fake upstream IdP.
+	// Confidential client the ID-JAG is bound to (ADR 0010 D2b). Registered on
+	// the shared testServer; OAuth-client lookup is global, so the federation
+	// server's VerifyClientSecret resolves it from the same DB.
+	client := registerOAuthClient(t, uid("idjag-client"), []string{"data:read"})
+
+	// signIDJAG mints a validly-signed ID-JAG against the fake upstream IdP. It
+	// auto-fills the bound client_id (D2b) and a UNIQUE jti (D2a) unless the
+	// caller already set them, so happy-path subtests don't collide on replay.
 	signIDJAG := func(t *testing.T, claims map[string]any) string {
 		t.Helper()
+		if _, ok := claims["client_id"]; !ok {
+			claims["client_id"] = client.ClientID
+		}
+		if _, ok := claims["jti"]; !ok {
+			claims["jti"] = uid("idjag-jti")
+		}
 		// Force the ID-JAG typ header on the upstream-signed token.
 		return upstream.SignTokenWithTyp(t, idJAGTyp, claims)
+	}
+
+	// idJAGBody builds the /oauth2/token form with the confidential client auth
+	// (D2b) every redemption now requires.
+	idJAGBody := func(idjag string) map[string]any {
+		return map[string]any{
+			"grant_type":    "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":       idjag,
+			"account_id":    fedCfg.AccountID,
+			"project_id":    fedCfg.ProjectID,
+			"client_id":     client.ClientID,
+			"client_secret": client.ClientSecret,
+		}
 	}
 
 	t.Run("happy path: mapped claims and aud==resource", func(t *testing.T) {
@@ -71,12 +104,7 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 			"exp":      now.Add(5 * time.Minute).Unix(),
 		})
 
-		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
-			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-			"subject":    idjag,
-			"account_id": fedCfg.AccountID,
-			"project_id": fedCfg.ProjectID,
-		})
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
 		require.Equal(t, http.StatusOK, resp.StatusCode,
 			"ID-JAG jwt-bearer must return 200; body=%s", resp.RawBody)
 
@@ -120,12 +148,7 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 			"exp":      now.Add(5 * time.Minute).Unix(),
 		})
 
-		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
-			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-			"subject":    idjag,
-			"account_id": fedCfg.AccountID,
-			"project_id": fedCfg.ProjectID,
-		})
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
 		require.Equal(t, http.StatusOK, resp.StatusCode,
 			"an array-valued resource is valid per RFC 8707; body=%s", resp.RawBody)
 
@@ -145,12 +168,7 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 			"exp":   now.Add(5 * time.Minute).Unix(),
 		})
 
-		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
-			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-			"subject":    idjag,
-			"account_id": fedCfg.AccountID,
-			"project_id": fedCfg.ProjectID,
-		})
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
 		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
 		require.Empty(t, resp.AccessToken, "no token may be minted without an audience binding")
@@ -168,10 +186,12 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 		})
 
 		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
-			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-			"subject":    idjag,
-			"account_id": "acct-not-in-allowlist",
-			"project_id": fedCfg.ProjectID,
+			"grant_type":    "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":       idjag,
+			"account_id":    "acct-not-in-allowlist",
+			"project_id":    fedCfg.ProjectID,
+			"client_id":     client.ClientID,
+			"client_secret": client.ClientSecret,
 		})
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
 		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
@@ -180,22 +200,20 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 
 	t.Run("bad signature fails closed (invalid_grant)", func(t *testing.T) {
 		now := time.Now()
-		// Sign with a foreign key the upstream JWKS does not publish.
+		// Sign with a foreign key the upstream JWKS does not publish. Inject the
+		// bound client_id + a jti so the only failing check is the signature.
 		forged := signForeignIDJAG(t, idJAGTyp, map[string]any{
-			"iss":      upstreamIss,
-			"aud":      federationAud,
-			"sub":      "00uFORGED",
-			"resource": mcpResource,
-			"iat":      now.Unix(),
-			"exp":      now.Add(5 * time.Minute).Unix(),
+			"iss":       upstreamIss,
+			"aud":       federationAud,
+			"sub":       "00uFORGED",
+			"resource":  mcpResource,
+			"client_id": client.ClientID,
+			"jti":       uid("idjag-jti"),
+			"iat":       now.Unix(),
+			"exp":       now.Add(5 * time.Minute).Unix(),
 		})
 
-		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
-			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-			"subject":    forged,
-			"account_id": fedCfg.AccountID,
-			"project_id": fedCfg.ProjectID,
-		})
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(forged))
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
 		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
 		require.Empty(t, resp.AccessToken)
@@ -214,14 +232,138 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 			"exp":      now.Add(5 * time.Minute).Unix(),
 		})
 
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken)
+	})
+
+	// ── ADR 0010 D2a — single-use jti replay rejection ───────────────────────
+
+	t.Run("replay: same jti redeemed twice → 2nd is invalid_grant", func(t *testing.T) {
+		now := time.Now()
+		// Pin the jti so both redemptions present the SAME single-use grant.
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uREPLAY01",
+			"resource": mcpResource,
+			"scope":    "tools:read",
+			"jti":      uid("idjag-jti-replay"),
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		// First redemption mints normally.
+		resp1 := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
+		require.Equal(t, http.StatusOK, resp1.StatusCode,
+			"first redemption of a fresh ID-JAG must succeed; body=%s", resp1.RawBody)
+		require.NotEmpty(t, resp1.AccessToken)
+
+		// Replaying the exact same ID-JAG (same jti) must be rejected.
+		resp2 := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
+		require.Equal(t, http.StatusBadRequest, resp2.StatusCode, "body=%s", resp2.RawBody)
+		require.Equal(t, "invalid_grant", resp2.Error,
+			"a replayed single-use ID-JAG must be invalid_grant; body=%s", resp2.RawBody)
+		require.Empty(t, resp2.AccessToken, "no token may be minted on replay")
+	})
+
+	t.Run("missing jti fails closed (invalid_grant)", func(t *testing.T) {
+		now := time.Now()
+		// Sign directly (bypassing signIDJAG's jti auto-fill) so the grant
+		// carries NO jti at all. client_id is still set so the only failing
+		// check is the missing single-use jti.
+		idjag := upstream.SignTokenWithTyp(t, idJAGTyp, map[string]any{
+			"iss":       upstreamIss,
+			"aud":       federationAud,
+			"sub":       "00uNOJTI01",
+			"resource":  mcpResource,
+			"scope":     "tools:read",
+			"client_id": client.ClientID,
+			"iat":       now.Unix(),
+			"exp":       now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_grant", resp.Error,
+			"a single-use grant with no jti must be invalid_grant; body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken)
+	})
+
+	// ── ADR 0010 D2b — confidential client auth + client_id binding ──────────
+
+	t.Run("no client auth → invalid_client", func(t *testing.T) {
+		now := time.Now()
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uNOCLIENT01",
+			"resource": mcpResource,
+			"scope":    "tools:read",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		// No client_id / client_secret presented.
 		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
 			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
 			"subject":    idjag,
 			"account_id": fedCfg.AccountID,
 			"project_id": fedCfg.ProjectID,
 		})
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_client", resp.Error,
+			"ID-JAG redemption without confidential client auth must be invalid_client; body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken)
+	})
+
+	t.Run("bad client secret → invalid_client", func(t *testing.T) {
+		now := time.Now()
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uBADSECRET01",
+			"resource": mcpResource,
+			"scope":    "tools:read",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type":    "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":       idjag,
+			"account_id":    fedCfg.AccountID,
+			"project_id":    fedCfg.ProjectID,
+			"client_id":     client.ClientID,
+			"client_secret": "wrong-secret",
+		})
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_client", resp.Error,
+			"a wrong client_secret must be invalid_client; body=%s", resp.RawBody)
+		require.Empty(t, resp.AccessToken)
+	})
+
+	t.Run("client_id mismatch (authed client != ID-JAG client_id) → invalid_grant", func(t *testing.T) {
+		now := time.Now()
+		// The ID-JAG is bound to a DIFFERENT client than the one redeeming it.
+		idjag := signIDJAG(t, map[string]any{
+			"iss":       upstreamIss,
+			"aud":       federationAud,
+			"sub":       "00uMISMATCH01",
+			"resource":  mcpResource,
+			"scope":     "tools:read",
+			"client_id": "some-other-client-id",
+			"iat":       now.Unix(),
+			"exp":       now.Add(5 * time.Minute).Unix(),
+		})
+
+		// Authenticate as our real client — which does NOT match the ID-JAG's
+		// client_id claim. The binding (not the signature) must reject this.
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
-		require.Equal(t, "invalid_grant", resp.Error, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_grant", resp.Error,
+			"an ID-JAG whose client_id does not match the authenticated client must be invalid_grant; body=%s", resp.RawBody)
 		require.Empty(t, resp.AccessToken)
 	})
 }
@@ -282,22 +424,29 @@ func TestIDJAG_ConfigurableScopeClaim(t *testing.T) {
 	defer fedHTTPSrv.Close()
 	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
 
+	// Confidential client the ID-JAG is bound to (D2b).
+	client := registerOAuthClient(t, uid("idjag-scp-client"), []string{"data:read"})
+
 	now := time.Now()
 	idjag := upstream.SignTokenWithTyp(t, idJAGTyp, map[string]any{
-		"iss":      upstreamIss,
-		"aud":      federationAud,
-		"sub":      "00uENTRASCP01",
-		"resource": mcpResource,
-		"scp":      "tools:read tools:exec", // non-standard scope claim name
-		"iat":      now.Unix(),
-		"exp":      now.Add(5 * time.Minute).Unix(),
+		"iss":       upstreamIss,
+		"aud":       federationAud,
+		"sub":       "00uENTRASCP01",
+		"resource":  mcpResource,
+		"scp":       "tools:read tools:exec", // non-standard scope claim name
+		"client_id": client.ClientID,
+		"jti":       uid("idjag-scp-jti"),
+		"iat":       now.Unix(),
+		"exp":       now.Add(5 * time.Minute).Unix(),
 	})
 
 	resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
-		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-		"subject":    idjag,
-		"account_id": fedCfg.AccountID,
-		"project_id": fedCfg.ProjectID,
+		"grant_type":    "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":       idjag,
+		"account_id":    fedCfg.AccountID,
+		"project_id":    fedCfg.ProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
 	})
 	require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
 

--- a/tests/integration/id_jag_test.go
+++ b/tests/integration/id_jag_test.go
@@ -104,6 +104,36 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 		require.ElementsMatch(t, []any{"tools:read", "tools:exec"}, claims["scopes"])
 	})
 
+	t.Run("resource as RFC 8707 array → aud is the full authorized set", func(t *testing.T) {
+		now := time.Now()
+		const mcpResource2 = "https://mcp-server-2.idjag.test"
+		// RFC 8707 permits `resource` as an array; some IdPs emit even a single
+		// resource as a one-element array. Accept it and audience-restrict to
+		// every resource the IdP authorized (D4).
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uMULTIRES01",
+			"resource": []any{mcpResource, mcpResource2},
+			"scope":    "tools:read",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+			"subject":    idjag,
+			"account_id": fedCfg.AccountID,
+			"project_id": fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"an array-valued resource is valid per RFC 8707; body=%s", resp.RawBody)
+
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		require.ElementsMatch(t, []any{mcpResource, mcpResource2}, claims["aud"],
+			"minted aud must contain every resource in the ID-JAG resource array")
+	})
+
 	t.Run("missing resource fails closed (invalid_grant)", func(t *testing.T) {
 		now := time.Now()
 		idjag := signIDJAG(t, map[string]any{
@@ -223,4 +253,55 @@ func TestIDJAG_NHISelfSignedRegression(t *testing.T) {
 	claims := decodeIssuedTokenClaims(t, accessTok)
 	require.Equal(t, identity.WIMSEURI, claims["sub"], "NHI token sub must be the agent WIMSE URI")
 	require.NotEqual(t, "id_jag", claims["token_exchange"], "NHI token must not carry the ID-JAG fingerprint")
+}
+
+// TestIDJAG_ConfigurableScopeClaim proves the ID-JAG path sources scopes from
+// the claim NAME configured in ClaimMapping["scope"] (defaulting to "scope"),
+// so IdPs that emit scopes under a non-standard name — e.g. Microsoft Entra's
+// `scp` — work without code changes (ADR 0010 D3).
+func TestIDJAG_ConfigurableScopeClaim(t *testing.T) {
+	upstreamIss := "https://corp-idp-scp.idjag.test"
+	federationAud := "https://zeroid.idjag.test"
+	const mcpResource = "https://mcp-server.idjag.test"
+
+	upstream := newFakeUpstreamIdP(t)
+	defer upstream.Close()
+
+	fedSrv, fedHTTPSrv, fedCfg := newFederationServer(t, domain.ExternalIssuerConfig{
+		Issuer:   upstreamIss,
+		JWKSURI:  upstream.JWKSURL(),
+		Audience: federationAud,
+		ClaimMapping: map[string]string{
+			"user_id": "sub",
+			// Entra emits scopes under `scp`, not the standard `scope`. The
+			// claim NAME is configurable; the ID-JAG path must read from it.
+			"scope": "scp",
+		},
+		AllowedAccounts: []string{"acct-fed-001"},
+	})
+	defer fedHTTPSrv.Close()
+	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
+
+	now := time.Now()
+	idjag := upstream.SignTokenWithTyp(t, idJAGTyp, map[string]any{
+		"iss":      upstreamIss,
+		"aud":      federationAud,
+		"sub":      "00uENTRASCP01",
+		"resource": mcpResource,
+		"scp":      "tools:read tools:exec", // non-standard scope claim name
+		"iat":      now.Unix(),
+		"exp":      now.Add(5 * time.Minute).Unix(),
+	})
+
+	resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    idjag,
+		"account_id": fedCfg.AccountID,
+		"project_id": fedCfg.ProjectID,
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+
+	claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+	require.ElementsMatch(t, []any{"tools:read", "tools:exec"}, claims["scopes"],
+		"scopes must be sourced from the ClaimMapping-configured scope claim (scp)")
 }


### PR DESCRIPTION
Implements the **MCP Authorization Server** leg of [highflame-architecture ADR 0010](https://github.com/highflame-ai/highflame-architecture/pull/174) for MCP [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) (ID-JAG / SEP-990).

ZeroID becomes the MCP Authorization Server: it accepts an **ID-JAG** (Identity Assertion JWT Authorization Grant, `typ: oauth-id-jag+jwt`) presented at `POST /oauth2/token` with `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`, validates it against the corporate IdP, maps the external identity to a Highflame principal, and mints an **audience-restricted** ZeroID access token. The ID-JAG terminates here — only the minted ZeroID token travels downstream to Firehog/Shield, so Cedar enforcement is unchanged.

### Changes
- **`internal/service/oauth.go`** — `jwtBearer` branches on the assertion's JWS `typ`: `oauth-id-jag+jwt` → `idJAGBearer`; **every other assertion keeps the exact NHI self-signed registered-key path** (branch placed before any NHI work).
- **`internal/service/oauth_id_jag.go`** (new) — the `idJAGBearer` handler (ADR D2–D4): issuer lookup, `AllowedAccounts` tenant binding, `resource`→`aud` restriction, claim mapping (`role`/`privilege_scope`/`trust_level` sourced only from the JWKS-verified ID-JAG), scope from the IdP-scoped `scope` claim gated through the identity-policy ceiling.
- **`internal/service/oauth_external_idp.go`** — extracted the #88 verification into a shared `validateExternalAssertion` helper (alg allow-list → JWKS load → sig/iss/aud/exp/nbf → kid-refresh retry → RFC 7523 sub/exp presence → `MaxTokenAge` cap), called by **both** the existing id_token-exchange path and the new ID-JAG path so they can't drift. The id_token path is **behavior-preserving** (the entry is registry-keyed by issuer, so `WithIssuer(cfg.Issuer) == WithIssuer(upstreamIss)`).
- **`internal/handler/wellknown.go`** — advertises `authorization_grant_profiles_supported: ["urn:ietf:params:oauth:grant-profile:id-jag"]` (ADR D6).

### Fail-closed (ADR D3/D4)
Returns OAuth `invalid_grant`, never mints, when: no external issuers configured, missing tenant, malformed assertion, missing/empty `iss`, unknown issuer, `AllowedAccounts` binding fails, signature/claim validation fails, identity unmappable, or `resource` claim absent.

### Tests
- Unit: `internal/service/oauth_id_jag_test.go`.
- Integration (real Postgres / testcontainers): `tests/integration/id_jag_test.go` — happy path (mapped claims + `aud==resource`), every fail-closed path → `invalid_grant`, the AS grant-profile advertisement, and an **NHI self-signed jwt-bearer regression**. `go test ./...` green; build/vet/gofmt clean (`GOEXPERIMENT=jsonv2`).

### Downstream validation
Validated against **highflame-authn** locally via a `go.mod replace` → `go build ./...` and `go vet ./...` both clean. The change is internal-only (no public-surface change), so no authn code change is required; an authn zeroid version bump will follow on release.

Pairs with the Firehog Resource-Server leg ([highflame-firehog#300](https://github.com/highflame-ai/highflame-firehog/pull/300)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)