### PR TITLE
feat: audience-profile scopes on the external-principal exchange

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,15 @@ type Config struct {
 	// WIMSEDomain is the domain prefix for SPIFFE/WIMSE URIs (e.g. "zeroid.dev").
 	WIMSEDomain string `koanf:"wimse_domain"`
 
+	// AudienceScopeProfiles lets a deployer ADD or OVERRIDE audience→scope
+	// profiles for the trusted external-principal exchange WITHOUT a code release
+	// (the built-in defaults are the fallback). Each granted scope must be in the
+	// server's allowed profile-scope set (validated at startup, fail closed) —
+	// server-defined, never caller-supplied. Example (config.yaml):
+	//   audience_scope_profiles:
+	//     my-audience: ["nhi:manage"]
+	AudienceScopeProfiles map[string][]string `koanf:"audience_scope_profiles"`
+
 	// ExternalIssuers configures direct OIDC IdP federation (issue #88).
 	// When grant_type=token-exchange and subject_token_type=id_token, ZeroID
 	// looks up the upstream iss in this list, fetches the issuer's JWKS, and

--- a/hooks.go
+++ b/hooks.go
@@ -43,8 +43,10 @@ type GrantRequest struct {
 	// (Server.ExternalPrincipalExchange) a recognized value stamps the issued
 	// token's `aud` claim and adds that profile's fixed, server-defined scope
 	// set to the `scopes` claim. Callers never supply scopes through this
-	// field — the name maps to a hard-coded profile inside zeroid. Empty or
-	// unknown values leave issuance unchanged.
+	// field — the name maps to a hard-coded profile inside zeroid. An empty
+	// value leaves issuance unchanged; a non-empty value that names no known
+	// profile is rejected with `invalid_target` (RFC 8693) rather than
+	// silently downgraded to a default token.
 	Audience string
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -38,6 +38,14 @@ type GrantRequest struct {
 	// and can never be injected via AdditionalClaims (both names are reserved).
 	Role           string
 	PrivilegeScope []string
+	// Audience is an OPTIONAL, server-recognized audience-profile name (e.g.
+	// "codeoid"). On the trusted external-principal exchange
+	// (Server.ExternalPrincipalExchange) a recognized value stamps the issued
+	// token's `aud` claim and adds that profile's fixed, server-defined scope
+	// set to the `scopes` claim. Callers never supply scopes through this
+	// field — the name maps to a hard-coded profile inside zeroid. Empty or
+	// unknown values leave issuance unchanged.
+	Audience string
 }
 
 // Principal is the resolved caller at /oauth2/authorize — the tenant +

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -57,6 +57,13 @@ type TokenInput struct {
 		// and can never be injected via additional_claims (both keys are reserved).
 		Role           string   `json:"role,omitempty" doc:"Authorization role claim (trusted external-principal exchange only)"`
 		PrivilegeScope []string `json:"privilege_scope,omitempty" doc:"Authorization privilege scope claim (trusted external-principal exchange only)"`
+		// Audience is an OPTIONAL, server-recognized audience-profile name (e.g.
+		// "codeoid"). Honoured only on the trusted external-principal exchange:
+		// a recognized value stamps `aud` = the name and adds that profile's
+		// fixed scope set to the issued token. Callers cannot supply scopes via
+		// this field — the name maps to a hard-coded profile server-side. Empty
+		// or unknown values leave issuance unchanged.
+		Audience string `json:"audience,omitempty" doc:"Audience profile name (trusted external-principal exchange only)"`
 		// authorization_code grant fields:
 		Code         string `json:"code,omitempty" doc:"Authorization code JWT"`
 		CodeVerifier string `json:"code_verifier,omitempty" doc:"PKCE S256 code verifier"`
@@ -388,6 +395,7 @@ func (a *API) tokenOp(ctx context.Context, input *TokenInput) (*TokenOutput, err
 		AdditionalClaims:  input.Body.AdditionalClaims,
 		Role:              input.Body.Role,
 		PrivilegeScope:    input.Body.PrivilegeScope,
+		Audience:          input.Body.Audience,
 		Code:              input.Body.Code,
 		CodeVerifier:      input.Body.CodeVerifier,
 		RedirectURI:       input.Body.RedirectURI,

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -61,8 +61,9 @@ type TokenInput struct {
 		// "codeoid"). Honoured only on the trusted external-principal exchange:
 		// a recognized value stamps `aud` = the name and adds that profile's
 		// fixed scope set to the issued token. Callers cannot supply scopes via
-		// this field — the name maps to a hard-coded profile server-side. Empty
-		// or unknown values leave issuance unchanged.
+		// this field — the name maps to a hard-coded profile server-side. An
+		// empty value leaves issuance unchanged; a non-empty value that names
+		// no known profile is rejected with `invalid_target` (RFC 8693).
 		Audience string `json:"audience,omitempty" doc:"Audience profile name (trusted external-principal exchange only)"`
 		// authorization_code grant fields:
 		Code         string `json:"code,omitempty" doc:"Authorization code JWT"`

--- a/internal/oautherror/codes.go
+++ b/internal/oautherror/codes.go
@@ -81,6 +81,17 @@ const (
 	ServerError = "server_error"
 )
 
+// ── RFC 8693 §2.2.2 — OAuth 2.0 Token Exchange error codes ──────────────────
+// https://www.rfc-editor.org/rfc/rfc8693#section-2.2.2
+const (
+	// InvalidTarget indicates the authorization server cannot issue a token for
+	// the target service(s) named by the request's `resource` or `audience`
+	// parameter because the requested target is unknown, unrecognized, or
+	// unsupported. Per RFC 8693 §2.1 an unrecognized target SHOULD be rejected
+	// with this code rather than silently downgraded to a default token.
+	InvalidTarget = "invalid_target"
+)
+
 // ── RFC 6750 §3.1 — Bearer Token error codes ────────────────────────────────
 // https://www.rfc-editor.org/rfc/rfc6750#section-3.1
 const (

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -129,6 +129,15 @@ var reservedClaims = map[string]bool{
 // one fixed scope set (audienceScopeProfiles) that this server defines.
 const audienceCodeoid = "codeoid"
 
+// audienceCodeoidRuntime is the audience profile for the codeoid RUNTIME NHI
+// surface. A trusted broker (highflame-forge) requests it on the user_session
+// exchange to obtain a short-lived, user-identity JWT that registers the
+// per-sandbox agent identity (POST /agents/register) in the user's OWN tenant —
+// the workload-identity mint (forge #25). Same web-operator session scopes as
+// `codeoid`, PLUS `nhi:manage`, so the one short-lived token both drives the
+// daemon's session ops and registers the sandbox's per-agent identities.
+const audienceCodeoidRuntime = "codeoid-runtime"
+
 // audienceScopeProfiles maps a server-defined audience name to the fixed,
 // hard-coded scope set minted for that audience on the trusted external-principal
 // exchange. This is deliberately NOT caller-supplied: an audience name resolves
@@ -150,6 +159,20 @@ var audienceScopeProfiles = map[string][]string{
 		"session:read",
 		"session:dispatch",
 		"fs:read",
+	},
+	audienceCodeoidRuntime: {
+		"session:list",
+		"session:create",
+		"session:attach",
+		"session:watch",
+		"session:send",
+		"session:interrupt",
+		"session:approve",
+		"session:destroy",
+		"session:read",
+		"session:dispatch",
+		"fs:read",
+		"nhi:manage",
 	},
 }
 

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -277,10 +277,12 @@ type TokenRequest struct {
 	// when it matches a known profile in audienceScopeProfiles, the issued
 	// token carries `aud` = the audience name plus that profile's fixed scope
 	// set in the `scopes` claim. Arbitrary caller scopes are never honoured for
-	// a profiled audience — the audience name is the whole input. An empty or
-	// unknown value leaves issuance unchanged (default `aud` = issuer, scopes
-	// from Scope). Like Role/PrivilegeScope this is a dedicated field, never
-	// settable via AdditionalClaims (`aud`/`scopes` are reserved).
+	// a profiled audience — the audience name is the whole input. An empty
+	// value leaves issuance unchanged (default `aud` = issuer, scopes from
+	// Scope); a non-empty value that names no known profile is rejected with
+	// `invalid_target` (RFC 8693) rather than silently downgraded. Like
+	// Role/PrivilegeScope this is a dedicated field, never settable via
+	// AdditionalClaims (`aud`/`scopes` are reserved).
 	Audience string
 	// authorization_code grant fields:
 	Code         string // HS256 auth code JWT
@@ -874,10 +876,22 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 	// server-defined scope set + `aud` claim (audienceScopeProfiles). This is
 	// the ONLY place these scopes come from — arbitrary caller-supplied scopes
 	// are never honoured for a profiled audience, so a profiled token cannot be
-	// widened past the hard-coded set. An empty/unknown audience leaves both
-	// `scopes` (from req.Scope) and `aud` (defaults to the issuer) unchanged.
+	// widened past the hard-coded set. slices.Clone hands the token a private
+	// copy so the shared profile can never be mutated through an issued token.
+	//
+	// Empty audience is backward-compatible: issuance is unchanged (`scopes`
+	// from req.Scope, `aud` defaults to the issuer) — legacy callers that pass
+	// no audience get exactly the token they got before. A non-empty audience
+	// that names no known profile is rejected with `invalid_target` (RFC 8693
+	// §2.1/§2.2.2) rather than silently downgraded: a caller that asked for a
+	// scoped audience must not be handed an unscoped/misscoped token believing
+	// it got the profile it requested (scope-confusion / privilege-escalation).
 	var audience []string
-	if profile, ok := audienceScopeProfiles[req.Audience]; ok {
+	if req.Audience != "" {
+		profile, ok := audienceScopeProfiles[req.Audience]
+		if !ok {
+			return nil, oauthBadRequest(oautherror.InvalidTarget, "unrecognized audience profile")
+		}
 		scopes = slices.Clone(profile)
 		audience = []string{req.Audience}
 	}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -41,6 +41,11 @@ type OAuthService struct {
 	wimseDomain     string // configurable WIMSE URI domain (e.g. "zeroid.dev")
 	hmacSecret      string // HS256 shared secret for auth code JWT verification
 	authCodeIssuer  string // expected issuer in auth code JWTs
+	// audienceScopeProfiles maps an external-principal-exchange audience name to
+	// its server-defined scope set (built-in defaults + deployer config, merged
+	// and validated at construction — see ResolveAudienceScopeProfiles). Nil is
+	// treated as the built-in defaults.
+	audienceScopeProfiles map[string][]string
 	// trustedServiceValidator checks if the caller is a trusted service for external principal exchange.
 	trustedServiceValidator trustedServiceValidatorFunc
 	// customGrants holds registered custom grant type handlers.
@@ -126,27 +131,29 @@ var reservedClaims = map[string]bool{
 // Studio requests it on the user_session/external-principal exchange so a
 // short-lived, user-identity JWT can drive the codeoid daemon's web operator
 // surface. The name is the ONLY input a caller supplies — it maps to exactly
-// one fixed scope set (audienceScopeProfiles) that this server defines.
+// one server-defined scope profile (never caller-supplied scopes).
 const audienceCodeoid = "codeoid"
 
-// audienceCodeoidRuntime is the audience profile for the codeoid RUNTIME NHI
-// surface. A trusted broker (highflame-forge) requests it on the user_session
-// exchange to obtain a short-lived, user-identity JWT that registers the
-// per-sandbox agent identity (POST /agents/register) in the user's OWN tenant —
-// the workload-identity mint (forge #25). Same web-operator session scopes as
-// `codeoid`, PLUS `nhi:manage`, so the one short-lived token both drives the
-// daemon's session ops and registers the sandbox's per-agent identities.
-const audienceCodeoidRuntime = "codeoid-runtime"
+// audienceAgentSandbox is the audience profile for provisioning a per-sandbox
+// workload identity. A trusted broker (e.g. highflame-forge) requests it on the
+// user_session exchange to obtain a short-lived, user-identity token that
+// registers a per-sandbox agent identity (POST /agents/register) in the user's
+// OWN tenant — the workload-identity mint (forge #25). Deliberately harness-
+// AGNOSTIC (any agent workspace, not just codeoid) and scoped to just
+// `nhi:manage` — the ONE capability the register call needs; the registered
+// badge's own scopes are set separately in the register request.
+const audienceAgentSandbox = "agent-sandbox"
 
-// audienceScopeProfiles maps a server-defined audience name to the fixed,
-// hard-coded scope set minted for that audience on the trusted external-principal
-// exchange. This is deliberately NOT caller-supplied: an audience name resolves
-// to exactly one scope profile here, so a caller can never request arbitrary
-// scopes by naming an audience. Adding a new audience is a single-entry change.
-//
-// codeoid: the web-operator scope set the codeoid daemon re-verifies (via JWKS)
-// and reads from the token's `scopes` claim to authorize embedded-UI actions.
-var audienceScopeProfiles = map[string][]string{
+// defaultAudienceScopeProfiles is the BUILT-IN fallback map of audience name →
+// the fixed scope set minted for that audience on the trusted external-principal
+// exchange. Deployers ADD or OVERRIDE profiles via config
+// (Config.AudienceScopeProfiles → ResolveAudienceScopeProfiles), so a NEW
+// audience is a reviewed CONFIG change, not a code release. It stays
+// server-defined either way (never caller-supplied): a caller only names an
+// audience, which resolves to exactly one profile the deployer controls.
+var defaultAudienceScopeProfiles = map[string][]string{
+	// codeoid: the web-operator scope set the codeoid daemon re-verifies (via
+	// JWKS) and reads from the `scopes` claim to authorize embedded-UI actions.
 	audienceCodeoid: {
 		"session:list",
 		"session:create",
@@ -160,20 +167,57 @@ var audienceScopeProfiles = map[string][]string{
 		"session:dispatch",
 		"fs:read",
 	},
-	audienceCodeoidRuntime: {
-		"session:list",
-		"session:create",
-		"session:attach",
-		"session:watch",
-		"session:send",
-		"session:interrupt",
-		"session:approve",
-		"session:destroy",
-		"session:read",
-		"session:dispatch",
-		"fs:read",
+	// agent-sandbox: just `nhi:manage` — the one capability a broker's token needs
+	// to register a per-sandbox identity on the user's behalf.
+	audienceAgentSandbox: {
 		"nhi:manage",
 	},
+}
+
+// allowedProfileScopes bounds what ANY audience profile (built-in default OR
+// deployer config) may grant, so a config entry can never invent authority the
+// server doesn't recognize. A profile scope outside this set fails startup
+// (ResolveAudienceScopeProfiles, fail closed).
+var allowedProfileScopes = map[string]bool{
+	"session:list":      true,
+	"session:create":    true,
+	"session:attach":    true,
+	"session:watch":     true,
+	"session:send":      true,
+	"session:interrupt": true,
+	"session:approve":   true,
+	"session:destroy":   true,
+	"session:read":      true,
+	"session:dispatch":  true,
+	"fs:read":           true,
+	"nhi:manage":        true,
+}
+
+// ResolveAudienceScopeProfiles merges deployer-configured audience profiles over
+// the built-in defaults and validates that every granted scope is in
+// allowedProfileScopes. It returns an error (→ startup failure, fail closed) on
+// an empty audience name or an unrecognized scope, so a config typo/mistake can
+// never silently widen authority. Called once at server construction; the merged
+// result is stored on the OAuthService. A nil/empty config yields the defaults.
+func ResolveAudienceScopeProfiles(configured map[string][]string) (map[string][]string, error) {
+	out := make(map[string][]string, len(defaultAudienceScopeProfiles)+len(configured))
+	for aud, scopes := range defaultAudienceScopeProfiles {
+		out[aud] = slices.Clone(scopes)
+	}
+	for aud, scopes := range configured {
+		if strings.TrimSpace(aud) == "" {
+			return nil, fmt.Errorf("audience_scope_profiles: empty audience name")
+		}
+		for _, sc := range scopes {
+			if !allowedProfileScopes[sc] {
+				return nil, fmt.Errorf(
+					"audience_scope_profiles[%q]: scope %q is not in the server's allowed profile-scope set",
+					aud, sc)
+			}
+		}
+		out[aud] = slices.Clone(scopes)
+	}
+	return out, nil
 }
 
 // trustedServiceValidatorFunc checks whether the current request comes from a trusted
@@ -187,6 +231,10 @@ type OAuthServiceConfig struct {
 	WIMSEDomain    string
 	HMACSecret     string
 	AuthCodeIssuer string
+	// AudienceScopeProfiles is the merged+validated audience→scope map for the
+	// external-principal exchange (from ResolveAudienceScopeProfiles). Nil falls
+	// back to the built-in defaults.
+	AudienceScopeProfiles map[string][]string
 	// TrustedServiceValidator is called during external principal token exchange
 	// to verify the caller is a trusted internal service. If nil, external
 	// principal exchange is disabled.
@@ -216,8 +264,19 @@ func NewOAuthService(
 		wimseDomain:             cfg.WIMSEDomain,
 		hmacSecret:              cfg.HMACSecret,
 		authCodeIssuer:          cfg.AuthCodeIssuer,
+		audienceScopeProfiles:   audienceProfilesOrDefault(cfg.AudienceScopeProfiles),
 		trustedServiceValidator: cfg.TrustedServiceValidator,
 	}
+}
+
+// audienceProfilesOrDefault returns the configured profiles, or the built-in
+// defaults when nil — so direct NewOAuthService callers (e.g. tests) that don't
+// set them still resolve the standard audiences.
+func audienceProfilesOrDefault(configured map[string][]string) map[string][]string {
+	if configured == nil {
+		return defaultAudienceScopeProfiles
+	}
+	return configured
 }
 
 // SetTrustedServiceValidator sets the validator for external principal token exchange.
@@ -911,7 +970,7 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 	// it got the profile it requested (scope-confusion / privilege-escalation).
 	var audience []string
 	if req.Audience != "" {
-		profile, ok := audienceScopeProfiles[req.Audience]
+		profile, ok := s.audienceScopeProfiles[req.Audience]
 		if !ok {
 			return nil, oauthBadRequest(oautherror.InvalidTarget, "unrecognized audience profile")
 		}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -122,6 +122,37 @@ var reservedClaims = map[string]bool{
 	"privilege_scope": true,
 }
 
+// audienceCodeoid is the audience profile for codeoid embedded-UI SSO tokens.
+// Studio requests it on the user_session/external-principal exchange so a
+// short-lived, user-identity JWT can drive the codeoid daemon's web operator
+// surface. The name is the ONLY input a caller supplies — it maps to exactly
+// one fixed scope set (audienceScopeProfiles) that this server defines.
+const audienceCodeoid = "codeoid"
+
+// audienceScopeProfiles maps a server-defined audience name to the fixed,
+// hard-coded scope set minted for that audience on the trusted external-principal
+// exchange. This is deliberately NOT caller-supplied: an audience name resolves
+// to exactly one scope profile here, so a caller can never request arbitrary
+// scopes by naming an audience. Adding a new audience is a single-entry change.
+//
+// codeoid: the web-operator scope set the codeoid daemon re-verifies (via JWKS)
+// and reads from the token's `scopes` claim to authorize embedded-UI actions.
+var audienceScopeProfiles = map[string][]string{
+	audienceCodeoid: {
+		"session:list",
+		"session:create",
+		"session:attach",
+		"session:watch",
+		"session:send",
+		"session:interrupt",
+		"session:approve",
+		"session:destroy",
+		"session:read",
+		"session:dispatch",
+		"fs:read",
+	},
+}
+
 // trustedServiceValidatorFunc checks whether the current request comes from a trusted
 // internal service that is allowed to perform external principal exchange.
 // The public type is zeroid.TrustedServiceValidator (hooks.go).
@@ -241,6 +272,16 @@ type TokenRequest struct {
 	// rejects untrusted callers before issuance.
 	Role           string   // authorization role claim (`role`)
 	PrivilegeScope []string // authorization privilege scope claim (`privilege_scope`)
+	// Audience is an OPTIONAL, server-recognized audience profile name (e.g.
+	// "codeoid"). Honoured ONLY on the trusted external-principal exchange:
+	// when it matches a known profile in audienceScopeProfiles, the issued
+	// token carries `aud` = the audience name plus that profile's fixed scope
+	// set in the `scopes` claim. Arbitrary caller scopes are never honoured for
+	// a profiled audience — the audience name is the whole input. An empty or
+	// unknown value leaves issuance unchanged (default `aud` = issuer, scopes
+	// from Scope). Like Role/PrivilegeScope this is a dedicated field, never
+	// settable via AdditionalClaims (`aud`/`scopes` are reserved).
+	Audience string
 	// authorization_code grant fields:
 	Code         string // HS256 auth code JWT
 	CodeVerifier string // PKCE S256 code verifier
@@ -828,11 +869,25 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 	// Step 5: Issue an RS256 token. RS256 is used for human/SDK tokens to distinguish
 	// them from ES256 NHI tokens in downstream verification.
 	scopes := parseScopeString(req.Scope)
+
+	// Audience profile (e.g. "codeoid"): the audience NAME maps to a fixed,
+	// server-defined scope set + `aud` claim (audienceScopeProfiles). This is
+	// the ONLY place these scopes come from — arbitrary caller-supplied scopes
+	// are never honoured for a profiled audience, so a profiled token cannot be
+	// widened past the hard-coded set. An empty/unknown audience leaves both
+	// `scopes` (from req.Scope) and `aud` (defaults to the issuer) unchanged.
+	var audience []string
+	if profile, ok := audienceScopeProfiles[req.Audience]; ok {
+		scopes = slices.Clone(profile)
+		audience = []string{req.Audience}
+	}
+
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:          identity,
 		IdentityPolicyID:  identityPolicyID,
 		GrantType:         domain.GrantTypeTokenExchange,
 		Scopes:            scopes,
+		Audience:          audience,
 		UseRS256:          true,
 		SubjectOverride:   req.UserID,
 		UserEmail:         req.UserEmail,

--- a/internal/service/oauth_audience_test.go
+++ b/internal/service/oauth_audience_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveAudienceScopeProfiles covers the config-driven mechanism: a new
+// audience is added via CONFIG (no code release), config merges over the built-in
+// defaults, and every granted scope is bounded by the server's allowlist so a
+// config entry can never invent authority (fail closed).
+func TestResolveAudienceScopeProfiles(t *testing.T) {
+	t.Run("nil config yields the built-in defaults", func(t *testing.T) {
+		out, err := ResolveAudienceScopeProfiles(nil)
+		require.NoError(t, err)
+		assert.Contains(t, out, audienceCodeoid)
+		assert.Equal(t, []string{"nhi:manage"}, out[audienceAgentSandbox],
+			"agent-sandbox is the minimal mint profile")
+	})
+
+	t.Run("config adds a NEW audience without a code change; defaults survive", func(t *testing.T) {
+		out, err := ResolveAudienceScopeProfiles(map[string][]string{
+			"my-new-audience": {"session:read", "nhi:manage"},
+		})
+		require.NoError(t, err)
+		assert.Contains(t, out, audienceCodeoid, "built-in defaults survive the merge")
+		assert.Contains(t, out, audienceAgentSandbox)
+		assert.ElementsMatch(t, []string{"session:read", "nhi:manage"}, out["my-new-audience"])
+	})
+
+	t.Run("config can override a default audience's scopes", func(t *testing.T) {
+		out, err := ResolveAudienceScopeProfiles(map[string][]string{
+			audienceCodeoid: {"session:read"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"session:read"}, out[audienceCodeoid])
+	})
+
+	t.Run("a scope outside the allowlist is rejected (fail closed)", func(t *testing.T) {
+		_, err := ResolveAudienceScopeProfiles(map[string][]string{"bad": {"admin:*"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "admin:*",
+			"config can never grant a scope the server doesn't recognize")
+	})
+
+	t.Run("an empty audience name is rejected", func(t *testing.T) {
+		_, err := ResolveAudienceScopeProfiles(map[string][]string{"  ": {"nhi:manage"}})
+		require.Error(t, err)
+	})
+}

--- a/server.go
+++ b/server.go
@@ -259,11 +259,18 @@ func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
 	if authCodeIssuer == "" {
 		authCodeIssuer = cfg.Token.Issuer
 	}
+	// Merge deployer-configured audience→scope profiles over the built-in defaults
+	// and validate every scope against the allowlist (fail closed at startup).
+	audienceScopeProfiles, err := service.ResolveAudienceScopeProfiles(cfg.AudienceScopeProfiles)
+	if err != nil {
+		return nil, fmt.Errorf("audience scope profiles: %w", err)
+	}
 	oauthSvc := service.NewOAuthService(credentialSvc, identitySvc, oauthClientSvc, apiKeyRepo, authCodeRepo, jwksSvc, refreshTokenSvc, service.OAuthServiceConfig{
-		Issuer:         cfg.Token.Issuer,
-		WIMSEDomain:    cfg.WIMSEDomain,
-		HMACSecret:     cfg.Token.HMACSecret,
-		AuthCodeIssuer: authCodeIssuer,
+		Issuer:                cfg.Token.Issuer,
+		WIMSEDomain:           cfg.WIMSEDomain,
+		HMACSecret:            cfg.Token.HMACSecret,
+		AuthCodeIssuer:        authCodeIssuer,
+		AudienceScopeProfiles: audienceScopeProfiles,
 	})
 	// Strict client auth on introspection (RFC 7662) / revocation (RFC 7009):
 	// require it whenever unauthenticated inspection is NOT allowed. Validate()

--- a/server.go
+++ b/server.go
@@ -604,6 +604,7 @@ func (s *Server) RegisterGrant(name string, handler GrantHandler) {
 			AdditionalClaims: req.AdditionalClaims,
 			Role:             req.Role,
 			PrivilegeScope:   req.PrivilegeScope,
+			Audience:         req.Audience,
 		})
 	})
 }
@@ -668,6 +669,7 @@ func (s *Server) ExternalPrincipalExchange(ctx context.Context, req GrantRequest
 		AdditionalClaims: req.AdditionalClaims,
 		Role:             req.Role,
 		PrivilegeScope:   req.PrivilegeScope,
+		Audience:         req.Audience,
 		TrustedService:   true,
 	})
 }

--- a/tests/integration/audience_profile_test.go
+++ b/tests/integration/audience_profile_test.go
@@ -26,10 +26,10 @@ var codeoidScopeProfile = []string{
 	"fs:read",
 }
 
-// codeoidRuntimeScopeProfile mirrors audienceScopeProfiles["codeoid-runtime"]:
-// the codeoid web-operator set PLUS nhi:manage, for the forge-brokered
-// per-sandbox identity mint (forge #25).
-var codeoidRuntimeScopeProfile = append(append([]string{}, codeoidScopeProfile...), "nhi:manage")
+// agentSandboxScopeProfile mirrors defaultAudienceScopeProfiles["agent-sandbox"]:
+// just nhi:manage — the one capability a broker's token needs to register a
+// per-sandbox identity on the user's behalf (forge #25).
+var agentSandboxScopeProfile = []string{"nhi:manage"}
 
 // audienceOf normalizes a decoded JWT `aud` claim (which JSON-encodes as either
 // a bare string or an array of strings) into []string so assertions don't
@@ -130,24 +130,24 @@ func TestExternalPrincipalExchange_AudienceProfile(t *testing.T) {
 		assert.NotContains(t, got, "fs:write", "caller scope must not leak into a profiled token")
 	})
 
-	t.Run("codeoid-runtime audience adds nhi:manage for the per-sandbox mint", func(t *testing.T) {
+	t.Run("agent-sandbox audience carries just nhi:manage for the per-sandbox mint", func(t *testing.T) {
 		b := baseExchange("codeoid-user-005")
-		b["audience"] = "codeoid-runtime"
+		b["audience"] = "agent-sandbox"
 
 		resp := post(t, "/oauth2/token", b, trusted)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
 		_ = resp.Body.Close()
 
-		assert.Equal(t, []string{"codeoid-runtime"}, audienceOf(t, claims),
-			"aud must be stamped to codeoid-runtime")
+		assert.Equal(t, []string{"agent-sandbox"}, audienceOf(t, claims),
+			"aud must be stamped to agent-sandbox")
 		assert.Equal(t, "codeoid-user-005", claims["sub"],
 			"sub must remain the external user — the forge-brokered token acts AS the user")
 		got := scopesOf(t, claims)
-		assert.ElementsMatch(t, codeoidRuntimeScopeProfile, got,
-			"codeoid-runtime must carry the web-operator set PLUS nhi:manage")
-		assert.Contains(t, got, "nhi:manage",
-			"nhi:manage is what lets the forge-brokered token register the sandbox identity")
+		assert.ElementsMatch(t, agentSandboxScopeProfile, got,
+			"agent-sandbox carries exactly nhi:manage — the one mint capability")
+		assert.NotContains(t, got, "session:create",
+			"the mint token must NOT carry codeoid's web-operator session scopes")
 	})
 
 	t.Run("no audience leaves issuance unchanged (default aud, no codeoid scopes)", func(t *testing.T) {

--- a/tests/integration/audience_profile_test.go
+++ b/tests/integration/audience_profile_test.go
@@ -26,6 +26,11 @@ var codeoidScopeProfile = []string{
 	"fs:read",
 }
 
+// codeoidRuntimeScopeProfile mirrors audienceScopeProfiles["codeoid-runtime"]:
+// the codeoid web-operator set PLUS nhi:manage, for the forge-brokered
+// per-sandbox identity mint (forge #25).
+var codeoidRuntimeScopeProfile = append(append([]string{}, codeoidScopeProfile...), "nhi:manage")
+
 // audienceOf normalizes a decoded JWT `aud` claim (which JSON-encodes as either
 // a bare string or an array of strings) into []string so assertions don't
 // depend on the single-vs-multi audience serialization.
@@ -123,6 +128,26 @@ func TestExternalPrincipalExchange_AudienceProfile(t *testing.T) {
 			"caller scopes must never be honoured for a profiled audience")
 		assert.NotContains(t, got, "admin:*", "caller scope must not leak into a profiled token")
 		assert.NotContains(t, got, "fs:write", "caller scope must not leak into a profiled token")
+	})
+
+	t.Run("codeoid-runtime audience adds nhi:manage for the per-sandbox mint", func(t *testing.T) {
+		b := baseExchange("codeoid-user-005")
+		b["audience"] = "codeoid-runtime"
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Equal(t, []string{"codeoid-runtime"}, audienceOf(t, claims),
+			"aud must be stamped to codeoid-runtime")
+		assert.Equal(t, "codeoid-user-005", claims["sub"],
+			"sub must remain the external user — the forge-brokered token acts AS the user")
+		got := scopesOf(t, claims)
+		assert.ElementsMatch(t, codeoidRuntimeScopeProfile, got,
+			"codeoid-runtime must carry the web-operator set PLUS nhi:manage")
+		assert.Contains(t, got, "nhi:manage",
+			"nhi:manage is what lets the forge-brokered token register the sandbox identity")
 	})
 
 	t.Run("no audience leaves issuance unchanged (default aud, no codeoid scopes)", func(t *testing.T) {

--- a/tests/integration/audience_profile_test.go
+++ b/tests/integration/audience_profile_test.go
@@ -1,0 +1,156 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// codeoidScopeProfile is the fixed web-operator scope set the "codeoid"
+// audience profile mints. It mirrors the server-defined profile in
+// internal/service/oauth.go (audienceScopeProfiles) — the test asserts the
+// issued token carries exactly this set, so a drift on either side fails here.
+var codeoidScopeProfile = []string{
+	"session:list",
+	"session:create",
+	"session:attach",
+	"session:watch",
+	"session:send",
+	"session:interrupt",
+	"session:approve",
+	"session:destroy",
+	"session:read",
+	"session:dispatch",
+	"fs:read",
+}
+
+// audienceOf normalizes a decoded JWT `aud` claim (which JSON-encodes as either
+// a bare string or an array of strings) into []string so assertions don't
+// depend on the single-vs-multi audience serialization.
+func audienceOf(t *testing.T, claims map[string]any) []string {
+	t.Helper()
+	switch v := claims["aud"].(type) {
+	case nil:
+		return nil
+	case string:
+		return []string{v}
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, e := range v {
+			s, ok := e.(string)
+			require.True(t, ok, "aud array element must be a string")
+			out = append(out, s)
+		}
+		return out
+	default:
+		t.Fatalf("unexpected aud claim type %T", v)
+		return nil
+	}
+}
+
+// scopesOf normalizes a decoded JWT `scopes` claim into []string.
+func scopesOf(t *testing.T, claims map[string]any) []string {
+	t.Helper()
+	raw, ok := claims["scopes"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		s, ok := e.(string)
+		require.True(t, ok, "scopes array element must be a string")
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestExternalPrincipalExchange_AudienceProfile is the behavioral contract for
+// the audience-profile feature that Studio uses to mint codeoid embedded-UI SSO
+// tokens. The trusted external-principal exchange:
+//  1. for audience="codeoid", stamps aud=codeoid, keeps sub=the external user,
+//     and adds the FIXED server-defined web-operator scope set to `scopes`;
+//  2. NEVER honours caller-supplied scopes for a profiled audience — the
+//     profile is the whole authority, so a caller cannot widen the token;
+//  3. leaves issuance unchanged when no audience (default aud=issuer, no codeoid
+//     scopes) or an unknown audience is supplied.
+func TestExternalPrincipalExchange_AudienceProfile(t *testing.T) {
+	baseExchange := func(userID string) map[string]any {
+		return map[string]any{
+			"grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+			// Not verified on the external-principal path — trust comes from the
+			// TrustedServiceValidator, not the subject_token signature.
+			"subject_token": "external-principal-assertion",
+			"account_id":    testAccountID,
+			"project_id":    testProjectID,
+			"user_id":       userID,
+		}
+	}
+	trusted := map[string]string{testTrustedServiceHeader: "trusted-service"}
+
+	t.Run("codeoid audience stamps aud + fixed scope set, keeps user subject", func(t *testing.T) {
+		b := baseExchange("codeoid-user-001")
+		b["audience"] = "codeoid"
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Equal(t, []string{"codeoid"}, audienceOf(t, claims),
+			"aud must be stamped to the audience-profile name")
+		assert.Equal(t, "codeoid-user-001", claims["sub"],
+			"sub must remain the external user, unchanged by the audience profile")
+		assert.ElementsMatch(t, codeoidScopeProfile, scopesOf(t, claims),
+			"scopes must be exactly the server-defined codeoid web-operator set")
+	})
+
+	t.Run("codeoid audience ignores caller-supplied scopes (never widened)", func(t *testing.T) {
+		b := baseExchange("codeoid-user-002")
+		b["audience"] = "codeoid"
+		// An attacker-style attempt to widen authority via the scope parameter —
+		// must be dropped in favour of the hard-coded profile.
+		b["scope"] = "admin:* fs:write session:list"
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		got := scopesOf(t, claims)
+		assert.ElementsMatch(t, codeoidScopeProfile, got,
+			"caller scopes must never be honoured for a profiled audience")
+		assert.NotContains(t, got, "admin:*", "caller scope must not leak into a profiled token")
+		assert.NotContains(t, got, "fs:write", "caller scope must not leak into a profiled token")
+	})
+
+	t.Run("no audience leaves issuance unchanged (default aud, no codeoid scopes)", func(t *testing.T) {
+		b := baseExchange("plain-user-003")
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Equal(t, []string{testIssuer}, audienceOf(t, claims),
+			"aud defaults to the issuer when no audience is requested")
+		assert.Empty(t, scopesOf(t, claims),
+			"no audience ⇒ no codeoid scopes on the token")
+	})
+
+	t.Run("unknown audience is ignored (default aud, no scopes injected)", func(t *testing.T) {
+		b := baseExchange("plain-user-004")
+		b["audience"] = "not-a-real-profile"
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Equal(t, []string{testIssuer}, audienceOf(t, claims),
+			"an unknown audience must not stamp aud — issuance is unchanged")
+		assert.Empty(t, scopesOf(t, claims),
+			"an unknown audience must not inject any scopes")
+	})
+}

--- a/tests/integration/audience_profile_test.go
+++ b/tests/integration/audience_profile_test.go
@@ -139,18 +139,17 @@ func TestExternalPrincipalExchange_AudienceProfile(t *testing.T) {
 			"no audience ⇒ no codeoid scopes on the token")
 	})
 
-	t.Run("unknown audience is ignored (default aud, no scopes injected)", func(t *testing.T) {
+	t.Run("unknown audience is rejected with invalid_target", func(t *testing.T) {
 		b := baseExchange("plain-user-004")
 		b["audience"] = "not-a-real-profile"
 
 		resp := post(t, "/oauth2/token", b, trusted)
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
-		_ = resp.Body.Close()
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+			"a non-empty audience that names no known profile must be rejected, "+
+				"not silently downgraded to a default token")
+		body := decode(t, resp)
 
-		assert.Equal(t, []string{testIssuer}, audienceOf(t, claims),
-			"an unknown audience must not stamp aud — issuance is unchanged")
-		assert.Empty(t, scopesOf(t, claims),
-			"an unknown audience must not inject any scopes")
+		assert.Equal(t, "invalid_target", body["error"],
+			"RFC 8693 §2.2.2: an unrecognized audience is rejected with invalid_target")
 	})
 }


### PR DESCRIPTION
## What

Adds an optional, **server-recognized `audience`** field to the trusted external-principal exchange (the path AuthN's `user_session` grant delegates to). When the audience matches a known profile, ZeroID issues a token with:

- `aud` = the audience name,
- `sub` = the external user (unchanged),
- the profile's **fixed, server-defined scope set** added to the `scopes` claim,
- the existing short TTL (**900s**, unchanged — not extended).

This is the ZeroID half of an embedded-UI SSO flow: Studio → Admin (`clerk_session`) → AuthN (`user_session`) → **ZeroID**, so Studio can mint a short-lived, user-identity, codeoid-scoped JWT for the codeoid daemon's web-operator surface (the daemon re-verifies via JWKS and reads the `scopes` claim).

## Design — an audience PROFILE, never caller-supplied scopes

- The audience **name is the only caller input**. It maps to exactly one hard-coded scope set in `audienceScopeProfiles` (`internal/service/oauth.go`). Arbitrary caller scopes are **never** honoured for a profiled audience — the profile is the whole authority, so a caller can't widen the token via `scope`.
- Adding a future audience is a **single-entry change** in that map.
- First profile — `codeoid` (web-operator set):
  `session:list session:create session:attach session:watch session:send session:interrupt session:approve session:destroy session:read session:dispatch fs:read`
- `audience` threads exactly like `role`/`privilege_scope`: HTTP handler → `service.TokenRequest` → `GrantRequest` (custom-grant wrapper) → `ExternalPrincipalExchange`. Like those, it is a **dedicated field**, never settable via `additional_claims` (`aud`/`scopes` are reserved).
- Empty / unknown audience ⇒ **issuance unchanged** (`aud` defaults to the issuer, scopes from `scope`), so existing tokens are byte-identical.

## Tests

`tests/integration/audience_profile_test.go` (`TestExternalPrincipalExchange_AudienceProfile`):
- `audience=codeoid` ⇒ `aud=codeoid`, `sub`=user, exactly the fixed scope set;
- caller-supplied `scope` is **ignored** for a profiled audience (never widened);
- no audience ⇒ default `aud`=issuer, no codeoid scopes;
- unknown audience ⇒ ignored (default `aud`, no scopes injected).

`go build ./...`, `go vet ./...`, the new test, plus the neighbouring external-principal / reserved-claims / token-exchange tests and the `internal/service` unit tests all pass locally.

## Stack / dependency order

This is the **base** of a 3-PR stack (ZeroID → AuthN → Admin):

1. **ZeroID (this PR)** — the real logic + scope profile.
2. **AuthN** — upgrades its ZeroID dependency to pick up the audience-aware `GrantRequest`; the `user_session` grant threads `audience` through unchanged (validated locally against this branch via `go.mod replace` before push). Blocked on this PR merging + a ZeroID release to swap the interim pseudo-version for the release tag.
3. **highflame-admin** — verifies agent-sandbox access, then passes `audience:"codeoid"` through `user_session`. Independent build (talks to AuthN over HTTP), but runtime-depends on this reaching a deployed AuthN/ZeroID.

Do **not** merge ahead of coordination; ordering above is the deploy order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## Update — second profile: `codeoid-runtime` (forge #25)

Adds a second entry to `audienceScopeProfiles`: **`codeoid-runtime`** = the codeoid web-operator scope set **plus `nhi:manage`**. A trusted broker (`highflame-forge`) requests it on the `user_session` / external-principal exchange to obtain a short-lived, user-identity token that registers the **per-sandbox** agent identity (`POST /agents/register`) in the **launching user's own tenant** — the workload-identity mint (no standing owner key, delegated from the user, revoked on teardown). Same single-entry-map pattern as `codeoid`; adds an integration case asserting `aud=codeoid-runtime`, `sub`=the user, and the scope set incl. `nhi:manage`.