### PR TITLE
fix: accept code_agent sub_type for agents + 400 (not 500) on invalid sub_type

### DIFF
--- a/domain/identity.go
+++ b/domain/identity.go
@@ -111,13 +111,17 @@ const (
 	SubTypeToolAgent    SubType = "tool_agent"
 	SubTypeHumanProxy   SubType = "human_proxy"
 	SubTypeEvaluator    SubType = "evaluator"
+	// SubTypeCodeAgent is a code-generation/analysis agent (e.g. a coding-agent
+	// workspace). It is valid for BOTH identity_type=agent (a delegated code
+	// agent, e.g. forge's per-sandbox mint) and identity_type=application (a
+	// code-gen product registered as an application) — see the two sets below.
+	SubTypeCodeAgent SubType = "code_agent"
 
 	// Application sub-types.
 	SubTypeChatbot    SubType = "chatbot"
 	SubTypeAssistant  SubType = "assistant"
 	SubTypeAPIService SubType = "api_service"
 	SubTypeCustom     SubType = "custom"
-	SubTypeCodeAgent  SubType = "code_agent"
 
 	// Service sub-types.
 	SubTypeLLMProvider SubType = "llm_provider"
@@ -130,9 +134,15 @@ var agentSubTypes = map[SubType]bool{
 	SubTypeToolAgent:    true,
 	SubTypeHumanProxy:   true,
 	SubTypeEvaluator:    true,
+	// A code agent IS an agent. Previously code_agent was only accepted for
+	// identity_type=application, so registering a code agent as an agent (the
+	// correct type) failed validation and 500'd.
+	SubTypeCodeAgent: true,
 }
 
 // applicationSubTypes is the set of sub-types valid for identity_type = "application".
+// code_agent is also accepted here (a code-gen product modeled as an application)
+// for backward compatibility; it is primarily an agent sub-type (see agentSubTypes).
 var applicationSubTypes = map[SubType]bool{
 	SubTypeChatbot:    true,
 	SubTypeAssistant:  true,

--- a/domain/identity_test.go
+++ b/domain/identity_test.go
@@ -135,3 +135,36 @@ func TestBuildWIMSEURI_LengthCap(t *testing.T) {
 		t.Fatalf("error not ErrSPIFFEIDTooLong: %v", err)
 	}
 }
+
+// TestSubTypeValidForIdentityType pins the sub_type ↔ identity_type matrix.
+// Regression: code_agent must be valid for identity_type=agent (a delegated
+// code agent, e.g. forge's per-sandbox mint) — it was previously accepted only
+// for application, so registering a code agent as an agent (the correct type)
+// failed validation and 500'd.
+func TestSubTypeValidForIdentityType(t *testing.T) {
+	cases := []struct {
+		sub  SubType
+		typ  IdentityType
+		want bool
+	}{
+		// code_agent is valid for BOTH agent and application.
+		{SubTypeCodeAgent, IdentityTypeAgent, true},
+		{SubTypeCodeAgent, IdentityTypeApplication, true},
+		// A code_agent is not a service/mcp_server sub-type.
+		{SubTypeCodeAgent, IdentityTypeService, false},
+		{SubTypeCodeAgent, IdentityTypeMCPServer, false},
+		// Core agent sub-types stay agent-only.
+		{SubTypeToolAgent, IdentityTypeAgent, true},
+		{SubTypeToolAgent, IdentityTypeApplication, false},
+		// Application sub-types stay application-only.
+		{SubTypeChatbot, IdentityTypeApplication, true},
+		{SubTypeChatbot, IdentityTypeAgent, false},
+		// Empty sub-type is always valid (no sub-classification).
+		{"", IdentityTypeAgent, true},
+	}
+	for _, c := range cases {
+		if got := c.sub.ValidForIdentityType(c.typ); got != c.want {
+			t.Errorf("SubType(%q).ValidForIdentityType(%q) = %v, want %v", c.sub, c.typ, got, c.want)
+		}
+	}
+}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -196,7 +196,7 @@ func (s *IdentityService) RegisterIdentity(ctx context.Context, req RegisterIden
 		req.SubType = domain.SubTypeToolAgent
 	}
 	if !req.SubType.ValidForIdentityType(req.IdentityType) {
-		return nil, fmt.Errorf("invalid sub_type: %s", req.SubType)
+		return nil, fmt.Errorf("%w: invalid sub_type %q for identity_type %q", ErrInvalidIdentityField, req.SubType, req.IdentityType)
 	}
 	if req.AllowedScopes == nil {
 		req.AllowedScopes = []string{}
@@ -681,7 +681,7 @@ func (s *IdentityService) UpdateIdentity(ctx context.Context, id, accountID, pro
 	}
 	if req.SubType != "" {
 		if !req.SubType.ValidForIdentityType(identity.IdentityType) {
-			return nil, fmt.Errorf("invalid sub_type: %s", req.SubType)
+			return nil, fmt.Errorf("%w: invalid sub_type %q for identity_type %q", ErrInvalidIdentityField, req.SubType, identity.IdentityType)
 		}
 		identity.SubType = req.SubType
 	}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -675,15 +675,21 @@ func (s *IdentityService) UpdateIdentity(ctx context.Context, id, accountID, pro
 	}
 	if req.IdentityType != "" {
 		if !req.IdentityType.Valid() {
-			return nil, fmt.Errorf("invalid identity_type: %s", req.IdentityType)
+			return nil, fmt.Errorf("%w: invalid identity_type: %s", ErrInvalidIdentityField, req.IdentityType)
 		}
 		identity.IdentityType = req.IdentityType
 	}
 	if req.SubType != "" {
-		if !req.SubType.ValidForIdentityType(identity.IdentityType) {
-			return nil, fmt.Errorf("%w: invalid sub_type %q for identity_type %q", ErrInvalidIdentityField, req.SubType, identity.IdentityType)
-		}
 		identity.SubType = req.SubType
+	}
+	// Whenever the identity_type OR the sub_type changed, the FINAL combination
+	// must be valid — otherwise retyping alone (sub_type unchanged) could strand a
+	// sub_type that isn't valid for the new identity_type. Only enforced when one
+	// of the two was actually touched, so an unrelated update (e.g. Name) never
+	// fails on pre-existing data.
+	if (req.IdentityType != "" || req.SubType != "") &&
+		!identity.SubType.ValidForIdentityType(identity.IdentityType) {
+		return nil, fmt.Errorf("%w: invalid sub_type %q for identity_type %q", ErrInvalidIdentityField, identity.SubType, identity.IdentityType)
 	}
 	if req.OwnerUserID != "" {
 		identity.OwnerUserID = req.OwnerUserID


### PR DESCRIPTION
## Symptom
Launching an agent sandbox in dev1 failed with **500** from `POST /agents/register`:
```
error: "invalid sub_type: code_agent"  caller: internal/handler/agent.go  → status 500
```

## Root cause — two bugs
Forge's per-sandbox identity mint registers with `identity_type: "agent"` + `sub_type: "code_agent"` (a code agent IS an agent). But:

1. **`code_agent` was only valid for `identity_type=application`** (`domain/identity.go`: it was in `applicationSubTypes`, never `agentSubTypes`), so `SubType.ValidForIdentityType("agent")` returned false and the registration was rejected.
2. **The rejection 500'd instead of 400.** The service returned a bare `fmt.Errorf("invalid sub_type: %s", …)`; the register handler only maps known sentinels to 4xx and falls through to `Error500InternalServerError` for anything else. A caller-supplied invalid sub_type is a **client** error.

## Fix
1. Add `code_agent` to `agentSubTypes` — kept in `applicationSubTypes` too (**additive, non-breaking**: a code-gen product modeled as an `application` still validates; a delegated code agent modeled as an `agent` now validates).
2. Wrap the two "invalid sub_type" errors in `ErrInvalidIdentityField` (already mapped to **400** by the handlers) and name the offending `sub_type` + `identity_type` in the message.

## Test
- New `domain.TestSubTypeValidForIdentityType` pins the matrix (`code_agent` valid for agent **and** application; agent/application sub-types stay type-scoped; empty always valid).
- `domain` + `internal/service` + `internal/handler` suites pass; `go build ./...` clean (`GOEXPERIMENT=jsonv2`).

## Deploy note
dev1 runs **v1.7.9** (latest) which has this bug, so a release + AuthN bump is needed to unblock the forge sandbox mint there. Forge keeps sending the semantically-correct `code_agent` (no forge change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)