### PR TITLE
fix: B1 — retain issued_credentials past expiry so the delegation graph survives

### DIFF
--- a/config.go
+++ b/config.go
@@ -236,6 +236,15 @@ type TokenConfig struct {
 	DefaultTTL int    `koanf:"default_ttl"`
 	MaxTTL     int    `koanf:"max_ttl"`
 
+	// AuditRetentionDays is how long an issued_credentials row remains
+	// queryable AFTER the token expires. The two clocks are deliberately
+	// decoupled (same model as signing_credentials): expires_at bounds how
+	// long the token authenticates; expires_at + AuditRetentionDays bounds
+	// how long the delegation graph can still answer historical questions
+	// about it. The cleanup worker prunes on the audit clock, never on
+	// expiry alone. See domain.IssuedCredential.AuditRetentionUntil.
+	AuditRetentionDays int `koanf:"audit_retention_days"`
+
 	// authorization_code grant configuration.
 	// HMACSecret is the shared secret used to sign and verify auth code JWTs (HS256).
 	HMACSecret string `koanf:"hmac_secret"`
@@ -554,6 +563,10 @@ func loadDefaults(k *koanf.Koanf) error {
 		// validateWIMSEDomain() reject empty values at startup.
 		"token.default_ttl": 3600,
 		"token.max_ttl":     7776000, // 90 days
+		// Delegation-graph evidence clock: issued_credentials rows stay
+		// queryable this long past token expiry (mirrors
+		// signing_credentials.audit_retention_days).
+		"token.audit_retention_days": 400,
 		// Accept-and-verify on introspect/revoke by default (dev/standalone).
 		// Validate() forces this false in production (RFC 7662/7009).
 		"token.allow_unauthenticated_token_inspection": true,
@@ -634,6 +647,8 @@ func loadEnvVars(k *koanf.Koanf) error {
 		"ZEROID_ISSUER":                "token.issuer",
 		"ZEROID_TOKEN_TTL_SECONDS":     "token.default_ttl",
 		"ZEROID_MAX_TOKEN_TTL_SECONDS": "token.max_ttl",
+		// Evidence clock for issued_credentials (delegation-graph retention).
+		"ZEROID_TOKEN_AUDIT_RETENTION_DAYS": "token.audit_retention_days",
 		// HMAC secret signs/verifies stateless authorization_code JWTs (HS256).
 		// A leak forges auth codes; Validate() enforces >= 32 bytes when set.
 		"ZEROID_HMAC_SECRET": "token.hmac_secret",

--- a/config.go
+++ b/config.go
@@ -390,6 +390,16 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("token.hmac_secret must be at least 32 bytes when set, got %d: it signs stateless auth-code JWTs (HS256) and a short secret is forgeable", len(c.Token.HMACSecret))
 	}
 
+	// token.audit_retention_days is a day count converted to time.Duration
+	// (days × 24h in nanoseconds); past ~106751 days the multiplication
+	// overflows int64 into a NEGATIVE duration, which would stamp
+	// AuditRetentionUntil before expiry and silently erase the evidence
+	// window the knob exists to guarantee. 36500 (~100y) is a generous
+	// practical ceiling. 0 means "use the shipped default (400)".
+	if c.Token.AuditRetentionDays < 0 || c.Token.AuditRetentionDays > 36500 {
+		return fmt.Errorf("token.audit_retention_days must be between 0 and 36500, got %d: it is the delegation-graph evidence-retention window in days (0 = default 400)", c.Token.AuditRetentionDays)
+	}
+
 	seen := make(map[string]struct{}, len(c.ExternalIssuers))
 	for i := range c.ExternalIssuers {
 		c.ExternalIssuers[i].Defaults()

--- a/config.go
+++ b/config.go
@@ -243,6 +243,11 @@ type TokenConfig struct {
 	// how long the delegation graph can still answer historical questions
 	// about it. The cleanup worker prunes on the audit clock, never on
 	// expiry alone. See domain.IssuedCredential.AuditRetentionUntil.
+	//
+	// Floor: the cleanup worker ANDs this evidence clock with the
+	// cascade-walk clock (Token.MaxTTL). A value below MaxTTL (~90d) has no
+	// effect on deletion timing — MaxTTL is the effective floor. 0 selects
+	// domain.DefaultAuditRetentionDays; see Validate for the accepted range.
 	AuditRetentionDays int `koanf:"audit_retention_days"`
 
 	// authorization_code grant configuration.
@@ -394,10 +399,10 @@ func (c *Config) Validate() error {
 	// (days × 24h in nanoseconds); past ~106751 days the multiplication
 	// overflows int64 into a NEGATIVE duration, which would stamp
 	// AuditRetentionUntil before expiry and silently erase the evidence
-	// window the knob exists to guarantee. 36500 (~100y) is a generous
-	// practical ceiling. 0 means "use the shipped default (400)".
-	if c.Token.AuditRetentionDays < 0 || c.Token.AuditRetentionDays > 36500 {
-		return fmt.Errorf("token.audit_retention_days must be between 0 and 36500, got %d: it is the delegation-graph evidence-retention window in days (0 = default 400)", c.Token.AuditRetentionDays)
+	// window the knob exists to guarantee. Bounds shared with the service
+	// clamp via domain. 0 means "use domain.DefaultAuditRetentionDays".
+	if c.Token.AuditRetentionDays < 0 || c.Token.AuditRetentionDays > domain.MaxAuditRetentionDays {
+		return fmt.Errorf("token.audit_retention_days must be between 0 and %d, got %d: it is the delegation-graph evidence-retention window in days (0 = default %d)", domain.MaxAuditRetentionDays, c.Token.AuditRetentionDays, domain.DefaultAuditRetentionDays)
 	}
 
 	seen := make(map[string]struct{}, len(c.ExternalIssuers))
@@ -574,9 +579,9 @@ func loadDefaults(k *koanf.Koanf) error {
 		"token.default_ttl": 3600,
 		"token.max_ttl":     7776000, // 90 days
 		// Delegation-graph evidence clock: issued_credentials rows stay
-		// queryable this long past token expiry (mirrors
-		// signing_credentials.audit_retention_days).
-		"token.audit_retention_days": 400,
+		// queryable this long past token expiry. Single source of truth in
+		// domain so the default can't drift from the service clamp / Validate.
+		"token.audit_retention_days": domain.DefaultAuditRetentionDays,
 		// Accept-and-verify on introspect/revoke by default (dev/standalone).
 		// Validate() forces this false in production (RFC 7662/7009).
 		"token.allow_unauthenticated_token_inspection": true,
@@ -714,6 +719,7 @@ func loadEnvVars(k *koanf.Koanf) error {
 			strings.HasSuffix(configPath, ".max_idle_conns") ||
 			strings.HasSuffix(configPath, ".default_ttl") ||
 			strings.HasSuffix(configPath, ".max_ttl") ||
+			strings.HasSuffix(configPath, ".audit_retention_days") ||
 			strings.HasSuffix(configPath, ".shutdown_timeout_seconds"):
 			intVal, err := strconv.Atoi(value)
 			if err != nil {

--- a/domain/credential.go
+++ b/domain/credential.go
@@ -6,6 +6,25 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// Audit-retention window bounds for issued_credentials. One source of truth
+// for the "evidence clock" default and ceiling, referenced by the koanf
+// default, Config.Validate, and CredentialService's clamp so the three can't
+// silently diverge.
+const (
+	// DefaultAuditRetentionDays is the retention applied when
+	// token.audit_retention_days is absent or 0. ~400 days mirrors the
+	// signing-credentials retention default. NOTE: migration 037's backfill
+	// hardcodes 400 (a migration can't read config); a deployment running a
+	// non-default window must re-stamp historical rows out-of-band.
+	DefaultAuditRetentionDays = 400
+	// MaxAuditRetentionDays caps the window. Past ~106751 days the
+	// days→time.Duration conversion overflows int64 into a negative
+	// duration, which would stamp retention BEFORE expiry and erase the
+	// evidence window the knob exists to protect. 36500 (~100y) is a
+	// generous practical ceiling well below the overflow point.
+	MaxAuditRetentionDays = 36500
+)
+
 // GrantType represents the OAuth2 grant type used to issue a credential.
 type GrantType string
 

--- a/domain/credential.go
+++ b/domain/credential.go
@@ -94,4 +94,11 @@ type IssuedCredential struct {
 	// Bearer tokens. When non-empty, the access token carries a cnf.jkt claim
 	// and must be presented with a valid DPoP proof at the protected resource.
 	DPoPKeyThumbprint string `bun:"dpop_key_thumbprint,type:text" json:"dpop_key_thumbprint,omitempty"`
+	// AuditRetentionUntil is the evidence clock, decoupled from ExpiresAt
+	// (the operational clock): how long the row remains queryable so the
+	// delegation graph (parent_jti walks, mission_id aggregates) survives
+	// token expiry. The cleanup worker prunes on this, not ExpiresAt. Nil on
+	// rows written before migration 037; those fall back to the legacy
+	// expires_at prune rule.
+	AuditRetentionUntil *time.Time `bun:"audit_retention_until" json:"audit_retention_until,omitempty"`
 }

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -30,6 +30,12 @@ var ErrIdentityNotUsable = errors.New("identity is not usable")
 // at the service layer so handlers can errors.Is and map to 4xx.
 var ErrCredentialExpired = errors.New("credential_expired")
 
+// ErrCredentialAlreadyRevoked is returned when an operation (e.g. rotation)
+// is attempted on a credential that is already revoked. Terminal state, not
+// a server fault — handlers map it to 409, same pattern as the sentinels
+// above.
+var ErrCredentialAlreadyRevoked = errors.New("credential_already_revoked")
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Trust Level
 // ──────────────────────────────────────────────────────────────────────────────

--- a/internal/handler/credential.go
+++ b/internal/handler/credential.go
@@ -248,6 +248,13 @@ func (a *API) rotateCredentialOp(ctx context.Context, input *CredentialIDInput) 
 
 	accessToken, newCred, err := a.credSvc.RotateCredential(ctx, input.ID, tenant.AccountID, tenant.ProjectID, identity)
 	if err != nil {
+		// Terminal-state rejections are client mistakes, not server faults:
+		// map them to 409 so they neither fire 5xx alerting nor tell the
+		// caller to retry something that can never succeed. A dead
+		// credential can't be rotated — the caller must issue a new one.
+		if errors.Is(err, domain.ErrCredentialExpired) || errors.Is(err, domain.ErrCredentialAlreadyRevoked) {
+			return nil, huma.Error409Conflict(err.Error())
+		}
 		log.Error().Err(err).Str("credential_id", input.ID).Msg("failed to rotate credential")
 		return nil, huma.Error500InternalServerError("failed to rotate credential")
 	}

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -686,6 +686,14 @@ func (s *CredentialService) RotateCredential(ctx context.Context, credID, accoun
 	if old.IsRevoked {
 		return nil, nil, fmt.Errorf("credential is already revoked")
 	}
+	// An expired credential cannot be rotated: the revoke half would be a
+	// silent no-op (the cascade anchor requires expires_at > revoked_at) and
+	// "rotate" would degrade to minting a fresh token off a dead row. Rows
+	// now outlive expiry by the audit-retention window, so without this
+	// guard a long-dead credential would stay rotatable for ~400 days.
+	if time.Now().After(old.ExpiresAt) {
+		return nil, nil, fmt.Errorf("credential is expired; issue a new credential instead of rotating")
+	}
 
 	// Revoke the old credential (cascades to descendants and fires the
 	// RevocationNotifier per affected JTI, same as any other revoke path).

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -26,6 +26,11 @@ type CredentialService struct {
 	issuer          string
 	defaultTTL      int
 	maxTTL          int
+	// auditRetention is how long past expiry an issued_credentials row
+	// stays queryable (the evidence clock the cleanup worker prunes on),
+	// so the delegation graph survives token expiry. From
+	// token.audit_retention_days.
+	auditRetention time.Duration
 	// revocationDispatcher fans out a RevocationEvent per revoked JTI to the
 	// deployer-supplied RevocationNotifier after each revocation commits.
 	// Shared with RefreshTokenService so one Server.SetRevocationNotifier call
@@ -41,8 +46,15 @@ func NewCredentialService(
 	policySvc *CredentialPolicyService,
 	attestationRepo *postgres.AttestationRepository,
 	issuer string,
-	defaultTTL, maxTTL int,
+	defaultTTL, maxTTL, auditRetentionDays int,
 ) *CredentialService {
+	// A non-positive retention would stamp AuditRetentionUntil at or before
+	// expiry, silently degrading the graph back to delete-at-expiry. Clamp
+	// to the shipped default instead — misconfiguration must not erase
+	// evidence.
+	if auditRetentionDays <= 0 {
+		auditRetentionDays = 400
+	}
 	return &CredentialService{
 		repo:            repo,
 		jwksSvc:         jwksSvc,
@@ -51,6 +63,7 @@ func NewCredentialService(
 		issuer:          issuer,
 		defaultTTL:      defaultTTL,
 		maxTTL:          maxTTL,
+		auditRetention:  time.Duration(auditRetentionDays) * 24 * time.Hour,
 	}
 }
 
@@ -474,7 +487,11 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 		return nil, nil, fmt.Errorf("failed to sign JWT: %w", signErr)
 	}
 
-	// Persist credential record
+	// Persist credential record. AuditRetentionUntil (evidence clock) is
+	// stamped at issuance so the row outlives the token: the delegation
+	// graph reads expired rows within the retention window (see the
+	// cleanup worker's two-clock prune).
+	auditRetentionUntil := expiresAt.Add(s.auditRetention)
 	cred := &domain.IssuedCredential{
 		ID:                  uuid.New().String(),
 		IdentityID:          stringPtrOrNil(req.Identity.ID),
@@ -492,6 +509,7 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 		DelegatedByWIMSEURI: req.DelegatedBy,
 		MissionID:           missionID,
 		DPoPKeyThumbprint:   req.DPoPKeyThumbprint,
+		AuditRetentionUntil: &auditRetentionUntil,
 	}
 
 	if err := s.repo.Create(ctx, cred); err != nil {

--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -48,12 +48,17 @@ func NewCredentialService(
 	issuer string,
 	defaultTTL, maxTTL, auditRetentionDays int,
 ) *CredentialService {
-	// A non-positive retention would stamp AuditRetentionUntil at or before
-	// expiry, silently degrading the graph back to delete-at-expiry. Clamp
-	// to the shipped default instead — misconfiguration must not erase
-	// evidence.
+	// Clamp defensively: this constructor is also reached from tests and
+	// external tools that bypass Config.Validate. A non-positive value would
+	// stamp AuditRetentionUntil at or before expiry (degrading the graph back
+	// to delete-at-expiry); an enormous value would overflow the
+	// days→Duration multiplication into a negative duration (same effect,
+	// worse). Both collapse to safe bounds — misconfiguration must never
+	// erase evidence. Bounds shared with Config.Validate via domain.
 	if auditRetentionDays <= 0 {
-		auditRetentionDays = 400
+		auditRetentionDays = domain.DefaultAuditRetentionDays
+	} else if auditRetentionDays > domain.MaxAuditRetentionDays {
+		auditRetentionDays = domain.MaxAuditRetentionDays
 	}
 	return &CredentialService{
 		repo:            repo,
@@ -683,16 +688,18 @@ func (s *CredentialService) RotateCredential(ctx context.Context, credID, accoun
 	if err != nil {
 		return nil, nil, fmt.Errorf("credential not found: %w", err)
 	}
+	// Both terminal-state rejections wrap a sentinel so the handler maps
+	// them to 409, not 500: with rows now outliving their tokens by the
+	// audit-retention window, rotating a long-dead credential is a routine
+	// client mistake, not a server fault, and must not fire 5xx alerting.
 	if old.IsRevoked {
-		return nil, nil, fmt.Errorf("credential is already revoked")
+		return nil, nil, fmt.Errorf("%w: issue a new credential instead of rotating", domain.ErrCredentialAlreadyRevoked)
 	}
 	// An expired credential cannot be rotated: the revoke half would be a
 	// silent no-op (the cascade anchor requires expires_at > revoked_at) and
-	// "rotate" would degrade to minting a fresh token off a dead row. Rows
-	// now outlive expiry by the audit-retention window, so without this
-	// guard a long-dead credential would stay rotatable for ~400 days.
+	// "rotate" would degrade to minting a fresh token off a dead row.
 	if time.Now().After(old.ExpiresAt) {
-		return nil, nil, fmt.Errorf("credential is expired; issue a new credential instead of rotating")
+		return nil, nil, fmt.Errorf("%w: issue a new credential instead of rotating", domain.ErrCredentialExpired)
 	}
 
 	// Revoke the old credential (cascades to descendants and fires the

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -23,9 +23,12 @@ type IdentityExpirer interface {
 // via IdentityService.SweepExpiredIdentities (an atomic conditional UPDATE
 // claim followed by the existing runDeactivationCleanup cascade).
 // Running the cleanup prevents unbounded table growth since credentials have
-// a finite TTL. Safe to run multiple instances concurrently — DELETE WHERE
-// is idempotent and the DeactivateIfActive claim guarantees only one worker
-// fires the cascade per expired identity.
+// a finite TTL. issued_credentials rows are additionally retained until
+// their audit_retention_until evidence clock elapses, so the delegation
+// graph survives token expiry (two-clock model, mirroring
+// signing_credentials). Safe to run multiple instances concurrently —
+// DELETE WHERE is idempotent and the DeactivateIfActive claim guarantees
+// only one worker fires the cascade per expired identity.
 type CleanupWorker struct {
 	db              *bun.DB
 	backchannelRepo *postgres.BackchannelRequestRepository
@@ -95,12 +98,20 @@ func (w *CleanupWorker) RunOnce(ctx context.Context) {
 	now := time.Now()
 
 	// Delete expired credentials regardless of revocation status, but only
-	// after the retention window: parent_jti edges on expired rows are still
-	// needed by the cascade-revocation walk to reach live descendants (see
-	// NewCleanupWorker).
+	// once BOTH clocks have elapsed:
+	//   - expires_at + credRetention — the cascade-walk clock: parent_jti
+	//     edges on expired rows are still needed by the cascade-revocation
+	//     walk to reach live descendants (see NewCleanupWorker);
+	//   - audit_retention_until — the evidence clock: the delegation graph
+	//     (WalkUp/WalkDown/ListChains) reads expired rows within the audit
+	//     window, so historical chains stay answerable long after expiry.
+	// Rows written before migration 037 carry NULL audit_retention_until and
+	// fall back to the legacy expires_at-only rule. Backed by
+	// idx_issued_credentials_expires_at + idx_issued_credentials_retention.
 	credRes, err := w.db.NewDelete().
 		TableExpr("issued_credentials").
 		Where("expires_at < ?", now.Add(-w.credRetention)).
+		Where("(audit_retention_until IS NULL OR audit_retention_until < ?)", now).
 		Exec(ctx)
 	if err != nil {
 		log.Error().Err(err).Msg("Cleanup: failed to delete expired credentials")

--- a/migrations/037_issued_credentials_audit_retention.down.sql
+++ b/migrations/037_issued_credentials_audit_retention.down.sql
@@ -1,0 +1,13 @@
+-- Ordering: roll BACK the code before running this down migration — post-037
+-- code stamps AuditRetentionUntil on every issuance, selects it via the bun
+-- model, and names it in the cleanup DELETE; dropping the column under new
+-- code breaks issuance, graph reads, and cleanup.
+--
+-- Data note: per-row retention stamps are lost on down. A later down→up
+-- cycle re-derives them as expires_at + 400 days, which may differ from
+-- stamps written under a non-default token.audit_retention_days.
+
+DROP INDEX IF EXISTS idx_issued_credentials_retention;
+
+ALTER TABLE issued_credentials
+    DROP COLUMN IF EXISTS audit_retention_until;

--- a/migrations/037_issued_credentials_audit_retention.up.sql
+++ b/migrations/037_issued_credentials_audit_retention.up.sql
@@ -1,0 +1,29 @@
+-- Two-clock retention for issued_credentials (issue: delegation graph
+-- blanks after token expiry).
+--
+-- expires_at is the OPERATIONAL clock: how long the token authenticates.
+-- audit_retention_until is the EVIDENCE clock: how long the credential row
+-- remains queryable so the delegation graph (parent_jti walks, mission_id
+-- aggregates) can answer historical questions — "every write by this agent
+-- in Q3, with the human approver" — long after the token itself is dead.
+--
+-- Same model as signing_credentials (023): a merely-expired credential
+-- still appears in the graph within the retention window; the cleanup
+-- worker prunes on audit_retention_until, not expires_at.
+--
+-- Nullable by design: rows written by pre-037 code carry NULL and are
+-- pruned under the legacy expires_at rule until they age out. The backfill
+-- below stamps existing rows so history written before this migration
+-- survives too. 400 days mirrors the signing_credentials default
+-- (signing_credentials.audit_retention_days).
+
+ALTER TABLE issued_credentials
+    ADD COLUMN IF NOT EXISTS audit_retention_until TIMESTAMPTZ;
+
+UPDATE issued_credentials
+SET audit_retention_until = expires_at + INTERVAL '400 days'
+WHERE audit_retention_until IS NULL;
+
+-- Retention pruning (delete only past the retention window).
+CREATE INDEX IF NOT EXISTS idx_issued_credentials_retention
+    ON issued_credentials (audit_retention_until);

--- a/migrations/037_issued_credentials_audit_retention.up.sql
+++ b/migrations/037_issued_credentials_audit_retention.up.sql
@@ -14,8 +14,30 @@
 -- Nullable by design: rows written by pre-037 code carry NULL and are
 -- pruned under the legacy expires_at rule until they age out. The backfill
 -- below stamps existing rows so history written before this migration
--- survives too. 400 days mirrors the signing_credentials default
--- (signing_credentials.audit_retention_days).
+-- survives too.
+--
+-- FIXED 400-DAY BACKFILL vs configured window: a migration can't read config,
+-- so this hardcodes 400 days (= domain.DefaultAuditRetentionDays). The RUNTIME
+-- stamp uses token.audit_retention_days. A deployment running a non-default
+-- window (e.g. 30d for data-minimization, or 800d) gets a split: historical
+-- rows carry 400d regardless. If that matters, operators must re-stamp
+-- out-of-band, e.g.:
+--   UPDATE issued_credentials
+--   SET audit_retention_until = expires_at + (<days> * INTERVAL '1 day')
+--   WHERE issued_at < '<migration-deploy-time>';
+-- (Tracked in the release note for this change.)
+--
+-- LOCK POSTURE (cf. migrations 017/033): golang-migrate runs this whole file
+-- in one transaction, so the full-table backfill UPDATE and the
+-- non-CONCURRENT CREATE INDEX both hold write-blocking locks on
+-- issued_credentials — the per-token high-churn table — for their combined
+-- duration, blocking token issuance. This is acceptable at the current fleet
+-- size (the pre-037 cleanup bounds the table to ~MaxTTL of rows) but if this
+-- ever runs against a large installation, split the backfill into batches and
+-- move the index to CREATE INDEX CONCURRENTLY in its own out-of-transaction
+-- migration (033's pattern). lock_timeout below fails fast rather than
+-- queueing the auth plane behind a long-running query.
+SET LOCAL lock_timeout = '5s';
 
 ALTER TABLE issued_credentials
     ADD COLUMN IF NOT EXISTS audit_retention_until TIMESTAMPTZ;

--- a/server.go
+++ b/server.go
@@ -230,7 +230,7 @@ func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
 	// dependency-free and sits alongside credentialPolicySvc at the top.
 	auditSvc := service.NewAuditService(auditRepo)
 	credentialPolicySvc := service.NewCredentialPolicyService(credentialPolicyRepo)
-	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL)
+	credentialSvc := service.NewCredentialService(credentialRepo, jwksSvc, credentialPolicySvc, attestationRepo, cfg.Token.Issuer, cfg.Token.DefaultTTL, cfg.Token.MaxTTL, cfg.Token.AuditRetentionDays)
 	signalSvc := service.NewSignalService(signalRepo, credentialSvc, identityRepo)
 	signingCredSvc := service.NewSigningCredentialService(
 		signingCredRepo,

--- a/tests/integration/cleanup_retention_test.go
+++ b/tests/integration/cleanup_retention_test.go
@@ -144,6 +144,49 @@ func TestDelegationGraphSurvivesTokenExpiry(t *testing.T) {
 	assert.Contains(t, downJTIs, childJTI, "walk-down from the expired root must still reach the live child")
 }
 
+// TestRotateRejectsExpiredCredential pins the guard that keeps audit
+// retention from widening the rotation surface: rows now outlive expiry by
+// ~400 days, and RotateCredential's revoke half is a silent no-op on an
+// expired row (the cascade anchor requires expires_at > revoked_at) — so
+// without the guard, "rotate" would mint a live token off a long-dead
+// credential. An expired credential must be rejected, left unrevoked, and
+// no replacement minted.
+func TestRotateRejectsExpiredCredential(t *testing.T) {
+	ctx := context.Background()
+
+	policyID := delegationPolicy(t, uid("rotate-expired-policy"), []string{"mcp:read"})
+	identityID, jti, _ := issueRootCredential(t, policyID, "rotate-expired", []string{"mcp:read"})
+
+	var cred domain.IssuedCredential
+	require.NoError(t, testDB.NewSelect().Model(&cred).Where("jti = ?", jti).Scan(ctx))
+
+	// Age the credential past expiry directly — the API cannot mint an
+	// already-expired token.
+	_, err := testDB.NewUpdate().
+		Model((*domain.IssuedCredential)(nil)).
+		Set("expires_at = ?", time.Now().Add(-time.Hour)).
+		Where("id = ?", cred.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	resp := post(t, adminPath("/credentials/"+cred.ID+"/rotate"), nil, adminHeaders())
+	defer func() { _ = resp.Body.Close() }()
+	assert.GreaterOrEqual(t, resp.StatusCode, 400,
+		"rotating an expired credential must fail, not resurrect it")
+
+	// The expired row must be untouched: not retro-revoked, and no
+	// replacement credential minted for the identity.
+	require.NoError(t, testDB.NewSelect().Model(&cred).Where("id = ?", cred.ID).Scan(ctx))
+	assert.False(t, cred.IsRevoked, "failed rotation must not retro-revoke the expired row")
+
+	n, err := testDB.NewSelect().
+		Model((*domain.IssuedCredential)(nil)).
+		Where("identity_id = ?", identityID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "failed rotation must not mint a replacement credential")
+}
+
 // TestIssuedCredentialStampedWithAuditRetention proves the write path: a
 // credential minted through the real issuance flow carries a non-NULL
 // audit_retention_until strictly beyond its expires_at, so every new row

--- a/tests/integration/cleanup_retention_test.go
+++ b/tests/integration/cleanup_retention_test.go
@@ -1,0 +1,165 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
+)
+
+// insertIssuedCredentialRow inserts an issued_credentials row directly via
+// testDB so the test can deterministically place rows on either side of the
+// cleanup worker's two cutoffs (the expires_at cascade clock and the
+// audit_retention_until evidence clock) without minting real tokens whose
+// timestamps the service controls. auditRetentionUntil nil produces a NULL
+// column — the pre-037 legacy shape.
+func insertIssuedCredentialRow(t *testing.T, jti, parentJTI string, expiresAt time.Time, auditRetentionUntil *time.Time) {
+	t.Helper()
+	row := &domain.IssuedCredential{
+		ID:                  uuidV4(t),
+		AccountID:           testAccountID,
+		ProjectID:           testProjectID,
+		JTI:                 jti,
+		Subject:             "spiffe://" + testWIMSE + "/" + testAccountID + "/" + testProjectID + "/agent/cleanup-retention",
+		ExpiresAt:           expiresAt,
+		TTLSeconds:          3600,
+		Scopes:              []string{"mcp:read"},
+		GrantType:           domain.GrantType("client_credentials"),
+		ParentJTI:           parentJTI,
+		AuditRetentionUntil: auditRetentionUntil,
+	}
+	if parentJTI != "" {
+		row.DelegationDepth = 1
+	}
+	_, err := testDB.NewInsert().Model(row).Exec(context.Background())
+	require.NoError(t, err, "insert issued_credentials row %s", jti)
+}
+
+func issuedCredentialExists(t *testing.T, jti string) bool {
+	t.Helper()
+	n, err := testDB.NewSelect().
+		Model((*domain.IssuedCredential)(nil)).
+		Where("jti = ?", jti).
+		Count(context.Background())
+	require.NoError(t, err)
+	return n > 0
+}
+
+// TestCleanupRetainsCredentialsWithinAuditRetention proves the two-clock
+// prune in CleanupWorker.RunOnce (issue: delegation graph blanks after
+// token expiry). A row is deleted only when BOTH clocks have elapsed:
+//
+//   - expired long ago but audit_retention_until in the future → RETAINED
+//     (the evidence clock keeps the delegation graph answerable);
+//   - expired long ago and audit_retention_until elapsed → DELETED;
+//   - expired long ago with NULL audit_retention_until (pre-037 legacy
+//     row) → DELETED under the legacy expires_at-only rule;
+//   - audit_retention_until elapsed but expires_at still inside the
+//     cascade-walk window (credRetention) → RETAINED, because parent_jti
+//     edges may still be needed by cascade revocation;
+//   - active, unexpired → never touched.
+//
+// The test server's cleanup worker runs with credRetention = Token.MaxTTL
+// (90 days), so "past the cascade clock" means expires_at < now - 90d.
+func TestCleanupRetainsCredentialsWithinAuditRetention(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	future := now.Add(300 * 24 * time.Hour)
+	pastHour := now.Add(-time.Hour)
+	pastMinute := now.Add(-time.Minute)
+
+	// (1) Past the cascade clock, inside the audit window → RETAIN.
+	retainedAudit := uid("cred-retained-audit")
+	insertIssuedCredentialRow(t, retainedAudit, "", now.Add(-100*24*time.Hour), &future)
+
+	// (2) Past both clocks → DELETE.
+	prunedBoth := uid("cred-pruned-both")
+	insertIssuedCredentialRow(t, prunedBoth, "", now.Add(-100*24*time.Hour), &pastHour)
+
+	// (3) Legacy NULL retention, past the cascade clock → DELETE (old rule).
+	legacyNull := uid("cred-legacy-null")
+	insertIssuedCredentialRow(t, legacyNull, "", now.Add(-100*24*time.Hour), nil)
+
+	// (4) Audit window elapsed but expiry still inside the cascade-walk
+	// window → RETAIN. Proves the clocks are ANDed: an aggressive audit
+	// clock must never sever parent_jti edges the cascade walk still needs.
+	cascadeGuard := uid("cred-cascade-guard")
+	insertIssuedCredentialRow(t, cascadeGuard, "", pastHour, &pastMinute)
+
+	// (5) Active credential → RETAIN.
+	active := uid("cred-active")
+	insertIssuedCredentialRow(t, active, "", now.Add(time.Hour), &future)
+
+	testZeroIDServer.RunCleanupOnce(ctx)
+
+	assert.True(t, issuedCredentialExists(t, retainedAudit), "expired-but-within-retention row must survive the sweep")
+	assert.False(t, issuedCredentialExists(t, prunedBoth), "row past both clocks must be pruned")
+	assert.False(t, issuedCredentialExists(t, legacyNull), "legacy NULL-retention row must be pruned under the expires_at rule")
+	assert.True(t, issuedCredentialExists(t, cascadeGuard), "row inside the cascade-walk window must survive even with audit retention elapsed")
+	assert.True(t, issuedCredentialExists(t, active), "active row must never be touched")
+}
+
+// TestDelegationGraphSurvivesTokenExpiry proves the product symptom is
+// fixed: a delegation chain whose parent token expired long ago still
+// resolves through the graph CTEs (WalkUp from the live child reaches the
+// expired root; WalkDown from the expired root reaches the child) after a
+// cleanup pass, because the expired row is retained by its evidence clock.
+func TestDelegationGraphSurvivesTokenExpiry(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	future := now.Add(300 * 24 * time.Hour)
+
+	// Root expired well past the cascade clock (90d) but within audit
+	// retention; child is still live and points at it via parent_jti.
+	rootJTI := uid("cred-graph-root")
+	childJTI := uid("cred-graph-child")
+	insertIssuedCredentialRow(t, rootJTI, "", now.Add(-100*24*time.Hour), &future)
+	insertIssuedCredentialRow(t, childJTI, rootJTI, now.Add(time.Hour), &future)
+
+	testZeroIDServer.RunCleanupOnce(ctx)
+
+	repo := postgres.NewDelegationRepository(testDB)
+
+	up, err := repo.WalkUp(ctx, childJTI, testAccountID, testProjectID, 10)
+	require.NoError(t, err)
+	upJTIs := make([]string, 0, len(up))
+	for _, c := range up {
+		upJTIs = append(upJTIs, c.JTI)
+	}
+	assert.Contains(t, upJTIs, rootJTI, "walk-up from the live child must still reach the expired root")
+	assert.Contains(t, upJTIs, childJTI)
+
+	down, err := repo.WalkDown(ctx, rootJTI, testAccountID, testProjectID, 10)
+	require.NoError(t, err)
+	downJTIs := make([]string, 0, len(down))
+	for _, c := range down {
+		downJTIs = append(downJTIs, c.JTI)
+	}
+	assert.Contains(t, downJTIs, childJTI, "walk-down from the expired root must still reach the live child")
+}
+
+// TestIssuedCredentialStampedWithAuditRetention proves the write path: a
+// credential minted through the real issuance flow carries a non-NULL
+// audit_retention_until strictly beyond its expires_at, so every new row
+// participates in the two-clock model without backfill.
+func TestIssuedCredentialStampedWithAuditRetention(t *testing.T) {
+	policyID := delegationPolicy(t, uid("cleanup-retention-policy"), []string{"mcp:read"})
+	_, jti, _ := issueRootCredential(t, policyID, "cleanup-retention", []string{"mcp:read"})
+
+	var cred domain.IssuedCredential
+	err := testDB.NewSelect().
+		Model(&cred).
+		Where("jti = ?", jti).
+		Scan(context.Background())
+	require.NoError(t, err)
+
+	require.NotNil(t, cred.AuditRetentionUntil, "issuance must stamp the evidence clock")
+	assert.True(t, cred.AuditRetentionUntil.After(cred.ExpiresAt),
+		"audit_retention_until (%s) must be beyond expires_at (%s)", cred.AuditRetentionUntil, cred.ExpiresAt)
+}

--- a/tests/integration/cleanup_retention_test.go
+++ b/tests/integration/cleanup_retention_test.go
@@ -2,6 +2,7 @@ package integration_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
@@ -171,8 +172,10 @@ func TestRotateRejectsExpiredCredential(t *testing.T) {
 
 	resp := post(t, adminPath("/credentials/"+cred.ID+"/rotate"), nil, adminHeaders())
 	defer func() { _ = resp.Body.Close() }()
-	assert.GreaterOrEqual(t, resp.StatusCode, 400,
-		"rotating an expired credential must fail, not resurrect it")
+	// 409 Conflict, not 5xx: rotating a dead credential is a terminal-state
+	// client mistake, not a server fault (it must not fire 5xx alerting).
+	assert.Equal(t, http.StatusConflict, resp.StatusCode,
+		"rotating an expired credential must return 409, not resurrect it or 500")
 
 	// The expired row must be untouched: not retro-revoked, and no
 	// replacement credential minted for the identity.


### PR DESCRIPTION
Part of highflame-ai/highflame-architecture#132 (epic), bug #142 (B1).

## Problem
The delegation graph in Studio blanks out after a token expires. Root cause: `issued_credentials` rows were hard-pruned at (or shortly after) credential expiry, so the lineage the graph is built from (jti → parent_jti → mission_id) disappeared the moment a delegated token lapsed — exactly when you still want to inspect what happened.

## Fix
Retain `issued_credentials` **past expiry** so the delegation chain survives for audit/inspection, then prune on a separate, longer audit-retention clock:

- Two-clock retention on `issued_credentials` (migration): a row is only eligible for pruning when **both** its credential-expiry and its `audit_retention_until` have passed.
- `token.audit_retention_days` config (default 400, max 36500) as one source of truth (`domain.DefaultAuditRetentionDays` / `MaxAuditRetentionDays`), parsed correctly from env (was a real int-parse bug).
- Rotation-of-expired guard: rotating a dead credential returns a clean 409 (sentinels) instead of a 500.

## Tests
- [x] Migration lock-posture + fixed-400d backfill; prune requires both clocks; rotation-of-expired → 409.
- [x] Green on the zeroid suite (GOEXPERIMENT=jsonv2).

Follow-up: zeroid#226 (bounded graph root-expansion read path).
