### PR TITLE
feat: T3 — code-agent bootstrap primitives (/code-agents/*, zeroid:bootstrap, DPoP verified)

### DIFF
--- a/domain/credential.go
+++ b/domain/credential.go
@@ -27,6 +27,14 @@ const (
 	GrantTypeRefreshToken GrantType = "refresh_token"
 )
 
+// ScopeZeroIDBootstrap is the single-purpose OAuth scope that authorizes
+// code-agent bootstrap: registering a code-agent identity from a developer
+// machine and minting its first access token (POST /code-agents/bootstrap).
+// It grants nothing else — a bootstrap-scoped token is not accepted by any
+// other endpoint, so a leaked developer bootstrap token cannot read or manage
+// existing identities.
+const ScopeZeroIDBootstrap = "zeroid:bootstrap"
+
 // urnToShortGrantType maps OAuth2 URN grant type identifiers to their canonical short forms.
 var urnToShortGrantType = map[string]GrantType{
 	"urn:ietf:params:oauth:grant-type:jwt-bearer":     GrantTypeJWTBearer,

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -441,6 +441,19 @@ type Identity struct {
 	RiskTier       string `bun:"risk_tier,type:varchar(20),nullzero"       json:"risk_tier,omitempty"`
 	IAL            string `bun:"ial,type:varchar(20),nullzero"             json:"ial,omitempty"`
 
+	// Code-agent bootstrap (migration 038). BootstrapMachineID records the
+	// developer machine this code agent was bootstrapped from, enabling
+	// revoke-by-machine (lost/compromised laptop → deactivate every agent it
+	// spawned). LastAttestedAt + AttestationEvidence track attestation
+	// freshness: the agent periodically re-attests its runtime environment
+	// via POST /code-agents/{id}/attest. All three are NULL for anything
+	// that is not a bootstrapped code agent (`nullzero` keeps the empty Go
+	// string as SQL NULL so the partial bootstrap-machine index and the
+	// IS NOT NULL listing filters stay correct).
+	BootstrapMachineID  string          `bun:"bootstrap_machine_id,type:varchar(255),nullzero" json:"bootstrap_machine_id,omitempty"`
+	LastAttestedAt      *time.Time      `bun:"last_attested_at" json:"last_attested_at,omitempty"`
+	AttestationEvidence json.RawMessage `bun:"attestation_evidence,type:jsonb" json:"attestation_evidence,omitempty"`
+
 	// ExpiresAt time-bounds the grant of authority itself (NOT the JWT it
 	// issues). NULL means "no expiry" — the historical default. When set,
 	// IssueCredential rejects new tokens past this time and the cleanup

--- a/internal/handler/code_agent.go
+++ b/internal/handler/code_agent.go
@@ -1,0 +1,258 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"github.com/highflame-ai/zeroid/domain"
+	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
+	"github.com/highflame-ai/zeroid/internal/service"
+)
+
+// Code-agent bootstrap endpoints (highflame-architecture#136, epic #132 S3).
+//
+// Four surfaces, three auth models:
+//   - POST /code-agents/bootstrap        — public router, BootstrapAuthMiddleware
+//     (zeroid:bootstrap-scoped developer token; tenant + owner from claims).
+//   - POST /code-agents/{id}/attest      — public router, AgentAuthMiddleware
+//     (the agent's OWN access token; it can only attest itself).
+//   - POST /code-agents/by-machine/{machine_id}/revoke — admin router.
+//   - GET  /code-agents/by-developer/{user_id}          — admin router.
+
+// ── Bootstrap ────────────────────────────────────────────────────────────────
+
+type BootstrapCodeAgentInput struct {
+	Body struct {
+		PublicKeyPEM string `json:"public_key_pem" required:"true" minLength:"1" doc:"SPKI EC P-256 custody public key (PEM). The matching private key never leaves the developer machine; it signs the agent's jwt_bearer assertions."`
+		Framework    string `json:"framework" required:"true" minLength:"1" doc:"Code-agent runtime (e.g. claude-code, cursor). SPIFFE path segment characters only (a-z A-Z 0-9 . - _)."`
+		MachineID    string `json:"machine_id" required:"true" minLength:"1" doc:"Stable identifier of the developer machine the custody key lives on. Enables revoke-by-machine. SPIFFE path segment characters only."`
+		SubType      string `json:"sub_type,omitempty" enum:"orchestrator,tool_agent" doc:"Operational role (defaults to orchestrator)"`
+		Name         string `json:"name,omitempty" doc:"Human-readable name (defaults to <framework>-<machine id prefix>)"`
+	}
+}
+
+type BootstrapCodeAgentOutput struct {
+	Body *service.CodeAgentBootstrapResponse
+}
+
+// ── Attest ───────────────────────────────────────────────────────────────────
+
+type AttestCodeAgentInput struct {
+	ID   string `path:"id" doc:"Code agent identity UUID (must be the caller's own identity)"`
+	Body struct {
+		Evidence json.RawMessage `json:"evidence" required:"true" doc:"Opaque JSON attestation evidence document (runtime environment facts). Stored verbatim; policy elsewhere decides on freshness/shape."`
+	}
+}
+
+type AttestCodeAgentOutput struct {
+	Body struct {
+		LastAttestedAt time.Time `json:"last_attested_at" doc:"Server timestamp recorded for this attestation"`
+	}
+}
+
+// ── Revoke by machine ────────────────────────────────────────────────────────
+
+type RevokeCodeAgentsByMachineInput struct {
+	MachineID string `path:"machine_id" doc:"Bootstrap machine identifier whose code agents should be revoked"`
+	Body      struct {
+		OwnerUserID string `json:"owner_user_id,omitempty" doc:"Optional filter: only revoke this developer's agents on the machine"`
+	}
+}
+
+type RevokeCodeAgentsByMachineOutput struct {
+	Body struct {
+		Revoked int `json:"revoked" doc:"Number of code agents deactivated"`
+	}
+}
+
+// ── List by developer ────────────────────────────────────────────────────────
+
+type ListCodeAgentsByDeveloperInput struct {
+	UserID string `path:"user_id" doc:"Developer (owner) user ID"`
+}
+
+type ListCodeAgentsByDeveloperOutput struct {
+	Body struct {
+		CodeAgents []service.AgentResponse `json:"code_agents"`
+	}
+}
+
+// ── Route registration ───────────────────────────────────────────────────────
+
+// RegisterCodeAgentBootstrap registers the public bootstrap endpoint. It MUST
+// be mounted on the public router behind BootstrapAuthMiddleware — tenant and
+// owner come from the validated zeroid:bootstrap token claims, never from the
+// request body.
+func (a *API) RegisterCodeAgentBootstrap(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID:   "bootstrap-code-agent",
+		Method:        http.MethodPost,
+		Path:          "/code-agents/bootstrap",
+		Summary:       "Bootstrap a code agent from a developer machine (register identity + mint first token)",
+		Tags:          []string{"Code Agents"},
+		DefaultStatus: http.StatusCreated,
+	}, a.bootstrapCodeAgentOp)
+}
+
+// registerCodeAgentAttestRoute registers the agent self-service attestation
+// endpoint. Mounted with the other self-service routes on the public router
+// behind AgentAuthMiddleware — the caller authenticates with its OWN access
+// token and can only attest its own identity.
+func (a *API) registerCodeAgentAttestRoute(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "attest-code-agent",
+		Method:      http.MethodPost,
+		Path:        "/code-agents/{id}/attest",
+		Summary:     "Record fresh attestation evidence for the calling code agent",
+		Tags:        []string{"Code Agents"},
+	}, a.attestCodeAgentOp)
+}
+
+// registerCodeAgentAdminRoutes registers the operator surfaces on the admin
+// router (tenant from X-Account-ID/X-Project-ID headers).
+func (a *API) registerCodeAgentAdminRoutes(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "revoke-code-agents-by-machine",
+		Method:      http.MethodPost,
+		Path:        "/code-agents/by-machine/{machine_id}/revoke",
+		Summary:     "Revoke every active code agent bootstrapped from a machine (lost/compromised laptop response)",
+		Tags:        []string{"Code Agents"},
+	}, a.revokeCodeAgentsByMachineOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "list-code-agents-by-developer",
+		Method:      http.MethodGet,
+		Path:        "/code-agents/by-developer/{user_id}",
+		Summary:     "List every bootstrapped code agent owned by a developer",
+		Tags:        []string{"Code Agents"},
+	}, a.listCodeAgentsByDeveloperOp)
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+func (a *API) bootstrapCodeAgentOp(ctx context.Context, input *BootstrapCodeAgentInput) (*BootstrapCodeAgentOutput, error) {
+	claims, ok := internalMiddleware.GetBootstrapClaims(ctx)
+	if !ok || claims.UserID == "" {
+		return nil, huma.Error401Unauthorized("missing or invalid bootstrap token")
+	}
+
+	// Attribute the registration to the developer in the audit trail (this
+	// endpoint runs outside TenantContextMiddleware, so caller_name is
+	// otherwise unset).
+	ctx = internalMiddleware.SetCallerName(ctx, claims.UserID)
+
+	resp, err := a.agentSvc.RegisterCodeAgentFromBootstrap(ctx, service.CodeAgentBootstrapRequest{
+		AccountID:    claims.AccountID,
+		ProjectID:    claims.ProjectID,
+		OwnerUserID:  claims.UserID,
+		Framework:    input.Body.Framework,
+		MachineID:    input.Body.MachineID,
+		SubType:      domain.SubType(input.Body.SubType),
+		PublicKeyPEM: input.Body.PublicKeyPEM,
+		Name:         input.Body.Name,
+	})
+	if err != nil {
+		// This machine's agent is still active and already has a key: refuse
+		// to swap it from a bootstrap token (INV-IDN-004). Actionable 409.
+		// (A REVOKED machine is not an error here — the service mints a fresh
+		// identity and returns 201.)
+		if errors.Is(err, service.ErrCodeAgentAlreadyBootstrapped) {
+			return nil, huma.Error409Conflict(
+				"this machine already has an active code agent with an enrolled key; rotate the key via the key-change (proof-of-possession) endpoint, or revoke this machine and bootstrap again",
+				&huma.ErrorDetail{Location: "body.machine_id", Value: input.Body.MachineID},
+			)
+		}
+		if errors.Is(err, service.ErrIdentityAlreadyExists) {
+			return nil, huma.Error409Conflict("a code agent for this machine already exists and belongs to another developer")
+		}
+		if errors.Is(err, service.ErrInvalidIdentityField) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		return nil, mapErr(err)
+	}
+
+	return &BootstrapCodeAgentOutput{Body: resp}, nil
+}
+
+// maxAttestationEvidenceBytes bounds the opaque attestation document so an
+// agent owner can't store megabytes of arbitrary JSON per agent under the
+// global 10 MiB body cap. 64 KiB is generous for runtime-environment facts.
+const maxAttestationEvidenceBytes = 64 * 1024
+
+func (a *API) attestCodeAgentOp(ctx context.Context, input *AttestCodeAgentInput) (*AttestCodeAgentOutput, error) {
+	claims, ok := internalMiddleware.GetAgentClaims(ctx)
+	if !ok || claims.Subject == "" {
+		return nil, huma.Error401Unauthorized("missing or invalid agent token")
+	}
+
+	if len(input.Body.Evidence) > maxAttestationEvidenceBytes {
+		return nil, huma.Error422UnprocessableEntity(fmt.Sprintf(
+			"attestation evidence exceeds %d bytes", maxAttestationEvidenceBytes))
+	}
+
+	// The caller may only attest ITSELF. Access tokens carry the identity's
+	// WIMSE URI as sub (and identity_id only when a deployment injects it),
+	// so resolve the path id within the caller's tenant and require the
+	// caller's subject to match. A cross-tenant id never resolves (tenant
+	// scoping), which surfaces as 404 rather than leaking existence.
+	if claims.IdentityID != "" && claims.IdentityID != input.ID {
+		return nil, huma.Error403Forbidden("a code agent may only attest its own identity")
+	}
+	identity, err := a.identitySvc.GetIdentity(ctx, input.ID, claims.AccountID, claims.ProjectID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	if identity.WIMSEURI != claims.Subject {
+		return nil, huma.Error403Forbidden("a code agent may only attest its own identity")
+	}
+
+	// Attribute the attestation to the agent itself in the audit trail.
+	ctx = internalMiddleware.SetCallerName(ctx, claims.Subject)
+
+	attestedAt, err := a.agentSvc.RecordCodeAgentAttestation(ctx, input.ID, claims.AccountID, claims.ProjectID, input.Body.Evidence)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+
+	out := &AttestCodeAgentOutput{}
+	out.Body.LastAttestedAt = attestedAt
+	return out, nil
+}
+
+func (a *API) revokeCodeAgentsByMachineOp(ctx context.Context, input *RevokeCodeAgentsByMachineInput) (*RevokeCodeAgentsByMachineOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	revoked, err := a.agentSvc.RevokeCodeAgentsByMachine(ctx, tenant.AccountID, tenant.ProjectID, input.MachineID, input.Body.OwnerUserID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+
+	out := &RevokeCodeAgentsByMachineOutput{}
+	out.Body.Revoked = revoked
+	return out, nil
+}
+
+func (a *API) listCodeAgentsByDeveloperOp(ctx context.Context, input *ListCodeAgentsByDeveloperInput) (*ListCodeAgentsByDeveloperOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	agents, err := a.agentSvc.ListCodeAgentsByDeveloper(ctx, tenant.AccountID, tenant.ProjectID, input.UserID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+
+	out := &ListCodeAgentsByDeveloperOutput{}
+	out.Body.CodeAgents = agents
+	return out, nil
+}

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -237,6 +237,7 @@ func (a *API) RegisterAdmin(api huma.API, router chi.Router) {
 	a.registerExpiringSoonRoute(api)
 	a.registerSigningCredentialRoutes(api)
 	a.registerDelegationRoutes(api)
+	a.registerCodeAgentAdminRoutes(api)
 }
 
 // RegisterAgentAuth registers endpoints requiring agent-auth middleware (proof generation).
@@ -252,4 +253,5 @@ func (a *API) RegisterAgentAuth(api huma.API) {
 // wraps them in AgentAuthMiddleware, and tenant/identity come from token claims.
 func (a *API) RegisterAgentSelfService(api huma.API) {
 	a.registerAgentSelfServiceRoute(api)
+	a.registerCodeAgentAttestRoute(api)
 }

--- a/internal/middleware/bootstrap_auth.go
+++ b/internal/middleware/bootstrap_auth.go
@@ -1,0 +1,201 @@
+package middleware
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/jwtalg"
+)
+
+// BootstrapClaims holds the developer identity claims extracted from a
+// validated zeroid:bootstrap-scoped token. It is populated by
+// BootstrapAuthMiddleware and available via GetBootstrapClaims.
+type BootstrapClaims struct {
+	// UserID is the developer the bootstrap token was issued to (the token's
+	// sub claim) — becomes OwnerUserID on every code agent it registers.
+	UserID    string
+	AccountID string
+	ProjectID string
+	JTI       string
+	Scopes    []string
+}
+
+type bootstrapClaimsKey struct{}
+
+// BootstrapAuthConfig configures the BootstrapAuthMiddleware.
+type BootstrapAuthConfig struct {
+	// ECPublicKey is the ECDSA P-256 public key used to verify ES256 tokens
+	// (e.g. a client_credentials-minted bootstrap token).
+	ECPublicKey *ecdsa.PublicKey
+	// RSAPublicKey optionally verifies RS256 tokens — the developer bootstrap
+	// token from the PKCE authorization_code flow is RS256. Nil disables the
+	// RS256 fallback (deployments without RSA keys).
+	RSAPublicKey *rsa.PublicKey
+	// Issuer is the expected iss claim value.
+	Issuer string
+	// ResourceMetadataURL is the absolute URL of this server's RFC 9728
+	// Protected Resource Metadata document, emitted in WWW-Authenticate
+	// challenges (RFC 9728 §5.1). Empty disables the breadcrumb.
+	ResourceMetadataURL string
+}
+
+// BootstrapAuthMiddleware validates a ZeroID-issued Bearer token carrying the
+// zeroid:bootstrap scope and injects BootstrapClaims into the request context.
+// Modeled on AgentAuthMiddleware, with two deltas:
+//
+//   - It accepts both ES256 and RS256 signatures — the developer bootstrap
+//     token from the PKCE flow is RS256 (authorization_code sets UseRS256),
+//     while a client_credentials bootstrap token is ES256.
+//   - It REQUIRES the single-purpose zeroid:bootstrap scope; a valid ZeroID
+//     token without it is rejected with 403 insufficient_scope (RFC 6750 §3.1)
+//     so ordinary access tokens can never register code agents.
+//
+// It also sets the TenantContext so downstream handlers can call GetTenant().
+func BootstrapAuthMiddleware(cfg BootstrapAuthConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				// RFC 6750 §3: no auth info → bare Bearer challenge (no error
+				// code in the header); the JSON body still carries a human-
+				// readable message. Same convention as AgentAuthMiddleware.
+				writeBootstrapAuthError(w, http.StatusUnauthorized, "", "", "Authorization header is required", cfg.ResourceMetadataURL)
+				return
+			}
+			if !strings.HasPrefix(authHeader, "Bearer ") {
+				writeBootstrapAuthError(w, http.StatusUnauthorized, "invalid_request", "Authorization header must use the Bearer scheme", "Authorization header must use the Bearer scheme", cfg.ResourceMetadataURL)
+				return
+			}
+			tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+			if tokenStr == "" {
+				writeBootstrapAuthError(w, http.StatusUnauthorized, "invalid_request", "Authorization header carries an empty Bearer token", "Authorization header carries an empty Bearer token", cfg.ResourceMetadataURL)
+				return
+			}
+
+			// Reject alg=none / HS* before any signature work — JWT-SVID §3.
+			if err := jwtalg.Validate(tokenStr); err != nil {
+				log.Warn().Err(err).Str("path", r.URL.Path).Msg("Bootstrap JWT rejected: bad alg")
+				writeBootstrapAuthError(w, http.StatusUnauthorized, "invalid_token", "invalid or expired token", "invalid or expired token", cfg.ResourceMetadataURL)
+				return
+			}
+
+			// Try ES256 first (the NHI default), then RS256 when RSA keys are
+			// configured — the PKCE developer bootstrap token is RS256.
+			parsed, err := jwt.Parse([]byte(tokenStr),
+				jwt.WithKey(jwa.ES256(), cfg.ECPublicKey),
+				jwt.WithValidate(true),
+				jwt.WithIssuer(cfg.Issuer),
+			)
+			if err != nil && cfg.RSAPublicKey != nil {
+				parsed, err = jwt.Parse([]byte(tokenStr),
+					jwt.WithKey(jwa.RS256(), cfg.RSAPublicKey),
+					jwt.WithValidate(true),
+					jwt.WithIssuer(cfg.Issuer),
+				)
+			}
+			if err != nil {
+				log.Warn().Err(err).Str("path", r.URL.Path).Msg("Bootstrap JWT validation failed")
+				writeBootstrapAuthError(w, http.StatusUnauthorized, "invalid_token", "invalid or expired token", "invalid or expired token", cfg.ResourceMetadataURL)
+				return
+			}
+
+			claims := extractBootstrapClaims(parsed)
+
+			if claims.UserID == "" {
+				writeBootstrapAuthError(w, http.StatusUnauthorized, "invalid_token", "token missing required sub claim", "token missing required sub claim", cfg.ResourceMetadataURL)
+				return
+			}
+			if claims.AccountID == "" || claims.ProjectID == "" {
+				writeBootstrapAuthError(w, http.StatusUnauthorized, "invalid_token", "token missing required tenant claims", "token missing required tenant claims", cfg.ResourceMetadataURL)
+				return
+			}
+
+			// The single-purpose scope gate: a valid ZeroID token that was not
+			// minted for bootstrap must not register code agents. RFC 6750
+			// §3.1: insufficient_scope → 403.
+			if !slices.Contains(claims.Scopes, domain.ScopeZeroIDBootstrap) {
+				writeBootstrapAuthError(w, http.StatusForbidden, "insufficient_scope",
+					"token lacks the required "+domain.ScopeZeroIDBootstrap+" scope",
+					"token lacks the required "+domain.ScopeZeroIDBootstrap+" scope",
+					cfg.ResourceMetadataURL)
+				return
+			}
+
+			ctx := r.Context()
+			ctx = SetTenant(ctx, claims.AccountID, claims.ProjectID)
+			ctx = context.WithValue(ctx, bootstrapClaimsKey{}, claims)
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetBootstrapClaims retrieves the bootstrap claims from the request context.
+// Handlers behind BootstrapAuthMiddleware call this to read the developer's
+// identity + tenant without re-parsing the JWT.
+func GetBootstrapClaims(ctx context.Context) (BootstrapClaims, bool) {
+	claims, ok := ctx.Value(bootstrapClaimsKey{}).(BootstrapClaims)
+	return claims, ok
+}
+
+func extractBootstrapClaims(token jwt.Token) BootstrapClaims {
+	sub, _ := token.Subject()
+	jti, _ := token.JwtID()
+	claims := BootstrapClaims{
+		UserID: sub,
+		JTI:    jti,
+	}
+
+	if v, err := jwt.Get[string](token, "account_id"); err == nil {
+		claims.AccountID = v
+	}
+	if v, err := jwt.Get[string](token, "project_id"); err == nil {
+		claims.ProjectID = v
+	}
+	// ZeroID-issued tokens carry granted scopes in the "scopes" claim; the
+	// "scp" spelling is accepted as well for interop with auth-code shaped
+	// tokens. Each can decode as []string or []any depending on the JSON
+	// round-trip — same fallback dance as AgentAuthMiddleware / authcode.go.
+	for _, name := range []string{"scopes", "scp"} {
+		if v, err := jwt.Get[[]string](token, name); err == nil {
+			claims.Scopes = append(claims.Scopes, v...)
+		} else if v, err := jwt.Get[[]any](token, name); err == nil {
+			for _, item := range v {
+				if str, ok := item.(string); ok {
+					claims.Scopes = append(claims.Scopes, str)
+				}
+			}
+		}
+	}
+
+	return claims
+}
+
+// writeBootstrapAuthError emits an RFC 6750 §3 challenge. Unlike
+// writeAgentAuthError it takes the status explicitly because the scope gate
+// responds 403 insufficient_scope (RFC 6750 §3.1) while credential failures
+// respond 401. Same header/body conventions as writeAgentAuthError: the
+// WWW-Authenticate header carries the RFC 6750 error info (empty when the
+// request had no auth info at all), the JSON body always carries a
+// human-readable message.
+func writeBootstrapAuthError(w http.ResponseWriter, status int, errorCode, headerMessage, bodyMessage, resourceMetadataURL string) {
+	w.Header().Set("WWW-Authenticate", WWWAuthenticate(errorCode, headerMessage, resourceMetadataURL))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": bodyMessage,
+		},
+	})
+}

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -24,6 +24,10 @@ type AgentService struct {
 	// proof must target is derived from it (see keyProofAudience).
 	issuer        string
 	delegationSvc *DelegationService
+	// credentialSvc mints the first access token during code-agent bootstrap
+	// (RegisterCodeAgentFromBootstrap) so a freshly registered agent leaves
+	// the bootstrap call already able to authenticate.
+	credentialSvc *CredentialService
 }
 
 // NewAgentService creates a new AgentService. keyProofReplay backs single-use
@@ -36,6 +40,7 @@ func NewAgentService(
 	keyProofReplay keyProofReplayGuard,
 	issuer string,
 	delegationSvc *DelegationService,
+	credentialSvc *CredentialService,
 ) *AgentService {
 	return &AgentService{
 		identitySvc:    identitySvc,
@@ -44,6 +49,7 @@ func NewAgentService(
 		keyProofReplay: keyProofReplay,
 		issuer:         issuer,
 		delegationSvc:  delegationSvc,
+		credentialSvc:  credentialSvc,
 	}
 }
 

--- a/internal/service/code_agent.go
+++ b/internal/service/code_agent.go
@@ -1,0 +1,340 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// ErrCodeAgentAlreadyBootstrapped is returned when a re-bootstrap targets a
+// machine whose code-agent identity is still active AND already has a custody
+// key enrolled. Silently replacing that key from a bootstrap token would let a
+// stolen developer session hijack an established identity (INV-IDN-004); the
+// key may only rotate via the proof-of-possession path, or the machine must be
+// revoked (which lets re-bootstrap mint a fresh identity). Handlers map this
+// to 409.
+var ErrCodeAgentAlreadyBootstrapped = errors.New("code_agent_already_bootstrapped")
+
+// Code-agent bootstrap (highflame-architecture#136, epic #132 slice S3).
+//
+// A code agent (Claude Code, Cursor, ...) running on a developer machine
+// bootstraps its identity with a zeroid:bootstrap-scoped developer token:
+// it generates an EC P-256 custody keypair locally, registers the PUBLIC key
+// here, and receives its identity plus a first access token in one call.
+// Subsequent tokens are self-served via the jwt_bearer grant (assertion
+// signed with the custody key) — no shared secret ever leaves the machine.
+// The machine id recorded at bootstrap enables revoke-by-machine when a
+// laptop is lost or compromised.
+
+// codeAgentSubTypes is the set of sub-types a bootstrapped code agent may
+// take. Narrower than agentSubTypes on purpose: a code agent is either the
+// coordinating session (orchestrator) or a spawned single-purpose worker
+// (tool_agent) — the human-proxy/evaluator/autonomous roles are not
+// bootstrap-from-a-laptop shapes.
+var codeAgentSubTypes = map[domain.SubType]bool{
+	domain.SubTypeOrchestrator: true,
+	domain.SubTypeToolAgent:    true,
+}
+
+// CodeAgentBootstrapRequest carries a code-agent bootstrap registration.
+// Tenant + owner come from the validated bootstrap-token claims (never from
+// the request body).
+type CodeAgentBootstrapRequest struct {
+	AccountID   string
+	ProjectID   string
+	OwnerUserID string
+	// Framework identifies the code-agent runtime (e.g. claude-code, cursor).
+	Framework string
+	// MachineID is a stable identifier for the developer machine the custody
+	// key lives on. Ends up in the WIMSE URI path, so it must be SPIFFE-clean.
+	MachineID string
+	// SubType defaults to orchestrator; only orchestrator and tool_agent are
+	// valid for a bootstrapped code agent.
+	SubType domain.SubType
+	// PublicKeyPEM is the SPKI EC P-256 custody public key (required) —
+	// verifies the agent's jwt_bearer assertions from the first token on.
+	PublicKeyPEM string
+	// Name is optional; defaults to "<framework>-<machineID short>".
+	Name string
+}
+
+// CodeAgentBootstrapResponse is the result of a bootstrap registration:
+// the registered identity plus its first access token, so the agent leaves
+// the call already able to authenticate.
+type CodeAgentBootstrapResponse struct {
+	Identity    AgentResponse       `json:"identity"`
+	WIMSEURI    string              `json:"wimse_uri"`
+	AccessToken *domain.AccessToken `json:"access_token"`
+}
+
+// codeAgentExternalID derives the deterministic external_id for a
+// (framework, machine) pair. Deterministic on purpose: identities are unique
+// on (account_id, project_id, external_id), so a re-bootstrap from the same
+// machine collides with its own previous registration. That collision is how
+// we DETECT a re-bootstrap and refuse to silently swap a live key (see
+// RegisterCodeAgentFromBootstrap). SPIFFE path segments forbid ":", so the
+// joiner is "-".
+func codeAgentExternalID(framework, machineID string) string {
+	return fmt.Sprintf("code-agent-%s-%s", framework, machineID)
+}
+
+// randomExternalIDSuffix returns a short random hex token appended to the
+// deterministic external_id when re-bootstrapping a machine whose previous
+// identity was REVOKED — so recovery mints a fresh identity instead of
+// colliding with (or resurrecting) the dead row. crypto/rand so it cannot
+// collide predictably.
+func randomExternalIDSuffix() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read failing is near-impossible; fall back to a timestamp so we
+		// never return an empty (colliding) suffix.
+		return fmt.Sprintf("%x", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// shortMachineID truncates a machine id for use in a human-readable name.
+func shortMachineID(machineID string) string {
+	if len(machineID) <= 8 {
+		return machineID
+	}
+	return machineID[:8]
+}
+
+// RegisterCodeAgentFromBootstrap registers a code-agent identity from a
+// developer machine and mints its first access token.
+//
+//   - TrustLevel is verified_third_party: the registration was authorized by
+//     an authenticated developer's bootstrap token, but the runtime itself has
+//     not attested — first_party stays reserved for attestation-backed trust.
+//   - The identity is registered through RegisterAgent, which also creates a
+//     linked API key. Code agents authenticate via jwt_bearer with the custody
+//     key, not the API key; the key is accepted as harmless bootstrap baggage
+//     because RegisterAgent has no skip flag (it is revoked with everything
+//     else on deactivation).
+//   - Re-bootstrap from the same (framework, machine): the deterministic
+//     external_id collides; when the existing identity is ACTIVE and owned by
+//     the SAME developer it is refreshed in place (custody key force-set to
+//     the newly generated one — the bootstrap token is the authorization,
+//     mirroring the admin recovery path) and a fresh first token is minted.
+//     A different owner or a deactivated (revoked) identity is a 409-shaped
+//     error: revoked machines stay revoked until an operator acts.
+func (s *AgentService) RegisterCodeAgentFromBootstrap(ctx context.Context, req CodeAgentBootstrapRequest) (*CodeAgentBootstrapResponse, error) {
+	if req.OwnerUserID == "" {
+		return nil, fmt.Errorf("%w: owner user id is required", ErrInvalidIdentityField)
+	}
+	// framework + machine_id land in the WIMSE URI path via the derived
+	// external_id — validate them as SPIFFE path segments up front so the
+	// error names the offending field instead of the derived value.
+	if err := domain.ValidateSPIFFEPathSegment("framework", req.Framework); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidIdentityField, err)
+	}
+	if err := domain.ValidateSPIFFEPathSegment("machine_id", req.MachineID); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidIdentityField, err)
+	}
+
+	subType := req.SubType
+	if subType == "" {
+		subType = domain.SubTypeOrchestrator
+	}
+	if !codeAgentSubTypes[subType] {
+		return nil, fmt.Errorf("%w: invalid sub_type for a code agent: %q (allowed: %s, %s)",
+			ErrInvalidIdentityField, subType, domain.SubTypeOrchestrator, domain.SubTypeToolAgent)
+	}
+
+	// The custody public key is the whole point of bootstrap — without it the
+	// agent could never self-serve a jwt_bearer token.
+	if req.PublicKeyPEM == "" {
+		return nil, fmt.Errorf("%w: public_key_pem is required", ErrInvalidIdentityField)
+	}
+	if _, err := parseECPublicKeyPEM(req.PublicKeyPEM); err != nil {
+		return nil, fmt.Errorf("%w: public_key_pem: %v", ErrInvalidIdentityField, err)
+	}
+
+	name := req.Name
+	if name == "" {
+		name = fmt.Sprintf("%s-%s", req.Framework, shortMachineID(req.MachineID))
+	}
+
+	baseExternalID := codeAgentExternalID(req.Framework, req.MachineID)
+
+	register := func(externalID string) (*AgentRegistrationResponse, error) {
+		return s.RegisterAgent(ctx, RegisterAgentRequest{
+			AccountID:    req.AccountID,
+			ProjectID:    req.ProjectID,
+			Name:         name,
+			ExternalID:   externalID,
+			IdentityType: domain.IdentityTypeAgent,
+			SubType:      subType,
+			TrustLevel:   domain.TrustLevelVerifiedThirdParty,
+			Framework:    req.Framework,
+			CreatedBy:    req.OwnerUserID, // becomes OwnerUserID in RegisterIdentity
+			PublicKeyPEM: req.PublicKeyPEM,
+		})
+	}
+
+	var identity *domain.Identity
+	var deactErr *IdentityDeactivatedConflictError
+	reg, err := register(baseExternalID)
+	switch {
+	case err == nil:
+		identity, err = s.identitySvc.GetIdentity(ctx, reg.Identity.ID, req.AccountID, req.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load registered code agent: %w", err)
+		}
+	case errors.Is(err, ErrIdentityAlreadyExists):
+		// The deterministic external_id is held by an ACTIVE (usable) identity:
+		// a re-bootstrap from a machine whose agent still exists.
+		existing, gerr := s.identitySvc.GetIdentityByExternalID(ctx, baseExternalID, req.AccountID, req.ProjectID)
+		if gerr != nil {
+			return nil, fmt.Errorf("failed to load existing code agent for re-bootstrap: %w", gerr)
+		}
+		if existing.OwnerUserID != req.OwnerUserID {
+			// Not this developer's agent — surface the original conflict (409).
+			return nil, err
+		}
+		if !existing.Status.IsUsable() {
+			// Suspended (not deactivated — that path is handled below). Fail
+			// closed: an operator must resolve the suspension.
+			return nil, fmt.Errorf("%w (status: %s)", domain.ErrIdentityNotUsable, existing.Status)
+		}
+		if existing.PublicKeyPEM != "" {
+			// A custody key is already enrolled. Overwriting it from a bootstrap
+			// token would let a stolen developer session swap the key of an
+			// ESTABLISHED identity and impersonate the agent — the escalation
+			// INV-IDN-004 forbids (an enrolled key rotates only via
+			// proof-of-possession or admin authority, never a bearer token).
+			// Refuse. Recovery: rotate via the countersigned PoP flow, or
+			// revoke-by-machine then re-bootstrap (mints a fresh identity below).
+			return nil, ErrCodeAgentAlreadyBootstrapped
+		}
+		// No key was ever enrolled — the trust-on-first-use window is still
+		// open, so first-set is legitimate (this is enrolment, not rotation).
+		identity, gerr = s.identitySvc.SetPublicKey(ctx, existing.ID, req.AccountID, req.ProjectID, req.PublicKeyPEM)
+		if gerr != nil {
+			return nil, fmt.Errorf("failed to set code agent custody key: %w", gerr)
+		}
+	case errors.As(err, &deactErr):
+		// The deterministic external_id belongs to a DEACTIVATED identity — its
+		// machine was revoked (lost/decommissioned laptop). Recovery mints a
+		// BRAND-NEW identity under a fresh external_id; the revoked row stays
+		// revoked so the retired agent's audit lineage is preserved and nothing
+		// resurrects it.
+		freshExternalID := baseExternalID + "-" + randomExternalIDSuffix()
+		reg, err = register(freshExternalID)
+		if err != nil {
+			return nil, fmt.Errorf("re-bootstrap after machine revoke: %w", err)
+		}
+		identity, err = s.identitySvc.GetIdentity(ctx, reg.Identity.ID, req.AccountID, req.ProjectID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load re-bootstrapped code agent: %w", err)
+		}
+		log.Info().
+			Str("identity_id", identity.ID).
+			Str("external_id", freshExternalID).
+			Str("machine_id", req.MachineID).
+			Msg("Code agent re-bootstrapped after revoke (fresh identity)")
+	default:
+		return nil, err
+	}
+
+	// Stamp the bootstrap columns. Bootstrap counts as the first attestation
+	// (the developer token vouches for the machine at this instant).
+	now := time.Now()
+	if err := s.identitySvc.repo.SetBootstrapInfo(ctx, identity.ID, req.AccountID, req.ProjectID, req.MachineID, now); err != nil {
+		return nil, fmt.Errorf("failed to record bootstrap machine: %w", err)
+	}
+	identity.BootstrapMachineID = req.MachineID
+	identity.LastAttestedAt = &now
+
+	// Mint the first access token. GrantType jwt_bearer: that is the grant
+	// this agent will use for every subsequent self-served token, so the
+	// first token is governed by the same policy axis (and the identity
+	// policy is resolved + enforced at the chokepoint).
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+		Identity:              identity,
+		GrantType:             domain.GrantTypeJWTBearer,
+		ResolveIdentityPolicy: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to issue first code-agent token: %w", err)
+	}
+
+	log.Info().
+		Str("identity_id", identity.ID).
+		Str("external_id", identity.ExternalID).
+		Str("machine_id", req.MachineID).
+		Str("owner_user_id", req.OwnerUserID).
+		Str("framework", req.Framework).
+		Msg("Code agent bootstrapped")
+
+	return &CodeAgentBootstrapResponse{
+		Identity:    identityToAgentResponse(identity, s.getKeyPrefix(ctx, identity.ID)),
+		WIMSEURI:    identity.WIMSEURI,
+		AccessToken: accessToken,
+	}, nil
+}
+
+// RecordCodeAgentAttestation refreshes the agent's attestation state:
+// last_attested_at = now plus the caller-supplied evidence document (opaque
+// JSON). Tenant-scoped. Returns the attestation timestamp.
+func (s *AgentService) RecordCodeAgentAttestation(ctx context.Context, identityID, accountID, projectID string, evidence json.RawMessage) (time.Time, error) {
+	if len(evidence) == 0 {
+		evidence = json.RawMessage("{}")
+	}
+	now := time.Now()
+	if err := s.identitySvc.repo.RecordAttestation(ctx, identityID, accountID, projectID, evidence, now); err != nil {
+		return time.Time{}, err
+	}
+	return now, nil
+}
+
+// RevokeCodeAgentsByMachine deactivates every ACTIVE code agent bootstrapped
+// from the given machine (optionally narrowed to one owner) — the
+// lost/compromised-laptop response. Each agent goes through
+// DeactivateIdentity, so the full cascade runs per agent: API keys swept,
+// active credentials revoked, retirement CAE signal emitted. Returns the
+// number of agents revoked; on a mid-sweep failure the count reflects the
+// agents already revoked before the error.
+func (s *AgentService) RevokeCodeAgentsByMachine(ctx context.Context, accountID, projectID, machineID, ownerUserID string) (int, error) {
+	identities, err := s.identitySvc.repo.ListActiveByBootstrapMachine(ctx, accountID, projectID, machineID, ownerUserID)
+	if err != nil {
+		return 0, err
+	}
+	revoked := 0
+	for _, identity := range identities {
+		if _, err := s.identitySvc.DeactivateIdentity(ctx, identity.ID, accountID, projectID); err != nil {
+			return revoked, fmt.Errorf("failed to revoke code agent %s: %w", identity.ID, err)
+		}
+		revoked++
+	}
+	log.Info().
+		Str("machine_id", machineID).
+		Str("owner_user_id", ownerUserID).
+		Int("revoked", revoked).
+		Msg("Code agents revoked by machine")
+	return revoked, nil
+}
+
+// ListCodeAgentsByDeveloper returns every bootstrapped code agent owned by
+// the given developer (all statuses — revoked agents stay visible in the
+// developer's history).
+func (s *AgentService) ListCodeAgentsByDeveloper(ctx context.Context, accountID, projectID, userID string) ([]AgentResponse, error) {
+	identities, err := s.identitySvc.repo.ListBootstrappedByOwner(ctx, accountID, projectID, userID)
+	if err != nil {
+		return nil, err
+	}
+	agents := make([]AgentResponse, len(identities))
+	for i, identity := range identities {
+		agents[i] = identityToAgentResponse(identity, s.getKeyPrefix(ctx, identity.ID))
+	}
+	return agents, nil
+}

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -467,6 +467,114 @@ func (r *IdentityRepository) DeactivateStaleDiscovered(ctx context.Context, acco
 	return int(n), nil
 }
 
+// SetBootstrapInfo stamps the code-agent bootstrap columns (migration 038):
+// the developer machine the agent's custody key lives on plus the initial
+// attestation timestamp (bootstrap counts as the first attestation). Tenant-
+// scoped; returns a not-found error when no row matched so the service layer
+// can surface a 404 instead of silently succeeding.
+func (r *IdentityRepository) SetBootstrapInfo(ctx context.Context, id, accountID, projectID, machineID string, attestedAt time.Time) error {
+	db := dbOrTx(ctx, r.db)
+	q := db.NewUpdate().
+		TableExpr("identities").
+		Set("bootstrap_machine_id = ?", machineID).
+		Set("last_attested_at = ?", attestedAt).
+		Set("updated_at = ?", time.Now())
+	if callerID := middleware.GetCallerName(ctx); callerID != "" {
+		q = q.Set("modified_by = ?", callerID)
+	}
+	res, err := q.
+		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to set bootstrap info: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("set bootstrap info rows: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("identity %s not found", id)
+	}
+	return nil
+}
+
+// RecordAttestation refreshes a code agent's attestation state: bumps
+// last_attested_at and replaces attestation_evidence with the latest
+// evidence document (opaque JSON — ZeroID stores it, policy elsewhere
+// decides on staleness). Tenant-scoped; 0 rows matched is a not-found error
+// so the handler can 404.
+func (r *IdentityRepository) RecordAttestation(ctx context.Context, id, accountID, projectID string, evidence json.RawMessage, attestedAt time.Time) error {
+	db := dbOrTx(ctx, r.db)
+	q := db.NewUpdate().
+		TableExpr("identities").
+		Set("last_attested_at = ?", attestedAt).
+		Set("attestation_evidence = ?::jsonb", string(evidence)).
+		Set("updated_at = ?", time.Now())
+	if callerID := middleware.GetCallerName(ctx); callerID != "" {
+		q = q.Set("modified_by = ?", callerID)
+	}
+	res, err := q.
+		Where("id = ?", id).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to record attestation: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("record attestation rows: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("identity %s not found", id)
+	}
+	return nil
+}
+
+// ListActiveByBootstrapMachine returns the ACTIVE code agents bootstrapped
+// from the given machine, optionally narrowed to one owner. Backs
+// revoke-by-machine (lost/compromised laptop → deactivate everything it
+// spawned); the partial idx_identities_bootstrap_machine index keeps the
+// scan O(code-agent-rows).
+func (r *IdentityRepository) ListActiveByBootstrapMachine(ctx context.Context, accountID, projectID, machineID, ownerUserID string) ([]*domain.Identity, error) {
+	var identities []*domain.Identity
+	db := dbOrTx(ctx, r.db)
+	q := db.NewSelect().Model(&identities).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("bootstrap_machine_id = ?", machineID).
+		Where("status = ?", string(domain.IdentityStatusActive))
+	if ownerUserID != "" {
+		q = q.Where("owner_user_id = ?", ownerUserID)
+	}
+	if err := q.OrderExpr("created_at DESC").Scan(ctx); err != nil {
+		return nil, fmt.Errorf("failed to list identities by bootstrap machine: %w", err)
+	}
+	return identities, nil
+}
+
+// ListBootstrappedByOwner returns every bootstrapped code agent (agent-type
+// identity with a bootstrap_machine_id) owned by the given developer — the
+// "my code agents" inventory view. All statuses are returned so revoked
+// agents remain visible in the developer's history.
+func (r *IdentityRepository) ListBootstrappedByOwner(ctx context.Context, accountID, projectID, ownerUserID string) ([]*domain.Identity, error) {
+	var identities []*domain.Identity
+	db := dbOrTx(ctx, r.db)
+	if err := db.NewSelect().Model(&identities).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("owner_user_id = ?", ownerUserID).
+		Where("identity_type = ?", string(domain.IdentityTypeAgent)).
+		Where("bootstrap_machine_id IS NOT NULL").
+		OrderExpr("created_at DESC").
+		Scan(ctx); err != nil {
+		return nil, fmt.Errorf("failed to list bootstrapped identities by owner: %w", err)
+	}
+	return identities, nil
+}
+
 // ListExpiredActive returns identities whose expires_at has passed while
 // their status is still 'active'. Used by the cleanup worker's identity
 // sweep. The partial index on (expires_at) WHERE status='active' makes

--- a/migrations/038_code_agent_bootstrap.down.sql
+++ b/migrations/038_code_agent_bootstrap.down.sql
@@ -1,0 +1,13 @@
+-- Revert 038: drop the code-agent bootstrap constraint, index + columns.
+-- Dropping the column also drops the partial index and CHECK, but the
+-- explicit statements keep the intent clear.
+--
+-- Ordering: roll back the DEPLOYMENT first — post-038 binaries name these
+-- columns in every identities SELECT (bun explicit column lists), so running
+-- this down under new code breaks the whole auth plane, not just /code-agents.
+ALTER TABLE identities DROP CONSTRAINT IF EXISTS identities_bootstrap_machine_id_not_empty;
+DROP INDEX IF EXISTS idx_identities_bootstrap_machine;
+
+ALTER TABLE identities DROP COLUMN IF EXISTS bootstrap_machine_id;
+ALTER TABLE identities DROP COLUMN IF EXISTS last_attested_at;
+ALTER TABLE identities DROP COLUMN IF EXISTS attestation_evidence;

--- a/migrations/038_code_agent_bootstrap.up.sql
+++ b/migrations/038_code_agent_bootstrap.up.sql
@@ -1,0 +1,40 @@
+-- 038: code-agent bootstrap — columns supporting per-machine registration of
+-- developer-workstation code agents (highflame-architecture#136, epic #132 S3).
+--
+-- A code agent (Claude Code, Cursor, ...) bootstraps from a developer machine
+-- with a zeroid:bootstrap-scoped token: registration records WHICH machine the
+-- agent's custody key lives on (`bootstrap_machine_id`), so operators can
+-- revoke every agent from a lost/compromised laptop in one call
+-- (revoke-by-machine). `last_attested_at` + `attestation_evidence` track
+-- attestation freshness: the agent periodically re-attests its runtime
+-- environment and policy can later gate on staleness.
+--
+-- Additive-only; no backfill needed — NULL bootstrap_machine_id simply means
+-- "not a bootstrapped code agent" (every pre-existing row).
+--
+-- identities is on every auth path and the whole file runs as one implicit
+-- transaction (simple query protocol), so the ALTER's AccessExclusiveLock is
+-- held through the index build. Fail fast rather than queueing the auth plane
+-- behind a long-running query.
+-- SET LOCAL: scoped to this file's implicit transaction, so the timeout does
+-- not leak onto the migration connection for later files.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE identities ADD COLUMN IF NOT EXISTS bootstrap_machine_id VARCHAR(255);
+ALTER TABLE identities ADD COLUMN IF NOT EXISTS last_attested_at TIMESTAMPTZ;
+ALTER TABLE identities ADD COLUMN IF NOT EXISTS attestation_evidence JSONB;
+
+-- Revoke-by-machine and per-machine listing filter on (account_id,
+-- bootstrap_machine_id). Partial: only bootstrapped code agents carry a
+-- machine id, so the index stays O(code-agent-rows), not O(all-identities).
+CREATE INDEX IF NOT EXISTS idx_identities_bootstrap_machine ON identities (account_id, bootstrap_machine_id) WHERE bootstrap_machine_id IS NOT NULL;
+
+-- Structural guard for the partial index's IS NOT NULL semantics: the model's
+-- nullzero tag maps empty Go strings to NULL, but one service-layer UPDATE
+-- writes the column raw — make "empty string" impossible at the schema level
+-- so a missed validation can never plant a row that matches machine listings.
+-- NULL passes the CHECK (NULL <> '' is not false). NOT VALID skips the
+-- validation scan entirely — every pre-038 row is NULL for this column, so
+-- validation would be vacuous, and new writes are checked regardless.
+ALTER TABLE identities ADD CONSTRAINT identities_bootstrap_machine_id_not_empty
+    CHECK (bootstrap_machine_id <> '') NOT VALID;

--- a/server.go
+++ b/server.go
@@ -301,7 +301,7 @@ func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
 	// Created before AgentService so depths can be included in agent list responses.
 	delegationSvc := service.NewDelegationService(credentialRepo, delegationRepo, identityRepo)
 
-	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo, postgres.NewDPoPReplayStore(db), cfg.Token.Issuer, delegationSvc)
+	agentSvc := service.NewAgentService(identitySvc, apiKeySvc, apiKeyRepo, postgres.NewDPoPReplayStore(db), cfg.Token.Issuer, delegationSvc, credentialSvc)
 
 	// BackchannelService (CIBA) is constructed after oauthSvc/credentialSvc and
 	// then wired back into oauthSvc.SetBackchannelService — the CIBA grant
@@ -400,13 +400,35 @@ func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
 	// Agent self-service group — authenticated by the agent's OWN access token
 	// (NOT the admin/internal secret) and mounted on the public router so agents
 	// can reach it directly on the public ingress. Tenant + identity come from the
-	// validated token claims (never headers). Holds POST /agents/self/public-key.
+	// validated token claims (never headers). Holds POST /agents/self/public-key
+	// and POST /code-agents/{id}/attest.
 	r.Group(func(r chi.Router) {
 		r.Use(internalMiddleware.AgentAuthMiddleware(agentAuthCfg))
 		// Specless: this group shares the root router with RegisterPublic, so it
 		// must not register a second /openapi.json that would shadow the canonical
 		// public spec.
 		apiHandler.RegisterAgentSelfService(handler.NewHumaAPISpecless(r))
+	})
+
+	// Code-agent bootstrap group — authenticated by a zeroid:bootstrap-scoped
+	// developer token (BootstrapAuthMiddleware) and mounted on the public router
+	// so a code agent on a developer machine can reach it on the public ingress.
+	// Tenant + owner come from the validated token claims (never the body).
+	// Holds POST /code-agents/bootstrap. RS256 fallback covers the PKCE-minted
+	// developer token (authorization_code issues RS256); deployments without
+	// RSA keys simply accept ES256 bootstrap tokens only.
+	bootstrapAuthCfg := internalMiddleware.BootstrapAuthConfig{
+		ECPublicKey:         jwksSvc.PublicKey(),
+		Issuer:              cfg.Token.Issuer,
+		ResourceMetadataURL: cfg.Token.Issuer + "/.well-known/oauth-protected-resource",
+	}
+	if jwksSvc.HasRSAKeys() {
+		bootstrapAuthCfg.RSAPublicKey = jwksSvc.RSAPublicKey()
+	}
+	r.Group(func(r chi.Router) {
+		r.Use(internalMiddleware.BootstrapAuthMiddleware(bootstrapAuthCfg))
+		// Specless for the same reason as the self-service group above.
+		apiHandler.RegisterCodeAgentBootstrap(handler.NewHumaAPISpecless(r))
 	})
 
 	// Admin routes — mounted under AdminPathPrefix (default "/api/v1").

--- a/tests/integration/code_agent_bootstrap_test.go
+++ b/tests/integration/code_agent_bootstrap_test.go
@@ -1,0 +1,410 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"database/sql"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Code-agent bootstrap integration tests (highflame-architecture#136, epic
+// #132 slice S3): a code agent on a developer machine registers itself with a
+// zeroid:bootstrap-scoped developer token + locally generated EC P-256
+// custody key, receives identity + first token, self-serves subsequent
+// tokens via jwt_bearer, periodically attests, and is revocable by machine.
+
+// mintBootstrapToken mints a developer bootstrap token through the PKCE
+// authorization_code flow — the real path a `zeroid login`-style CLI uses.
+// The resulting access token is RS256 with sub = userID and carries the given
+// scopes, exercising BootstrapAuthMiddleware's RS256 fallback.
+func mintBootstrapToken(t *testing.T, userID string, scopes []string) string {
+	t.Helper()
+	verifier, challenge := buildPKCEPair(t)
+	code := buildAuthCode(t, testCLIClientID, userID, testRedirectURI, challenge, scopes)
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     testCLIClientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "bootstrap token mint: expected 200")
+	return decode(t, resp)["access_token"].(string)
+}
+
+// bootstrappedCodeAgent bundles everything a bootstrap call returns plus the
+// custody key the "machine" generated.
+type bootstrappedCodeAgent struct {
+	IdentityID  string
+	WIMSEURI    string
+	AccessToken string
+	Key         *ecdsa.PrivateKey
+	MachineID   string
+}
+
+// bootstrapCodeAgent generates a custody keypair and registers a code agent
+// via POST /code-agents/bootstrap, asserting the 201 happy path.
+func bootstrapCodeAgent(t *testing.T, bootstrapToken, framework, machineID string) bootstrappedCodeAgent {
+	t.Helper()
+	key := generateKey(t)
+	resp := post(t, "/code-agents/bootstrap", map[string]any{
+		"public_key_pem": ecPublicKeyPEM(t, key),
+		"framework":      framework,
+		"machine_id":     machineID,
+	}, map[string]string{"Authorization": "Bearer " + bootstrapToken})
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "bootstrap: expected 201")
+	body := decode(t, resp)
+
+	identity := body["identity"].(map[string]any)
+	accessToken := body["access_token"].(map[string]any)
+	return bootstrappedCodeAgent{
+		IdentityID:  identity["id"].(string),
+		WIMSEURI:    body["wimse_uri"].(string),
+		AccessToken: accessToken["access_token"].(string),
+		Key:         key,
+		MachineID:   machineID,
+	}
+}
+
+// codeAgentBootstrapRow reads the migration-038 columns for one identity
+// directly from the database.
+type codeAgentBootstrapRow struct {
+	OwnerUserID         string
+	BootstrapMachineID  sql.NullString
+	LastAttestedAt      sql.NullTime
+	AttestationEvidence sql.NullString
+	Status              string
+}
+
+func fetchBootstrapRow(t *testing.T, identityID string) codeAgentBootstrapRow {
+	t.Helper()
+	var row codeAgentBootstrapRow
+	err := testDB.NewSelect().
+		TableExpr("identities").
+		ColumnExpr("owner_user_id, bootstrap_machine_id, last_attested_at, attestation_evidence, status").
+		Where("id = ?", identityID).
+		Scan(context.Background(), &row.OwnerUserID, &row.BootstrapMachineID, &row.LastAttestedAt, &row.AttestationEvidence, &row.Status)
+	require.NoError(t, err)
+	return row
+}
+
+// TestCodeAgentBootstrap_HappyPath: PKCE developer token → bootstrap → 201
+// with a spiffe:// identity, persisted machine binding, owner = token sub,
+// and a first access token that is a valid ES256 ZeroID JWT for the agent.
+func TestCodeAgentBootstrap_HappyPath(t *testing.T) {
+	developer := uid("dev-boot")
+	token := mintBootstrapToken(t, developer, []string{"zeroid:bootstrap"})
+
+	agent := bootstrapCodeAgent(t, token, "claude-code", uid("machine"))
+
+	assert.True(t, strings.HasPrefix(agent.WIMSEURI, "spiffe://"), "wimse_uri must be a SPIFFE ID, got %q", agent.WIMSEURI)
+
+	// DB row: machine binding + ownership from the token, never the body.
+	row := fetchBootstrapRow(t, agent.IdentityID)
+	require.True(t, row.BootstrapMachineID.Valid)
+	assert.Equal(t, agent.MachineID, row.BootstrapMachineID.String)
+	assert.Equal(t, developer, row.OwnerUserID, "owner_user_id must be the bootstrap token's sub")
+	require.True(t, row.LastAttestedAt.Valid, "bootstrap counts as the first attestation")
+
+	// First token: ES256, signed by this server, sub = the agent's WIMSE URI.
+	parsed, err := jwt.Parse([]byte(agent.AccessToken),
+		jwt.WithKey(jwa.ES256(), &testServerPrivKey.PublicKey),
+		jwt.WithValidate(true),
+		jwt.WithIssuer(testIssuer),
+	)
+	require.NoError(t, err, "first access token must be a valid ES256 ZeroID JWT")
+	sub, _ := parsed.Subject()
+	assert.Equal(t, agent.WIMSEURI, sub)
+}
+
+// TestCodeAgentBootstrap_ES256ClientCredentialsTokenAccepted covers the
+// middleware's primary ES256 branch: a client_credentials-minted token
+// carrying zeroid:bootstrap also authorizes bootstrap (sub is the client
+// identity's WIMSE URI, which simply becomes the owner id).
+func TestCodeAgentBootstrap_ES256ClientCredentialsTokenAccepted(t *testing.T) {
+	extID := uid("boot-cc-client")
+	registerIdentity(t, extID, []string{"zeroid:bootstrap"})
+	client := registerOAuthClient(t, extID, []string{"zeroid:bootstrap"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "zeroid:bootstrap",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	ccToken := decode(t, resp)["access_token"].(string)
+
+	agent := bootstrapCodeAgent(t, ccToken, "claude-code", uid("machine-cc"))
+	row := fetchBootstrapRow(t, agent.IdentityID)
+	require.True(t, row.BootstrapMachineID.Valid)
+	assert.Equal(t, agent.MachineID, row.BootstrapMachineID.String)
+}
+
+// TestCodeAgentBootstrap_JWTBearerRoundTrip: after bootstrap the agent
+// self-serves its next token via jwt_bearer signed with the custody key —
+// and a single tampered signature byte flips the answer to invalid_grant.
+func TestCodeAgentBootstrap_JWTBearerRoundTrip(t *testing.T) {
+	token := mintBootstrapToken(t, uid("dev-jb"), []string{"zeroid:bootstrap"})
+	agent := bootstrapCodeAgent(t, token, "claude-code", uid("machine-jb"))
+
+	assertion := buildAssertion(t, agent.Key, agent.WIMSEURI)
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    assertion,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "jwt_bearer with the bootstrap custody key must succeed")
+	nextToken := decode(t, resp)["access_token"].(string)
+	require.NotEmpty(t, nextToken)
+	sub := decodeJWTUnsafe(t, nextToken)["sub"].(string)
+	assert.Equal(t, agent.WIMSEURI, sub)
+
+	// Tamper one byte of the assertion's signature → invalid_grant.
+	tampered := assertion[:len(assertion)-1] + flipLastByte(assertion)
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    tampered,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_grant", body["error"], "tampered assertion signature must be invalid_grant")
+}
+
+// TestCodeAgentBootstrap_MissingScopeForbidden: a perfectly valid ZeroID
+// token WITHOUT zeroid:bootstrap must be rejected with 403
+// insufficient_scope — ordinary access tokens can never register code agents.
+func TestCodeAgentBootstrap_MissingScopeForbidden(t *testing.T) {
+	token := mintBootstrapToken(t, uid("dev-noscope"), []string{"data:read"})
+
+	key := generateKey(t)
+	resp := post(t, "/code-agents/bootstrap", map[string]any{
+		"public_key_pem": ecPublicKeyPEM(t, key),
+		"framework":      "claude-code",
+		"machine_id":     uid("machine-noscope"),
+	}, map[string]string{"Authorization": "Bearer " + token})
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("WWW-Authenticate"), "insufficient_scope",
+		"403 must carry an RFC 6750 insufficient_scope challenge")
+	_ = resp.Body.Close()
+}
+
+// TestCodeAgentAttest: the agent refreshes its attestation with its OWN
+// access token; another agent's token is rejected with 403.
+func TestCodeAgentAttest(t *testing.T) {
+	token := mintBootstrapToken(t, uid("dev-attest"), []string{"zeroid:bootstrap"})
+	agentA := bootstrapCodeAgent(t, token, "claude-code", uid("machine-att-a"))
+	agentB := bootstrapCodeAgent(t, token, "claude-code", uid("machine-att-b"))
+
+	before := fetchBootstrapRow(t, agentA.IdentityID)
+	require.True(t, before.LastAttestedAt.Valid)
+
+	resp := post(t, "/code-agents/"+agentA.IdentityID+"/attest", map[string]any{
+		"evidence": map[string]any{"os": "darwin", "hostname_hash": "abc123"},
+	}, map[string]string{"Authorization": "Bearer " + agentA.AccessToken})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	require.NotEmpty(t, body["last_attested_at"])
+
+	after := fetchBootstrapRow(t, agentA.IdentityID)
+	require.True(t, after.LastAttestedAt.Valid)
+	assert.True(t, after.LastAttestedAt.Time.After(before.LastAttestedAt.Time),
+		"attest must bump last_attested_at past the bootstrap timestamp")
+	require.True(t, after.AttestationEvidence.Valid)
+	assert.Contains(t, after.AttestationEvidence.String, "darwin")
+
+	// Another agent's token must not attest agent A.
+	resp = post(t, "/code-agents/"+agentA.IdentityID+"/attest", map[string]any{
+		"evidence": map[string]any{"os": "linux"},
+	}, map[string]string{"Authorization": "Bearer " + agentB.AccessToken})
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	_ = resp.Body.Close()
+}
+
+// TestCodeAgentRevokeByMachine: the lost-laptop response — every agent
+// bootstrapped from the machine is deactivated in one admin call, and the
+// custody key stops working for jwt_bearer immediately.
+func TestCodeAgentRevokeByMachine(t *testing.T) {
+	token := mintBootstrapToken(t, uid("dev-revoke"), []string{"zeroid:bootstrap"})
+	machineID := uid("machine-rv")
+	agent := bootstrapCodeAgent(t, token, "claude-code", machineID)
+	// A second framework on the same machine — revoke must catch both.
+	agent2 := bootstrapCodeAgent(t, token, "cursor", machineID)
+
+	resp := post(t, adminPath("/code-agents/by-machine/"+machineID+"/revoke"),
+		map[string]any{}, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, float64(2), body["revoked"], "both agents on the machine must be revoked")
+
+	for _, id := range []string{agent.IdentityID, agent2.IdentityID} {
+		row := fetchBootstrapRow(t, id)
+		assert.Equal(t, "deactivated", row.Status)
+	}
+
+	// The custody key is dead: a fresh jwt_bearer assertion now fails.
+	assertion := buildAssertion(t, agent.Key, agent.WIMSEURI)
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    assertion,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	tokenBody := decode(t, resp)
+	assert.Equal(t, "invalid_grant", tokenBody["error"],
+		"a revoked code agent must not mint fresh tokens")
+
+	// Idempotent-ish: a second sweep finds nothing active.
+	resp = post(t, adminPath("/code-agents/by-machine/"+machineID+"/revoke"),
+		map[string]any{}, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, float64(0), decode(t, resp)["revoked"])
+}
+
+// TestCodeAgentRevokeByMachine_OwnerFilter: the optional owner_user_id filter
+// only revokes that developer's agents on the shared machine.
+func TestCodeAgentRevokeByMachine_OwnerFilter(t *testing.T) {
+	devA := uid("dev-shared-a")
+	devB := uid("dev-shared-b")
+	machineID := uid("machine-shared")
+	agentA := bootstrapCodeAgent(t, mintBootstrapToken(t, devA, []string{"zeroid:bootstrap"}), "claude-code", machineID)
+	agentB := bootstrapCodeAgent(t, mintBootstrapToken(t, devB, []string{"zeroid:bootstrap"}), "cursor", machineID)
+
+	resp := post(t, adminPath("/code-agents/by-machine/"+machineID+"/revoke"),
+		map[string]any{"owner_user_id": devA}, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, float64(1), decode(t, resp)["revoked"])
+
+	assert.Equal(t, "deactivated", fetchBootstrapRow(t, agentA.IdentityID).Status)
+	assert.Equal(t, "active", fetchBootstrapRow(t, agentB.IdentityID).Status,
+		"the other developer's agent on the same machine must stay active")
+}
+
+// TestCodeAgentListByDeveloper: the admin inventory view returns the
+// developer's bootstrapped agents (and only theirs).
+func TestCodeAgentListByDeveloper(t *testing.T) {
+	developer := uid("dev-list")
+	token := mintBootstrapToken(t, developer, []string{"zeroid:bootstrap"})
+	agent := bootstrapCodeAgent(t, token, "claude-code", uid("machine-ls"))
+
+	resp := get(t, adminPath("/code-agents/by-developer/"+developer), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	agents, ok := body["code_agents"].([]any)
+	require.True(t, ok, "response must carry a code_agents array")
+	require.Len(t, agents, 1)
+	got := agents[0].(map[string]any)
+	assert.Equal(t, agent.IdentityID, got["id"])
+	assert.Equal(t, developer, got["owner_user_id"])
+
+	// A developer with no agents gets an empty list, not an error.
+	resp = get(t, adminPath("/code-agents/by-developer/"+uid("dev-empty")), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	empty := decode(t, resp)
+	assert.Empty(t, empty["code_agents"])
+}
+
+// TestCodeAgentReBootstrap_SameOwnerWithEnrolledKeyConflicts: re-bootstrapping
+// the same (framework, machine) while its agent is still active and already
+// has a custody key MUST be refused (409), never a silent key swap — otherwise
+// a stolen bootstrap token could hijack an established identity (INV-IDN-004).
+// The original custody key keeps working; nothing is rotated.
+func TestCodeAgentReBootstrap_SameOwnerWithEnrolledKeyConflicts(t *testing.T) {
+	developer := uid("dev-reboot")
+	token := mintBootstrapToken(t, developer, []string{"zeroid:bootstrap"})
+	machineID := uid("machine-rb")
+
+	first := bootstrapCodeAgent(t, token, "claude-code", machineID)
+
+	// Second bootstrap for the same machine with a DIFFERENT key → 409.
+	newKey := generateKey(t)
+	resp := post(t, "/code-agents/bootstrap", map[string]any{
+		"public_key_pem": ecPublicKeyPEM(t, newKey),
+		"framework":      "claude-code",
+		"machine_id":     machineID,
+	}, map[string]string{"Authorization": "Bearer " + token})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode,
+		"re-bootstrap of an active agent with an enrolled key must be refused, not swap the key")
+	_ = resp.Body.Close()
+
+	// The ORIGINAL key still works — the refused re-bootstrap changed nothing.
+	assertion := buildAssertion(t, first.Key, first.WIMSEURI)
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    assertion,
+	}, nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"the original custody key must remain valid after a refused re-bootstrap")
+	_ = resp.Body.Close()
+}
+
+// TestCodeAgentReBootstrap_RevokedMachineCreatesFreshIdentity: the sanctioned
+// lost-laptop recovery. After revoke-by-machine, re-bootstrapping the same
+// machine mints a BRAND-NEW identity (new id + WIMSE URI); the revoked row
+// stays deactivated (audit lineage preserved) and its old key stays dead.
+func TestCodeAgentReBootstrap_RevokedMachineCreatesFreshIdentity(t *testing.T) {
+	developer := uid("dev-recover")
+	token := mintBootstrapToken(t, developer, []string{"zeroid:bootstrap"})
+	machineID := uid("machine-recover")
+
+	first := bootstrapCodeAgent(t, token, "claude-code", machineID)
+
+	// Lost laptop → revoke the machine.
+	resp := post(t, adminPath("/code-agents/by-machine/"+machineID+"/revoke"),
+		map[string]any{}, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, float64(1), decode(t, resp)["revoked"])
+
+	// Re-bootstrap now succeeds with a fresh identity (not the revoked one).
+	second := bootstrapCodeAgent(t, token, "claude-code", machineID)
+	assert.NotEqual(t, first.IdentityID, second.IdentityID,
+		"recovery must mint a NEW identity, not reuse the revoked one")
+	assert.NotEqual(t, first.WIMSEURI, second.WIMSEURI,
+		"the fresh identity must carry its own WIMSE URI")
+
+	// The revoked identity stays deactivated and its key stays dead.
+	assert.Equal(t, "deactivated", fetchBootstrapRow(t, first.IdentityID).Status)
+	oldAssertion := buildAssertion(t, first.Key, first.WIMSEURI)
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    oldAssertion,
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"the revoked identity's key must stay dead")
+	_ = resp.Body.Close()
+
+	// The fresh identity's new key works.
+	newAssertion := buildAssertion(t, second.Key, second.WIMSEURI)
+	resp = post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"subject":    newAssertion,
+	}, nil)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "the fresh identity's key must work")
+	_ = resp.Body.Close()
+}
+
+// TestCodeAgentReBootstrap_DifferentOwnerConflicts: another developer cannot
+// take over an existing machine registration — the deterministic external_id
+// collision surfaces as 409 rather than a silent key swap.
+func TestCodeAgentReBootstrap_DifferentOwnerConflicts(t *testing.T) {
+	machineID := uid("machine-steal")
+	bootstrapCodeAgent(t, mintBootstrapToken(t, uid("dev-victim"), []string{"zeroid:bootstrap"}), "claude-code", machineID)
+
+	thief := mintBootstrapToken(t, uid("dev-thief"), []string{"zeroid:bootstrap"})
+	key := generateKey(t)
+	resp := post(t, "/code-agents/bootstrap", map[string]any{
+		"public_key_pem": ecPublicKeyPEM(t, key),
+		"framework":      "claude-code",
+		"machine_id":     machineID,
+	}, map[string]string{"Authorization": "Bearer " + thief})
+	assert.Equal(t, http.StatusConflict, resp.StatusCode,
+		"another developer must not be able to take over an existing machine registration")
+	_ = resp.Body.Close()
+}


### PR DESCRIPTION
Part of highflame-ai/highflame-architecture#136 (T3) + #143 (B2 verification), epic #132 slice S3.

## Summary
- **Bootstrap flow**: `POST /code-agents/bootstrap` (behind `BootstrapAuthMiddleware`, a `zeroid:bootstrap`-scoped token gate) registers an `identity_type=agent` identity from a developer machine and mints its first `jwt_bearer` token. Plus `/{id}/attest`, `by-machine/{id}/revoke`, `by-developer/{id}`.
- **Migration 038**: `bootstrap_machine_id` / `last_attested_at` / `attestation_evidence` + partial index; `SET LOCAL lock_timeout` and an empty-machine `CHECK`.
- **Re-bootstrap is INV-IDN-004-safe**: a bootstrap token NEVER silently swaps an enrolled custody key. Active agent with a key → **409** (rotate via proof-of-possession, or revoke-by-machine first). Revoked machine → recovery mints a **fresh identity** (old row stays deactivated). First-set allowed only while no key is enrolled (TOFU).
- **B2**: DPoP already lives in `pkg/dpop` and `token_exchange` already issues `cnf.jkt`-bound credentials on main — verified (61 pkg/dpop unit + 27 DPoP/RFC 9449 integration tests pass). No new code needed; authn consumes via the zeroid module.

## ⚠️ Merge order
Merge **after #225** (migration 037). golang-migrate applies strictly-increasing versions, so 037 must land before 038 or it would be skipped. (See #225 review thread.)

## Test plan
- [x] `tests/integration/code_agent_bootstrap_test.go` — 11 tests incl. bootstrap happy-path, jwt_bearer round-trip + tamper, missing-scope 403, attest + foreign-token 403, revoke-by-machine, by-developer, and the three re-bootstrap cases (active+key→409, revoked→fresh identity, foreign-owner→409)
- [x] Full suite green under `GOEXPERIMENT=jsonv2` (unit + integration, 44s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)