### PR TITLE
feat: human delegator does not cap agent scopes on token exchange (code-agent identity, #132)

### DIFF
--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -609,34 +609,58 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 		return nil, oauthServerError("failed to resolve actor credential policy", err)
 	}
 
-	// Step 4: Compute the granted scopes as the three-way intersection of
-	// requested ∩ orchestrator.granted ∩ actor.policy.allowed_scopes. When
-	// the policy declares no scope restriction we fall back to the legacy
-	// identity.AllowedScopes for backward compat during the deprecation
-	// window. The orchestrator's granted scopes remain authoritative for
-	// what can be delegated — a sub-agent can never receive more than its
-	// principal currently holds, per RFC 8693 intent.
+	// Step 4: Compute the granted scopes. The rule depends on WHO the subject
+	// (delegator) is:
+	//
+	//   - Agent orchestrator → sub-agent: three-way intersection
+	//     requested ∩ orchestrator.granted ∩ actor.policy.allowed_scopes. The
+	//     orchestrator's granted scopes cap the child — a sub-agent can never
+	//     receive more than its principal currently holds (RFC 8693 intent).
+	//
+	//   - Human delegator → agent: requested ∩ actor.policy.allowed_scopes. The
+	//     human is recorded in the act-chain as the accountable delegator, NOT a
+	//     scope ceiling. A developer's login scopes (e.g. account:read) are
+	//     orthogonal to an agent's operational authority, which is defined by the
+	//     agent's OWN credential policy; capping by the human's scopes would zero
+	//     out an agent whose human happens to hold unrelated scopes. The agent
+	//     must therefore carry an explicit policy — no allowed_scopes means no
+	//     delegable authority (fail closed).
+	//
+	// When the actor policy declares no scope restriction we fall back to the
+	// legacy identity.AllowedScopes for backward compat during the deprecation
+	// window.
 	requestedScopes := parseScopeString(req.Scope)
 	actorAllowed := effectiveAllowedScopes(actorPolicy, actorIdentity)
-	orchSet := make(map[string]bool, len(subjectCred.Scopes))
-	for _, s := range subjectCred.Scopes {
-		orchSet[s] = true
+	actorSet := make(map[string]bool, len(actorAllowed))
+	for _, s := range actorAllowed {
+		actorSet[s] = true
 	}
+
+	// The delegator is an agent orchestrator only when the subject token itself
+	// is an agent identity (identity_type=agent, stamped at mint). A human PKCE
+	// / IdP session carries a non-agent identity_type, so it is treated as a
+	// pure delegator and does not cap the agent's operational scopes.
+	subjectIDType, _ := jwt.Get[string](subjectParsed, "identity_type")
+	subjectIsAgentPrincipal := subjectIDType == string(domain.IdentityTypeAgent)
+
 	var scopes []string
-	if len(actorAllowed) == 0 {
-		// Actor has no scope restriction → intersection is requested ∩ orchestrator.
+	if subjectIsAgentPrincipal {
+		orchSet := make(map[string]bool, len(subjectCred.Scopes))
+		for _, s := range subjectCred.Scopes {
+			orchSet[s] = true
+		}
 		for _, s := range requestedScopes {
-			if orchSet[s] {
+			if orchSet[s] && (len(actorAllowed) == 0 || actorSet[s]) {
 				scopes = append(scopes, s)
 			}
 		}
 	} else {
-		actorSet := make(map[string]bool, len(actorAllowed))
-		for _, s := range actorAllowed {
-			actorSet[s] = true
+		if len(actorAllowed) == 0 {
+			return nil, oauthBadRequest(oautherror.InvalidScope,
+				"actor identity has no allowed_scopes; a credential policy is required for human-delegated token exchange")
 		}
 		for _, s := range requestedScopes {
-			if orchSet[s] && actorSet[s] {
+			if actorSet[s] {
 				scopes = append(scopes, s)
 			}
 		}


### PR DESCRIPTION
Part of the code-agent identity epic (highflame-ai/highflame-architecture#132). Surfaced by end-to-end local testing.

## Problem
On the code-agent Guardian flow, Cerberus exchanges the **developer's** bearer (`subject_token`) + the **agent's** signed assertion (`actor_token`) for a delegated token (`sub=agent_wimse, act={sub=human}`). The delegated token was coming back with only the **developer's login scopes** (`account:read, gateway:read`) and none of the agent's `tools:*` — so Shield's `tools:*` scope ceiling denied every action.

Root cause: `tokenExchange` always capped the grant by the **subject** token's scopes (`requested ∩ subject.granted ∩ actor.policy`). That's correct for **agent → sub-agent** (a child can't exceed its principal, RFC 8693), but wrong for **human → agent**: a developer's login scopes are orthogonal to an agent's operational authority, and intersecting with them zeroes out `tools:*`.

## Change
Branch the scope rule on **who the delegator is** (the subject token's `identity_type`, stamped at mint):

- **Agent orchestrator → sub-agent** (`identity_type=agent`): unchanged — `requested ∩ orchestrator.granted ∩ actor.policy.allowed_scopes`. The principal cap holds.
- **Human delegator → agent** (any non-agent subject): `requested ∩ actor.policy.allowed_scopes`. The human is the accountable delegator in the act-chain, **not** a scope ceiling. The agent's own credential policy defines what it may do. An agent with **no** `allowed_scopes` has no delegable authority → `invalid_scope` (fail closed).

This implements the decision that a code agent's operational scopes come from **its own credential policy** (matches "one credential policy per code agent" in the epic plan), while preserving the sub-agent attenuation invariant.

## Tests
- [x] `go build` + `go vet` clean (GOEXPERIMENT=jsonv2).
- [x] Service unit tests pass.
- [x] Delegation + subagent-exchange integration tests pass (agent→subagent path unchanged — no regression).
- [ ] **Follow-up:** a dedicated integration test for the human→agent path needs a small harness helper to mint a non-agent (human) subject token — the current `tests/integration` helpers only mint agent subjects (`issueRootCredential` uses `client_credentials`). The path is exercised end-to-end via Cerberus on the local stack (highflame-cerberus#121). I'll add the zeroid-level test with the helper.

Pairs with highflame-cerberus#121 (requests the explicit `tools:*` list, not a `"tools:*"` literal — zeroid does exact-string matching — and registers the agent with `allowed_scopes`).
