### PR TITLE
fix: harden audience-scope-profile resolution (audit follow-up)

### DIFF
--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -205,8 +205,23 @@ func ResolveAudienceScopeProfiles(configured map[string][]string) (map[string][]
 		out[aud] = slices.Clone(scopes)
 	}
 	for aud, scopes := range configured {
+		out[aud] = slices.Clone(scopes)
+	}
+	// Validate the MERGED set (built-in defaults AND deployer config) uniformly and
+	// fail closed. Validating the defaults too guards against a future default
+	// scope drifting out of allowedProfileScopes (a config trying to grant the same
+	// scope would then be rejected while the default silently grants it).
+	for aud, scopes := range out {
 		if strings.TrimSpace(aud) == "" {
 			return nil, fmt.Errorf("audience_scope_profiles: empty audience name")
+		}
+		if len(scopes) == 0 {
+			// A recognized-but-empty profile mints a token with the audience stamped
+			// and ZERO scopes — every scope-gated action then silently denies. Reject
+			// at boot (fail loud) rather than shipping a scopeless audience.
+			return nil, fmt.Errorf(
+				"audience_scope_profiles[%q]: empty scope list — a recognized audience must grant at least one scope",
+				aud)
 		}
 		for _, sc := range scopes {
 			if !allowedProfileScopes[sc] {
@@ -215,7 +230,6 @@ func ResolveAudienceScopeProfiles(configured map[string][]string) (map[string][]
 					aud, sc)
 			}
 		}
-		out[aud] = slices.Clone(scopes)
 	}
 	return out, nil
 }
@@ -274,7 +288,13 @@ func NewOAuthService(
 // set them still resolve the standard audiences.
 func audienceProfilesOrDefault(configured map[string][]string) map[string][]string {
 	if configured == nil {
-		return defaultAudienceScopeProfiles
+		// Deep-copy the shared defaults so a direct caller (e.g. a test) can never
+		// mutate the package global under another OAuthService in the same process.
+		out := make(map[string][]string, len(defaultAudienceScopeProfiles))
+		for aud, scopes := range defaultAudienceScopeProfiles {
+			out[aud] = slices.Clone(scopes)
+		}
+		return out
 	}
 	return configured
 }

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -283,20 +283,21 @@ func NewOAuthService(
 	}
 }
 
-// audienceProfilesOrDefault returns the configured profiles, or the built-in
-// defaults when nil — so direct NewOAuthService callers (e.g. tests) that don't
-// set them still resolve the standard audiences.
+// audienceProfilesOrDefault returns a deep copy of the configured profiles, or of
+// the built-in defaults when nil — so direct NewOAuthService callers (e.g. tests)
+// that don't set them still resolve the standard audiences. It always clones, so
+// an OAuthService can never alias the package-global defaults (nil path) nor a map
+// the caller retains and later mutates (non-nil path).
 func audienceProfilesOrDefault(configured map[string][]string) map[string][]string {
-	if configured == nil {
-		// Deep-copy the shared defaults so a direct caller (e.g. a test) can never
-		// mutate the package global under another OAuthService in the same process.
-		out := make(map[string][]string, len(defaultAudienceScopeProfiles))
-		for aud, scopes := range defaultAudienceScopeProfiles {
-			out[aud] = slices.Clone(scopes)
-		}
-		return out
+	source := configured
+	if source == nil {
+		source = defaultAudienceScopeProfiles
 	}
-	return configured
+	out := make(map[string][]string, len(source))
+	for aud, scopes := range source {
+		out[aud] = slices.Clone(scopes)
+	}
+	return out
 }
 
 // SetTrustedServiceValidator sets the validator for external principal token exchange.

--- a/internal/service/oauth_audience_test.go
+++ b/internal/service/oauth_audience_test.go
@@ -74,14 +74,28 @@ func TestDefaultAudienceProfilesAreWithinAllowlist(t *testing.T) {
 	}
 }
 
-// TestAudienceProfilesOrDefaultClones proves the nil path returns a deep copy, so
-// a caller can never mutate the shared package-global defaults.
+// TestAudienceProfilesOrDefaultClones proves both the nil and non-nil paths return
+// a deep copy, so a caller can never mutate the shared package-global defaults nor
+// a config map it passed in and still holds a reference to.
 func TestAudienceProfilesOrDefaultClones(t *testing.T) {
-	got := audienceProfilesOrDefault(nil)
-	got[audienceCodeoid][0] = "MUTATED"
-	got["injected"] = []string{"x"}
-	assert.NotEqual(t, "MUTATED", defaultAudienceScopeProfiles[audienceCodeoid][0],
-		"mutating the returned map's slice must not corrupt the shared default")
-	assert.NotContains(t, defaultAudienceScopeProfiles, "injected",
-		"adding a key to the returned map must not corrupt the shared default")
+	t.Run("nil path clones defaults", func(t *testing.T) {
+		got := audienceProfilesOrDefault(nil)
+		got[audienceCodeoid][0] = "MUTATED"
+		got["injected"] = []string{"x"}
+		assert.NotEqual(t, "MUTATED", defaultAudienceScopeProfiles[audienceCodeoid][0],
+			"mutating the returned map's slice must not corrupt the shared default")
+		assert.NotContains(t, defaultAudienceScopeProfiles, "injected",
+			"adding a key to the returned map must not corrupt the shared default")
+	})
+
+	t.Run("non-nil path clones the configured map", func(t *testing.T) {
+		input := map[string][]string{"custom": {"session:read"}}
+		got := audienceProfilesOrDefault(input)
+		got["custom"][0] = "MUTATED"
+		got["injected"] = []string{"x"}
+		assert.Equal(t, "session:read", input["custom"][0],
+			"mutating the returned map's slice must not corrupt the input config")
+		assert.NotContains(t, input, "injected",
+			"adding a key to the returned map must not corrupt the input config")
+	})
 }

--- a/internal/service/oauth_audience_test.go
+++ b/internal/service/oauth_audience_test.go
@@ -49,4 +49,39 @@ func TestResolveAudienceScopeProfiles(t *testing.T) {
 		_, err := ResolveAudienceScopeProfiles(map[string][]string{"  ": {"nhi:manage"}})
 		require.Error(t, err)
 	})
+
+	t.Run("an empty scope LIST is rejected (would silently neuter a profile)", func(t *testing.T) {
+		// A config typo like `codeoid: []` must fail loud at boot, not ship an
+		// audience that mints scopeless tokens.
+		_, err := ResolveAudienceScopeProfiles(map[string][]string{"x": {}})
+		require.Error(t, err)
+		_, err = ResolveAudienceScopeProfiles(map[string][]string{audienceCodeoid: {}})
+		require.Error(t, err, "overriding a default down to zero scopes must also fail")
+	})
+}
+
+// TestDefaultAudienceProfilesAreWithinAllowlist pins the invariant that every
+// built-in default profile grants at least one scope and only scopes the server
+// recognizes — so a future default can't drift out of allowedProfileScopes (which
+// would let a default grant a scope a deployer config is then rejected for).
+func TestDefaultAudienceProfilesAreWithinAllowlist(t *testing.T) {
+	for aud, scopes := range defaultAudienceScopeProfiles {
+		assert.NotEmptyf(t, scopes, "default profile %q must grant at least one scope", aud)
+		for _, sc := range scopes {
+			assert.Truef(t, allowedProfileScopes[sc],
+				"default profile %q scope %q must be in allowedProfileScopes", aud, sc)
+		}
+	}
+}
+
+// TestAudienceProfilesOrDefaultClones proves the nil path returns a deep copy, so
+// a caller can never mutate the shared package-global defaults.
+func TestAudienceProfilesOrDefaultClones(t *testing.T) {
+	got := audienceProfilesOrDefault(nil)
+	got[audienceCodeoid][0] = "MUTATED"
+	got["injected"] = []string{"x"}
+	assert.NotEqual(t, "MUTATED", defaultAudienceScopeProfiles[audienceCodeoid][0],
+		"mutating the returned map's slice must not corrupt the shared default")
+	assert.NotContains(t, defaultAudienceScopeProfiles, "injected",
+		"adding a key to the returned map must not corrupt the shared default")
 }


### PR DESCRIPTION
## What

Follow-up hardening on the config-driven audience-scope-profile mechanism shipped in #236 / v1.7.9, from an adversarial audit of the per-sandbox identity work. **No behavior change on the happy path** — three fail-loud/robustness fixes in `internal/service/oauth.go`:

1. **Reject an empty scope list at boot.** A config typo like `codeoid: []` was previously accepted and minted a token with the audience stamped but **zero** scopes → every scope-gated action silently denies, no startup signal. Now errors at boot (matches `trusted_internal_services`' fail-loud posture).
2. **Validate the built-in defaults against the allowlist too** (one unified pass over the merged set), so a future default scope can't drift out of `allowedProfileScopes` — which would let a default grant a scope a *deployer config* is then rejected for.
3. **`audienceProfilesOrDefault(nil)` returns a deep copy** of the defaults, closing a latent aliasing hazard where a direct caller could mutate the shared package global under another `OAuthService`.

## Tests
`internal/service/oauth_audience_test.go`: empty-scope-list rejection (incl. overriding a default to `[]`), a `defaults ⊆ allowlist` + non-empty invariant, and a clone guard for the nil path. `go build ./...`, `go vet`, the unit + integration audience suites all pass.

Not release-blocking; pure hardening on top of v1.7.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
