### PR TITLE
feat: dismiss from pending reverts identity to discovered

### DIFF
--- a/domain/identity.go
+++ b/domain/identity.go
@@ -246,7 +246,8 @@ func (s IdentityStatus) CanTransitionTo(target IdentityStatus) bool {
 		// service layer, not here (this method is pure status topology).
 		return target == IdentityStatusPending || target == IdentityStatusActive || target == IdentityStatusDeactivated
 	case IdentityStatusPending:
-		return target == IdentityStatusActive || target == IdentityStatusDeactivated
+		// activate (→active), dismiss (→discovered, reverts adoption), deactivate (→deactivated).
+		return target == IdentityStatusActive || target == IdentityStatusDiscovered || target == IdentityStatusDeactivated
 	case IdentityStatusActive:
 		return target == IdentityStatusSuspended || target == IdentityStatusDeactivated || target == IdentityStatusExpired
 	case IdentityStatusSuspended:

--- a/domain/identity.go
+++ b/domain/identity.go
@@ -209,9 +209,10 @@ func CanRetypeDiscovered(status IdentityStatus, curType, newType IdentityType, n
 //	                    → deactivated (terminal-ish — reactivatable)
 //	                    → expired (time-bound authority lapsed)
 //	pending    → deactivated (registration rejected)
+//	pending    → discovered (dismiss reverts adoption — agent returns to adoption inbox)
 //
-// `discovered` is an *entry-only* state: discovery writes it at ingestion and
-// nothing transitions back into it. ISO mapping (24760 → ours):
+// `discovered` is the normal entry state but can also be re-entered from `pending`
+// when an adoption is reverted (dismiss). ISO mapping (24760 → ours):
 // Established=pending, Active=active, Suspended=suspended, Archived=deactivated/expired.
 type IdentityStatus string
 

--- a/domain/identity_discovery_test.go
+++ b/domain/identity_discovery_test.go
@@ -26,8 +26,8 @@ func TestIdentityStatusDiscovered_IsUsable(t *testing.T) {
 
 // TestCanTransitionTo_Discovered pins the discovered state machine: adopt
 // (→pending), direct activation (→active), and dismiss (→deactivated) are the
-// only legal moves out, and `discovered` is entry-only — nothing transitions
-// into it.
+// primary moves out. Dismiss from pending (→discovered) is also legal — it
+// reverts an adoption so the agent reappears in the adoption inbox.
 func TestCanTransitionTo_Discovered(t *testing.T) {
 	tests := []struct {
 		from   IdentityStatus
@@ -42,8 +42,8 @@ func TestCanTransitionTo_Discovered(t *testing.T) {
 		{IdentityStatusDiscovered, IdentityStatusSuspended, false},
 		{IdentityStatusDiscovered, IdentityStatusExpired, false},
 		{IdentityStatusDiscovered, IdentityStatusDiscovered, false},
-		// Into discovered — entry-only, never reachable by transition.
-		{IdentityStatusPending, IdentityStatusDiscovered, false},
+		// Into discovered — only pending can revert to discovered (dismiss from pending).
+		{IdentityStatusPending, IdentityStatusDiscovered, true},
 		{IdentityStatusActive, IdentityStatusDiscovered, false},
 		{IdentityStatusSuspended, IdentityStatusDiscovered, false},
 		{IdentityStatusDeactivated, IdentityStatusDiscovered, false},

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -1028,12 +1028,20 @@ func (s *IdentityService) DismissIdentity(ctx context.Context, id, accountID, pr
 		return s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
 	}
 	if identity.Status == domain.IdentityStatusPending {
-		// Revert the adoption: clear owner and credential policy, move back to discovered.
-		// UpdateIdentity cannot clear OwnerUserID (empty string is a no-op there), so
-		// we modify the domain struct directly and persist via the repo.
+		// Revert the adoption: clear owner, restore the tenant default credential
+		// policy, and move back to discovered. Every discovered identity has the
+		// tenant default policy from birth (set by resolveIdentityPolicyID at
+		// ingest), so we restore that rather than clearing to NULL — which would
+		// produce a state that normal ingest never creates.
+		// UpdateIdentity cannot clear OwnerUserID (empty string is a no-op there),
+		// so we modify the domain struct directly and persist via the repo.
+		defaultPolicyID, err := s.resolveIdentityPolicyID(ctx, identity.AccountID, identity.ProjectID, "")
+		if err != nil {
+			return nil, fmt.Errorf("resolve default policy on dismiss: %w", err)
+		}
 		identity.Status = domain.IdentityStatusDiscovered
 		identity.OwnerUserID = ""
-		identity.CredentialPolicyID = ""
+		identity.CredentialPolicyID = defaultPolicyID
 		identity.UpdatedAt = time.Now()
 		if err := s.repo.Update(ctx, identity); err != nil {
 			return nil, err

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -1003,15 +1003,18 @@ func (s *IdentityService) AdoptIdentity(ctx context.Context, id, accountID, proj
 	return s.UpdateIdentity(ctx, id, accountID, projectID, req)
 }
 
-// DismissIdentity dismisses a discovered identity (discovered → deactivated):
-// an operator marks an externally-observed agent out of scope. The row is
-// archived (audit-retained, never hard-deleted) per the offboarding obligation.
-// A discovered identity holds no credential, so the shared deactivation cleanup
-// finds nothing to revoke and only emits the lifecycle CAE signal.
+// DismissIdentity handles two dismiss paths:
+//
+//   - discovered → deactivated: an operator marks an externally-observed agent
+//     out of scope. The row is archived (audit-retained, never hard-deleted).
+//
+//   - pending → discovered: an operator reverts an adoption. The owner and
+//     credential policy are cleared and the identity returns to the adoption
+//     inbox so it can be re-adopted or dismissed later.
 //
 // Idempotent: an already-dismissed (deactivated) identity is a no-op success.
-// Only a discovered identity can be dismissed; deactivating a live identity is
-// DeactivateIdentity's job, not this one.
+// Active, suspended, or expired identities cannot be dismissed — use
+// DeactivateIdentity for those.
 func (s *IdentityService) DismissIdentity(ctx context.Context, id, accountID, projectID string) (*domain.Identity, error) {
 	identity, err := s.repo.GetByID(ctx, id, accountID, projectID)
 	if err != nil {
@@ -1020,11 +1023,24 @@ func (s *IdentityService) DismissIdentity(ctx context.Context, id, accountID, pr
 	if identity.Status == domain.IdentityStatusDeactivated {
 		return identity, nil
 	}
-	if identity.Status != domain.IdentityStatusDiscovered {
-		return nil, fmt.Errorf("%w: only a discovered identity can be dismissed (status=%s); use delete to deactivate a live identity", ErrInvalidIdentityField, identity.Status)
+	if identity.Status == domain.IdentityStatusDiscovered {
+		status := domain.IdentityStatusDeactivated
+		return s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
 	}
-	status := domain.IdentityStatusDeactivated
-	return s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
+	if identity.Status == domain.IdentityStatusPending {
+		// Revert the adoption: clear owner and credential policy, move back to discovered.
+		// UpdateIdentity cannot clear OwnerUserID (empty string is a no-op there), so
+		// we modify the domain struct directly and persist via the repo.
+		identity.Status = domain.IdentityStatusDiscovered
+		identity.OwnerUserID = ""
+		identity.CredentialPolicyID = ""
+		identity.UpdatedAt = time.Now()
+		if err := s.repo.Update(ctx, identity); err != nil {
+			return nil, err
+		}
+		return identity, nil
+	}
+	return nil, fmt.Errorf("%w: dismiss is only valid for discovered or pending identities (status=%s); use delete to deactivate a live identity", ErrInvalidIdentityField, identity.Status)
 }
 
 // runDeactivationCleanup sweeps everything a deactivated or deleted identity

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -1027,7 +1027,7 @@ func (s *IdentityService) DismissIdentity(ctx context.Context, id, accountID, pr
 		status := domain.IdentityStatusDeactivated
 		return s.UpdateIdentity(ctx, id, accountID, projectID, UpdateIdentityRequest{Status: &status})
 	}
-	if identity.Status == domain.IdentityStatusPending {
+	if identity.Status.CanTransitionTo(domain.IdentityStatusDiscovered) {
 		// Revert the adoption: clear owner, restore the tenant default credential
 		// policy, and move back to discovered. Every discovered identity has the
 		// tenant default policy from birth (set by resolveIdentityPolicyID at

--- a/tests/integration/discovery_lifecycle_test.go
+++ b/tests/integration/discovery_lifecycle_test.go
@@ -287,6 +287,188 @@ func TestPending_DismissRevertsToDiscovered(t *testing.T) {
 	}(), "dismissed-from-pending identity must reappear in the adoption inbox")
 }
 
+// TestPending_DismissRestoresExactDiscoveredState verifies that after dismiss
+// from pending, every field matches the state of a freshly ingested discovered
+// identity: status=discovered, owner cleared, credential_policy_id = tenant
+// default (not NULL), wimse_uri/origin/external_id all unchanged.
+func TestPending_DismissRestoresExactDiscoveredState(t *testing.T) {
+	ext := uid("dismiss-state-check")
+	out := ingestDiscovered(t, map[string]any{"external_id": ext, "origin": "okta"})
+	ingestedIdentity := out["identity"].(map[string]any)
+	id := ingestedIdentity["id"].(string)
+
+	// Capture the fields that must survive the adopt→dismiss round-trip unchanged.
+	ingestedPolicyID := ingestedIdentity["credential_policy_id"].(string)
+	ingestedWIMSE := ingestedIdentity["wimse_uri"].(string)
+	ingestedOrigin := ingestedIdentity["origin"].(string)
+	ingestedExtID := ingestedIdentity["external_id"].(string)
+
+	require.NotEmpty(t, ingestedPolicyID, "freshly ingested discovered identity must have credential_policy_id (tenant default)")
+
+	// Adopt with the default policy (no explicit policy supplied).
+	resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/adopt"), map[string]any{
+		"owner_user_id": "user-state-check",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "pending", decode(t, resp)["status"])
+
+	// Dismiss from pending.
+	resp, err = doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/dismiss"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	assert.Equal(t, "discovered", body["status"], "status must revert to discovered")
+	assert.Equal(t, "", body["owner_user_id"], "owner_user_id must be cleared")
+	assert.Equal(t, ingestedPolicyID, body["credential_policy_id"],
+		"credential_policy_id must be the tenant default (same as at ingest), not NULL")
+	assert.Equal(t, ingestedWIMSE, body["wimse_uri"], "wimse_uri must be immutable through the lifecycle")
+	assert.Equal(t, ingestedOrigin, body["origin"], "origin must be immutable through the lifecycle")
+	assert.Equal(t, ingestedExtID, body["external_id"], "external_id must be immutable through the lifecycle")
+}
+
+// TestPending_DismissWithCustomPolicyRevertsToTenantDefault verifies that
+// when adoption sets a specific (non-default) credential policy, dismiss
+// reverts to the tenant default — not to the custom policy, and not to NULL.
+func TestPending_DismissWithCustomPolicyRevertsToTenantDefault(t *testing.T) {
+	ext := uid("dismiss-custom-policy")
+	out := ingestDiscovered(t, map[string]any{"external_id": ext, "origin": "okta"})
+	id := out["identity"].(map[string]any)["id"].(string)
+	ingestedPolicyID := out["identity"].(map[string]any)["credential_policy_id"].(string)
+	require.NotEmpty(t, ingestedPolicyID, "ingest must set the tenant default policy")
+
+	// Create a custom policy and adopt with it.
+	customPolicyID := createCredentialPolicy(t, uid("custom-policy"), adminHeaders())
+	resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/adopt"), map[string]any{
+		"owner_user_id":        "user-custom-policy",
+		"credential_policy_id": customPolicyID,
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	adopted := decode(t, resp)
+	require.Equal(t, "pending", adopted["status"])
+	require.Equal(t, customPolicyID, adopted["credential_policy_id"],
+		"adopt should apply the custom policy")
+
+	// Dismiss — should revert to the tenant default, not keep the custom policy.
+	resp, err = doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/dismiss"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	assert.Equal(t, "discovered", body["status"])
+	assert.Equal(t, ingestedPolicyID, body["credential_policy_id"],
+		"dismiss must restore the tenant default policy, not retain the custom adoption policy")
+	assert.NotEqual(t, customPolicyID, body["credential_policy_id"],
+		"custom policy from adoption must not persist after dismiss")
+}
+
+// TestPending_DismissAllowsReAdoption verifies the full second adopt cycle:
+// dismiss from pending returns the identity to discovered so it can be
+// re-adopted and activated without any stale state blocking the path.
+func TestPending_DismissAllowsReAdoption(t *testing.T) {
+	ext := uid("readopt-me")
+	out := ingestDiscovered(t, map[string]any{"external_id": ext, "origin": "okta"})
+	id := out["identity"].(map[string]any)["id"].(string)
+
+	adopt := func(owner string) {
+		t.Helper()
+		resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/adopt"), map[string]any{
+			"owner_user_id": owner,
+		}, adminHeaders())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "pending", decode(t, resp)["status"])
+	}
+	dismiss := func() {
+		t.Helper()
+		resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/dismiss"), nil, adminHeaders())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.Equal(t, "discovered", decode(t, resp)["status"])
+	}
+
+	// First cycle: adopt → dismiss.
+	adopt("user-first-owner")
+	dismiss()
+
+	// Second cycle: re-adopt with a different owner → activate.
+	adopt("user-second-owner")
+
+	resp, err := doRaw(t, http.MethodPatch, adminPath("/identities/"+id), map[string]any{
+		"status": "active",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "active", body["status"], "re-adopted identity must be activatable")
+	assert.Equal(t, "user-second-owner", body["owner_user_id"], "second owner must be set after re-adoption")
+}
+
+// TestPending_DismissedIdentityNotResurrectedByReIngest verifies that after
+// pending → dismiss (→ discovered), a connector re-sync keeps the identity
+// in discovered and does not alter its status or owner.
+func TestPending_DismissedIdentityNotResurrectedByReIngest(t *testing.T) {
+	ext := uid("dismiss-reingest")
+	out := ingestDiscovered(t, map[string]any{"external_id": ext, "origin": "okta"})
+	id := out["identity"].(map[string]any)["id"].(string)
+
+	// Adopt → pending.
+	resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/adopt"), map[string]any{
+		"owner_user_id": "user-to-dismiss",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Dismiss → discovered.
+	resp, err = doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/dismiss"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "discovered", decode(t, resp)["status"])
+
+	// Re-ingest: connector sees the same agent again.
+	second := ingestDiscovered(t, map[string]any{"external_id": ext, "origin": "okta", "name": "updated-name"})
+	assert.Equal(t, false, second["created"], "re-ingest must reconcile to the same row")
+	got := second["identity"].(map[string]any)
+	assert.Equal(t, id, got["id"], "re-ingest must not create a new row")
+	assert.Equal(t, "discovered", got["status"],
+		"re-ingest after dismiss-from-pending must keep status=discovered")
+	assert.Equal(t, "", got["owner_user_id"],
+		"re-ingest must not restore the cleared owner")
+}
+
+// TestPending_ActiveExternalAgentCannotBeDismissed verifies that an adopted
+// and activated external agent (status=active) is rejected by dismiss — dismiss
+// is only for discovered or pending identities.
+func TestPending_ActiveExternalAgentCannotBeDismissed(t *testing.T) {
+	ext := uid("active-external-dismiss")
+	out := ingestDiscovered(t, map[string]any{"external_id": ext, "origin": "okta"})
+	id := out["identity"].(map[string]any)["id"].(string)
+
+	// Adopt → pending.
+	resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/adopt"), map[string]any{
+		"owner_user_id": "user-owner",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Activate → active.
+	resp, err = doRaw(t, http.MethodPatch, adminPath("/identities/"+id), map[string]any{
+		"status": "active",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "active", decode(t, resp)["status"])
+
+	// Dismiss must be rejected for an active external agent.
+	resp, err = doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/dismiss"), nil, adminHeaders())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"dismiss must refuse an active external agent — use deactivate instead")
+	_ = resp.Body.Close()
+}
+
 // TestDiscovered_DismissNonDiscoveredRejected verifies dismiss is only for
 // discovered or pending identities — a live native identity is deactivated via DELETE.
 func TestDiscovered_DismissNonDiscoveredRejected(t *testing.T) {

--- a/tests/integration/discovery_lifecycle_test.go
+++ b/tests/integration/discovery_lifecycle_test.go
@@ -249,8 +249,46 @@ func TestDiscovered_AdoptThenActivate(t *testing.T) {
 	assert.Equal(t, "active", decode(t, resp)["status"], "pending → active completes the path to a usable identity")
 }
 
+// TestPending_DismissRevertsToDiscovered verifies that dismissing a pending
+// identity reverts the adoption: status returns to discovered, owner is cleared,
+// and the identity reappears in the adoption inbox.
+func TestPending_DismissRevertsToDiscovered(t *testing.T) {
+	ext := uid("pending-dismiss")
+	out := ingestDiscovered(t, map[string]any{"external_id": ext, "origin": "okta"})
+	id := out["identity"].(map[string]any)["id"].(string)
+
+	// Adopt → pending
+	resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/adopt"), map[string]any{
+		"owner_user_id": "user-to-revert",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "pending", decode(t, resp)["status"])
+
+	// Dismiss from pending → should revert to discovered, clearing owner
+	resp, err = doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/dismiss"), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+	assert.Equal(t, "discovered", body["status"], "dismiss from pending reverts to discovered")
+	assert.Equal(t, "", body["owner_user_id"], "owner is cleared on dismiss from pending")
+
+	// The identity should now appear in the adoption inbox again
+	assert.True(t, func() bool {
+		r := get(t, adminPath("/identities?status=discovered&limit=100"), adminHeaders())
+		require.Equal(t, http.StatusOK, r.StatusCode)
+		b := decode(t, r)
+		for _, raw := range b["identities"].([]any) {
+			if raw.(map[string]any)["id"] == id {
+				return true
+			}
+		}
+		return false
+	}(), "dismissed-from-pending identity must reappear in the adoption inbox")
+}
+
 // TestDiscovered_DismissNonDiscoveredRejected verifies dismiss is only for
-// discovered identities — a live native identity is deactivated via DELETE.
+// discovered or pending identities — a live native identity is deactivated via DELETE.
 func TestDiscovered_DismissNonDiscoveredRejected(t *testing.T) {
 	reg := registerIdentity(t, uid("native-dismiss"), nil)
 	resp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+reg.ID+"/dismiss"), nil, adminHeaders())


### PR DESCRIPTION
## Summary

- **\`CanTransitionTo\`**: adds \`pending → discovered\` as a valid transition in the domain state machine
- **\`DismissIdentity\`**: pending path now uses \`CanTransitionTo(discovered)\` guard (consistent with rest of service layer), clears \`owner_user_id\`, and restores the tenant default \`credential_policy_id\` via \`resolveIdentityPolicyID\` — discovered identities always have the tenant default from birth, so clearing to NULL would produce a state that normal ingest never creates
- **Domain docstring**: removed stale "entry-only" claim from \`IdentityStatus\` comment; added \`pending → discovered\` to the lifecycle diagram
- **\`CanTransitionTo\` test**: updated \`TestCanTransitionTo_Discovered\` to reflect the new valid \`pending → discovered\` transition

Pairs with highflame-studio PR highflame-ai/highflame-studio#1197 which surfaces the Dismiss action for pending agents in the Identities page.

## Test plan

- [ ] `TestPending_DismissRevertsToDiscovered` — adopt → dismiss round-trip, owner cleared, reappears in adoption inbox
- [ ] `TestPending_DismissRestoresExactDiscoveredState` — \`credential_policy_id\` = tenant default (not NULL), \`wimse_uri\`/\`origin\`/\`external_id\` immutable
- [ ] `TestPending_DismissWithCustomPolicyRevertsToTenantDefault` — custom adoption policy reverts to tenant default on dismiss
- [ ] `TestPending_DismissAllowsReAdoption` — full second adopt → activate cycle works after dismiss
- [ ] `TestPending_DismissedIdentityNotResurrectedByReIngest` — re-sync after pending → dismiss keeps \`discovered\`, does not restore owner
- [ ] `TestPending_ActiveExternalAgentCannotBeDismissed` — active external agent returns 400
- [ ] `TestDiscovered_Dismiss` (discovered → deactivated) still passes — existing path unchanged
- [ ] `TestDiscovered_DismissNonDiscoveredRejected` — native agents still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)