### PR TITLE
fix: remove default-value production guard for token.issuer and wimse_domain

### DIFF
--- a/config.go
+++ b/config.go
@@ -396,7 +396,6 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-
 // isProductionEnv reports whether server.env names a production deployment.
 // Accepts the common spellings ("production", "prod") case-insensitively so a
 // deployer can't accidentally dodge the production gate with "Production".

--- a/config.go
+++ b/config.go
@@ -359,15 +359,10 @@ func (c *Config) Validate() error {
 		if c.Attestation.AllowUnsafeDevStub {
 			return fmt.Errorf("attestation.allow_unsafe_dev_stub must be false in production (server.env=%q): the stub accepts ANY submitted proof for image_hash/tpm — set ZEROID_ALLOW_UNSAFE_DEV_STUB=false", c.Server.Env)
 		}
-		// token.issuer and wimse_domain ship with Highflame's hosted defaults.
-		// A production deploy that forgets to override them silently runs on
-		// Highflame's identity — require an explicit value.
-		if c.Token.Issuer == defaultIssuer {
-			return fmt.Errorf("token.issuer must be set explicitly in production (server.env=%q): it still has the built-in default %q — set ZEROID_ISSUER to this deployment's public URL", c.Server.Env, defaultIssuer)
-		}
-		if c.WIMSEDomain == defaultWIMSEDomain {
-			return fmt.Errorf("wimse_domain must be set explicitly in production (server.env=%q): it still has the built-in default %q — set ZEROID_WIMSE_DOMAIN to this deployment's trust domain", c.Server.Env, defaultWIMSEDomain)
-		}
+		// token.issuer and wimse_domain are validated by validateIssuer()
+		// and validateWIMSEDomain() above (empty/malformed → reject).
+		// No default-value comparison here — the built-in default may
+		// legitimately be the deployer's intended production value.
 		// Introspection (RFC 7662 §2.1) and revocation (RFC 7009 §2.1) MUST
 		// require caller authorization. The default leaves them accept-and-
 		// verify (anonymous allowed) for the standalone/dev model; production
@@ -401,14 +396,6 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// defaultIssuer and defaultWIMSEDomain are the built-in dev defaults that the
-// production gate in Validate() rejects when left unchanged. They MUST match
-// the values set in loadDefaults() — kept as named constants so the gate and
-// the default can never drift.
-const (
-	defaultIssuer      = "https://auth.highflame.ai"
-	defaultWIMSEDomain = "highflame.ai"
-)
 
 // isProductionEnv reports whether server.env names a production deployment.
 // Accepts the common spellings ("production", "prod") case-insensitively so a
@@ -562,20 +549,15 @@ func loadDefaults(k *koanf.Koanf) error {
 		"keys.rsa_public_key_path":  "",
 		"keys.rsa_key_id":           "v1",
 
-		// Token
-		// Default points at Highflame's hosted ZeroID URL (the actual
-		// service, not the marketing site). Self-hosted deployments
-		// override via ZEROID_ISSUER or token.issuer in YAML. Local dev
-		// on localhost:8899 should set ZEROID_ISSUER=http://localhost:8899.
-		"token.issuer":      defaultIssuer,
+		// Token — no default for token.issuer or wimse_domain; every
+		// deployment must set them explicitly via ZEROID_ISSUER /
+		// ZEROID_WIMSE_DOMAIN or YAML. validateIssuer() and
+		// validateWIMSEDomain() reject empty values at startup.
 		"token.default_ttl": 3600,
 		"token.max_ttl":     7776000, // 90 days
 		// Accept-and-verify on introspect/revoke by default (dev/standalone).
 		// Validate() forces this false in production (RFC 7662/7009).
 		"token.allow_unauthenticated_token_inspection": true,
-
-		// WIMSE
-		"wimse_domain": defaultWIMSEDomain,
 
 		// Telemetry
 		"telemetry.enabled":       false,

--- a/config_test.go
+++ b/config_test.go
@@ -217,14 +217,12 @@ func TestRejectRemovedTelemetryKeys(t *testing.T) {
 // server.env rejects the unsafe dev stub and the unchanged default
 // issuer / wimse_domain, while dev leaves all three alone.
 func TestValidateProductionGate(t *testing.T) {
-	t.Run("dev_allows_stub_and_defaults", func(t *testing.T) {
+	t.Run("dev_allows_stub", func(t *testing.T) {
 		cfg := baseValidConfig(t)
 		cfg.Server.Env = "development"
 		cfg.Attestation.AllowUnsafeDevStub = true
-		cfg.Token.Issuer = defaultIssuer
-		cfg.WIMSEDomain = defaultWIMSEDomain
 		if err := cfg.Validate(); err != nil {
-			t.Fatalf("dev config must pass with stub on and default issuer/domain: %v", err)
+			t.Fatalf("dev config must pass with stub on: %v", err)
 		}
 	})
 
@@ -247,36 +245,12 @@ func TestValidateProductionGate(t *testing.T) {
 		}
 	})
 
-	t.Run("production_rejects_default_issuer", func(t *testing.T) {
+	t.Run("production_passes_with_valid_config", func(t *testing.T) {
 		cfg := baseValidConfig(t)
 		cfg.Server.Env = "production"
 		cfg.Attestation.AllowUnsafeDevStub = false
-		cfg.Token.Issuer = defaultIssuer
-		err := cfg.Validate()
-		if err == nil || !strings.Contains(err.Error(), "token.issuer must be set explicitly in production") {
-			t.Fatalf("production + default issuer must be rejected, got: %v", err)
-		}
-	})
-
-	t.Run("production_rejects_default_wimse_domain", func(t *testing.T) {
-		cfg := baseValidConfig(t)
-		cfg.Server.Env = "production"
-		cfg.Attestation.AllowUnsafeDevStub = false
-		cfg.WIMSEDomain = defaultWIMSEDomain
-		err := cfg.Validate()
-		if err == nil || !strings.Contains(err.Error(), "wimse_domain must be set explicitly in production") {
-			t.Fatalf("production + default wimse_domain must be rejected, got: %v", err)
-		}
-	})
-
-	t.Run("production_passes_with_explicit_values", func(t *testing.T) {
-		cfg := baseValidConfig(t)
-		cfg.Server.Env = "production"
-		cfg.Attestation.AllowUnsafeDevStub = false
-		cfg.Token.Issuer = "https://auth.acme.example"
-		cfg.WIMSEDomain = "acme.example"
 		if err := cfg.Validate(); err != nil {
-			t.Fatalf("production with explicit safe values must pass: %v", err)
+			t.Fatalf("production with valid config must pass: %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Removes the production gate that rejected `token.issuer` when it equaled the built-in default `"https://auth.highflame.ai"`
- Removes `defaultIssuer` and `defaultWIMSEDomain` constants and their `loadDefaults()` entries — every deployment must now set these explicitly
- `validateIssuer()` and `validateWIMSEDomain()` still reject empty/malformed values

## Root Cause

The production guard (`config.go:365`) compared `token.issuer` against `defaultIssuer = "https://auth.highflame.ai"`. Since that IS Highflame's actual production URL (set via `HIGHFLAME_ISSUER` in Helm secrets), the guard was un-passable — **authn crash-looped on every prod deploy** after the v1.7.2 bump (authn PR #121, merged 2026-06-21).

Dev worked because `HIGHFLAME_ISSUER=https://auth-dev.highflame.dev` ≠ the default.

Same issue existed for `wimse_domain` / `HIGHFLAME_WIMSE_DOMAIN: 'highflame.ai'`.

## Timeline

| When | What |
|------|------|
| June 9 | `649706d` added the production guard (PR #198) |
| June 18 | Merged to main, tagged v1.7.0 |
| June 21 | authn bumped to v1.7.2 (authn PR #121) |
| June 22 | Prod deploy → crash-loop |

## Test plan

- [x] Removed 3 tests that asserted the deleted guard behavior
- [x] Added test: production config passes with valid issuer/domain (no default-value rejection)
- [x] Existing `TestValidateIssuer` still covers empty/malformed rejection
- [x] Existing `TestValidateWIMSEDomain` still covers empty/malformed rejection
- [x] `zeroid.yaml` still has explicit values for `make run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)