### PR TITLE
fix: stop reflecting request body values in OAuth error responses

### DIFF
--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -491,6 +491,9 @@ type BcAuthorizeInput struct {
 		// to the BackchannelNotifier hook for typed approval-prompt
 		// rendering. Empty / omitted keeps the legacy CIBA flow unchanged.
 		AuthorizationDetails json.RawMessage `json:"authorization_details,omitempty" doc:"RFC 9396 Rich Authorization Requests payload (JSON array of typed objects)"`
+		// CIBA Core 1.0 §7.1 inherits RFC 6749 §3.1's ignore-unrecognized-params
+		// posture, same as TokenInput/IntrospectInput/OAuthRevokeInput.
+		_ struct{} `additionalProperties:"true"`
 	}
 }
 

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -65,6 +65,9 @@ type TokenInput struct {
 		RefreshToken string `json:"refresh_token,omitempty" doc:"Refresh token (zid_rt_*)"`
 		// CIBA (urn:openid:params:grant-type:ciba) grant fields:
 		AuthReqID string `json:"auth_req_id,omitempty" doc:"Backchannel auth_req_id returned from /oauth2/bc-authorize"`
+		// RFC 6749 §3.1: the server MUST ignore unrecognized request
+		// parameters rather than rejecting the request outright.
+		_ struct{} `additionalProperties:"true"`
 	}
 }
 
@@ -127,6 +130,8 @@ type IntrospectInput struct {
 		// the endpoint preserves the internal/network-isolated access path.
 		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth, client_secret_post)"`
 		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth, client_secret_post)"`
+		// RFC 7662 §2.1 inherits RFC 6749 §3.1's ignore-unrecognized-params posture.
+		_ struct{} `additionalProperties:"true"`
 	}
 }
 
@@ -148,6 +153,8 @@ type OAuthRevokeInput struct {
 		// authorization). Same accept-and-verify posture as introspection.
 		ClientID     string `json:"client_id,omitempty" doc:"OAuth client ID (optional client auth, client_secret_post)"`
 		ClientSecret string `json:"client_secret,omitempty" doc:"OAuth client secret (optional client auth, client_secret_post)"`
+		// RFC 7009 §2.1 inherits RFC 6749 §3.1's ignore-unrecognized-params posture.
+		_ struct{} `additionalProperties:"true"`
 	}
 }
 

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -177,7 +177,7 @@ func redactErrorValues(paths ...string) huma.Transformer {
 		}
 		if em, ok := v.(*huma.ErrorModel); ok {
 			for _, detail := range em.Errors {
-				if detail.Value != nil {
+				if detail != nil && detail.Value != nil {
 					detail.Value = "[redacted]"
 				}
 			}

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -144,7 +144,46 @@ func zeroidHumaConfig() huma.Config {
 		},
 	}
 
+	// Huma's schema validator echoes the offending request body back in
+	// ErrorDetail.Value on every failure path (unexpected property, missing
+	// required field, etc.) — see danielgtaylor/huma/v2 validate.go, the
+	// res.Add(path, m, ...) calls pass the whole parent object, not just the
+	// field in question. On the credential-bearing OAuth endpoints that
+	// reflects the caller's token/secret straight into the response (and
+	// anything downstream that logs it). Redact it there; leave it intact
+	// elsewhere, where echoing the bad value back is legitimate debugging aid.
+	config.Transformers = append(config.Transformers, redactErrorValues(
+		"/oauth2/token",
+		"/oauth2/token/introspect",
+		"/oauth2/token/revoke",
+		"/oauth2/bc-authorize",
+	))
+
 	return config
+}
+
+// redactErrorValues returns a huma.Transformer that blanks every
+// huma.ErrorDetail.Value on responses to the given paths, so validation
+// failures never echo submitted credential material back to the caller (or
+// into anything that logs the response body).
+func redactErrorValues(paths ...string) huma.Transformer {
+	redact := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		redact[p] = true
+	}
+	return func(ctx huma.Context, status string, v any) (any, error) {
+		if !redact[ctx.Operation().Path] {
+			return v, nil
+		}
+		if em, ok := v.(*huma.ErrorModel); ok {
+			for _, detail := range em.Errors {
+				if detail.Value != nil {
+					detail.Value = "[redacted]"
+				}
+			}
+		}
+		return v, nil
+	}
 }
 
 // prmURL returns the absolute URL of this server's RFC 9728 Protected

--- a/tests/integration/oauth_error_redaction_test.go
+++ b/tests/integration/oauth_error_redaction_test.go
@@ -1,0 +1,139 @@
+// Regression coverage for #191 / #202: the RFC OAuth endpoints must (1) ignore
+// unrecognized request parameters instead of 422ing on them (RFC 6749 §3.1),
+// and (2) never echo submitted request-body values — which can carry a
+// token/client_secret/notification token — back in a validation-error
+// response, regardless of which validation rule fired.
+package integration_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errorModelBody mirrors the subset of huma.ErrorModel this suite asserts on.
+type errorModelBody struct {
+	Errors []struct {
+		Location string `json:"location"`
+		Value    any    `json:"value"`
+	} `json:"errors"`
+}
+
+// assertNoSecretLeak reads resp's body, asserts the given secret substring
+// never appears anywhere in the raw response, and that every ErrorDetail.Value
+// present has been redacted rather than echoing the submitted value.
+func assertNoSecretLeak(t *testing.T, resp *http.Response, secret string) {
+	t.Helper()
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(raw), secret,
+		"validation-error response must never echo request body values on OAuth endpoints")
+
+	var body errorModelBody
+	require.NoError(t, json.Unmarshal(raw, &body))
+	require.NotEmpty(t, body.Errors, "expected at least one validation error detail")
+	for _, e := range body.Errors {
+		if e.Value != nil {
+			assert.Equal(t, "[redacted]", e.Value, "location %s: value must be redacted, not echoed", e.Location)
+		}
+	}
+}
+
+// ── RFC 6749 §3.1 — ignore unrecognized request parameters ─────────────────
+
+func TestOAuthTokenIgnoresUnknownParams(t *testing.T) {
+	agentID := uid("redaction-token-unknown-param")
+	scopes := []string{"data:read"}
+	registerIdentity(t, agentID, scopes)
+	client := registerOAuthClient(t, agentID, scopes)
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":             "client_credentials",
+		"client_id":              client.ClientID,
+		"client_secret":          client.ClientSecret,
+		"account_id":             testAccountID,
+		"project_id":             testProjectID,
+		"scope":                  "data:read",
+		"not_a_real_oauth_field": "123",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"unrecognized request parameters must be ignored, not rejected (RFC 6749 §3.1)")
+	body := decode(t, resp)
+	assert.NotEmpty(t, body["access_token"])
+}
+
+func TestOAuthIntrospectIgnoresUnknownParams(t *testing.T) {
+	// Exact repro from #191/#202: curl -d "token=12345&azz=123" .../introspect
+	// used to 422 with the unknown "azz" field, echoing the whole body
+	// (including the token) back in the error.
+	resp := post(t, "/oauth2/token/introspect", map[string]any{
+		"token": "12345",
+		"azz":   "123",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"unrecognized request parameters must be ignored, not rejected (RFC 6749 §3.1)")
+	body := decode(t, resp)
+	assert.False(t, body["active"].(bool), "not a real token, so introspection reports inactive")
+}
+
+func TestOAuthRevokeIgnoresUnknownParams(t *testing.T) {
+	resp := post(t, "/oauth2/token/revoke", map[string]any{
+		"token": "12345",
+		"azz":   "123",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"unrecognized request parameters must be ignored, not rejected (RFC 6749 §3.1); "+
+			"revoke also always returns 200 per RFC 7009 §2.2")
+	body := decode(t, resp)
+	assert.True(t, body["revoked"].(bool))
+}
+
+// ── Validation-error responses must never echo submitted values ────────────
+
+func TestOAuthTokenValidationErrorRedactsSecrets(t *testing.T) {
+	// grant_type is Huma-required and deliberately omitted here, so Huma's own
+	// schema validator rejects the request before tokenOp ever runs — the
+	// path that used to echo the entire parsed body (including client_secret)
+	// back in ErrorDetail.Value.
+	resp := post(t, "/oauth2/token", map[string]any{
+		"client_secret": "super-secret-should-never-leak",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+	}, nil)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"missing grant_type is a schema-level required-field failure")
+	assertNoSecretLeak(t, resp, "super-secret-should-never-leak")
+}
+
+func TestOAuthIntrospectValidationErrorRedactsSecrets(t *testing.T) {
+	// token is required and deliberately omitted; api_key stands in for a
+	// secret submitted under an unexpected key (e.g. a caller typo) — the
+	// exact shape that leaked in #191/#202 even after unknown params are
+	// otherwise ignored.
+	resp := post(t, "/oauth2/token/introspect", map[string]any{
+		"api_key": "zid_sk_should_never_leak",
+	}, nil)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"missing token is a schema-level required-field failure")
+	assertNoSecretLeak(t, resp, "zid_sk_should_never_leak")
+}
+
+func TestOAuthBcAuthorizeValidationErrorRedactsSecrets(t *testing.T) {
+	// client_id is required and deliberately omitted; client_notification_token
+	// is the CIBA ping-mode bearer the leak mechanism applies to equally.
+	resp := post(t, "/oauth2/bc-authorize", map[string]any{
+		"account_id":                testAccountID,
+		"project_id":                testProjectID,
+		"login_hint":                "user@example.com",
+		"client_notification_token": "should-never-leak-either",
+	}, nil)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"missing client_id is a schema-level required-field failure")
+	assertNoSecretLeak(t, resp, "should-never-leak-either")
+}

--- a/tests/integration/oauth_error_redaction_test.go
+++ b/tests/integration/oauth_error_redaction_test.go
@@ -82,6 +82,22 @@ func TestOAuthIntrospectIgnoresUnknownParams(t *testing.T) {
 	assert.False(t, body["active"].(bool), "not a real token, so introspection reports inactive")
 }
 
+func TestOAuthBcAuthorizeIgnoresUnknownParams(t *testing.T) {
+	clientID := setupCIBAClient(t)
+
+	resp := post(t, "/oauth2/bc-authorize", map[string]any{
+		"client_id":             clientID,
+		"account_id":            testAccountID,
+		"project_id":            testProjectID,
+		"group_hint":            "highflame:role:finance_lead",
+		"scope":                 "openid",
+		"not_a_real_ciba_field": "123",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"unrecognized request parameters must be ignored, not rejected (RFC 6749 §3.1, "+
+			"inherited by CIBA Core 1.0 §7.1)")
+}
+
 func TestOAuthRevokeIgnoresUnknownParams(t *testing.T) {
 	resp := post(t, "/oauth2/token/revoke", map[string]any{
 		"token": "12345",


### PR DESCRIPTION
## Problem
The token/introspect/revoke/bc-authorize endpoints rejected any unrecognized request parameter with a Huma 422, and the error response echoed the entire request body, including the submitted token or client_secret, back to the caller. A typo'd field name or an extra param was enough to leak a live credential into the HTTP response and anything downstream that logs it (proxies, access logs, error trackers).

## Root cause
`internal/handler/oauth.go`: the OAuth body structs (`TokenInput`, `IntrospectInput`, `OAuthRevokeInput`) had no `additionalProperties` override, so Huma's schema validator rejected unknown fields with a 422 (RFC 6749 §3.1 says the server MUST ignore unrecognized params instead).

`danielgtaylor/huma/v2` `validate.go`: on every schema validation failure (unexpected property, missing required field, etc.) it calls `res.Add(path, m, ...)`, passing the whole parsed request body as `ErrorDetail.Value`, not just the offending field. That's the actual leak mechanism, and it fires regardless of which validation rule trips.

## Fix
- Added `_ struct{} `additionalProperties:"true"`` sentinels to the three OAuth body structs so unrecognized params are ignored per RFC 6749 §3.1 instead of 422ing.
- Added a `huma.Transformer` in `zeroidHumaConfig()` (`internal/handler/routes.go`) scoped to `/oauth2/token`, `/oauth2/token/introspect`, `/oauth2/token/revoke`, and `/oauth2/bc-authorize` that redacts every `ErrorDetail.Value` to `"[redacted]"` on error responses from those paths. This closes the leak regardless of which validation rule fires, not just the unknown-param case.

Closes #191, closes #202.

## Verification
- `go build ./...` and `go vet ./...` clean.
- New integration tests (`tests/integration/oauth_error_redaction_test.go`): unknown params are now ignored on token/introspect/revoke; forcing a genuine schema validation error with a secret-shaped sibling field on token/introspect/bc-authorize never leaks it in the response body.
- Full existing suite (`go test ./tests/... ./internal/...`) passes, no regressions, including the OAuth compliance and form-compat suites.
- Independent codex review: no findings, "did not find a discrete regression introduced by the patch."