### PR TITLE
fix: surface owner_user_id in AgentResponse

### DIFF
--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -97,6 +97,7 @@ type AgentResponse struct {
 	TrustLevel         domain.TrustLevel     `json:"trust_level"`
 	Status             domain.IdentityStatus `json:"status"`
 	Origin             domain.Origin         `json:"origin"`
+	OwnerUserID        string                `json:"owner_user_id,omitempty"`
 	CredentialPolicyID string                `json:"credential_policy_id,omitempty"`
 	Framework          string                `json:"framework"`
 	Version            string                `json:"version"`
@@ -569,6 +570,7 @@ func identityToAgentResponse(identity *domain.Identity, keyPrefix string) AgentR
 		TrustLevel:         identity.TrustLevel,
 		Status:             identity.Status,
 		Origin:             identity.Origin,
+		OwnerUserID:        identity.OwnerUserID,
 		CredentialPolicyID: identity.CredentialPolicyID,
 		Framework:          identity.Framework,
 		Version:            identity.Version,

--- a/internal/service/agent_response_test.go
+++ b/internal/service/agent_response_test.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// TestIdentityToAgentResponse_SurfacesOwner is a regression guard: the agent DTO
+// must surface the identity's owner_user_id. It was previously omitted, so an
+// adopted agent (which has an owner but no creator) rendered as "ownerless" in
+// downstream UIs even though an accountable owner was assigned.
+func TestIdentityToAgentResponse_SurfacesOwner(t *testing.T) {
+	resp := identityToAgentResponse(&domain.Identity{
+		ID:          "id-1",
+		OwnerUserID: "user_123",
+		CreatedBy:   "user_creator",
+	}, "hf_sk_prefix")
+
+	if resp.OwnerUserID != "user_123" {
+		t.Errorf("AgentResponse.OwnerUserID = %q, want %q", resp.OwnerUserID, "user_123")
+	}
+	// created_by stays populated too — the two are distinct (creator vs owner).
+	if resp.CreatedBy != "user_creator" {
+		t.Errorf("AgentResponse.CreatedBy = %q, want %q", resp.CreatedBy, "user_creator")
+	}
+}


### PR DESCRIPTION
## Why
`AgentResponse` returned `created_by` but **never `owner_user_id`**. So every consumer of the agent registry (list + detail) could only ever display the *creator* as a stand-in for the owner:
- **Native agents** have a creator, so it looked correct.
- An **adopted identity** has a real `owner_user_id` but no creator (discovery ingested it) — so it rendered as **ownerless** in Studio even though an accountable owner had been assigned via adoption.

This surfaced when testing the new discovery→governance adoption flow: adopt an agent (owner assigned, `discovered → pending`) → open it → Owners tab says *"No owner assigned."*

## What
Add `owner_user_id` to `AgentResponse` and populate it in `identityToAgentResponse` — the **single** mapping used by `GetAgent`, `ListAgents`, adopt/activate/deactivate, etc. — so list **and** detail, native **and** adopted, all show the true owner. `created_by` is unchanged (creator and owner are distinct). Additive + `omitempty`.

Studio's Owners tab already prefers `owner_user_id || created_by`, so no downstream code change is needed — it just starts rendering the real owner once this ships.

## Verify
- `go build`, `go vet`, `gofmt` clean; new regression test `TestIdentityToAgentResponse_SurfacesOwner`.
- Validated **highflame-authn builds** against this change via a local `replace` (additive, no consumer break).

## Next
Tag a release after merge; bump highflame-authn's `zeroid` require to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)