### PR TITLE
feat: fall back to user_name for the OIDC-standard name claim on external-principal exchange

### DIFF
--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -416,6 +416,15 @@ func (s *CredentialService) IssueCredential(ctx context.Context, req IssueReques
 	// make identity-aware decisions without calling back to ZeroID.
 	if req.Identity.Name != "" {
 		_ = token.Set("name", req.Identity.Name)
+	} else if req.UserName != "" {
+		// No principal-specific name (e.g. the trusted external-principal
+		// exchange, where the minted principal is an ephemeral service
+		// identity acting on behalf of a human). Fall back to the acting
+		// user's display name so the OIDC-standard `name` claim (RFC 7519 /
+		// OpenID Connect) is populated for spec-compliant clients that read
+		// it. `user_name` below still carries the value verbatim; this only
+		// mirrors it into the reserved `name` claim when nothing else owns it.
+		_ = token.Set("name", req.UserName)
 	}
 	if req.Identity.Framework != "" {
 		_ = token.Set("framework", req.Identity.Framework)

--- a/tests/integration/audience_profile_test.go
+++ b/tests/integration/audience_profile_test.go
@@ -111,6 +111,44 @@ func TestExternalPrincipalExchange_AudienceProfile(t *testing.T) {
 			"scopes must be exactly the server-defined codeoid web-operator set")
 	})
 
+	t.Run("user_name mirrors into the OIDC-standard name claim when the principal has none", func(t *testing.T) {
+		// The external-principal exchange mints an ephemeral service identity
+		// with no name of its own, so a spec-compliant client (e.g. the codeoid
+		// web UI) reading the standard `name` claim would otherwise fall back to
+		// the raw `sub`. The exchange mirrors the acting user's display name into
+		// `name` so it renders correctly; `user_name` still carries it verbatim.
+		b := baseExchange("codeoid-user-006")
+		b["audience"] = "codeoid"
+		b["user_name"] = "Yash Datta"
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Equal(t, "Yash Datta", claims["name"],
+			"name must fall back to user_name when the principal has no name of its own")
+		assert.Equal(t, "Yash Datta", claims["user_name"],
+			"user_name is still emitted verbatim alongside the standard name claim")
+		assert.Equal(t, "codeoid-user-006", claims["sub"],
+			"sub is unaffected — it remains the external user id")
+	})
+
+	t.Run("no user_name leaves the name claim unset (no regression)", func(t *testing.T) {
+		// Without a user display name and without a principal name, `name` must
+		// stay absent rather than being coerced to an empty string.
+		b := baseExchange("codeoid-user-007")
+		b["audience"] = "codeoid"
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		_, present := claims["name"]
+		assert.False(t, present, "name must not be emitted when there is nothing to name")
+	})
+
 	t.Run("codeoid audience ignores caller-supplied scopes (never widened)", func(t *testing.T) {
 		b := baseExchange("codeoid-user-002")
 		b["audience"] = "codeoid"


### PR DESCRIPTION
## Problem

The codeoid embedded web UI's identity chip shows the raw `sub` (e.g. `user_3FX8DTFUYoDYFTETmQJN0NGoKWh`) instead of the user's name on dev1.

codeoid (an upstream, standards-based client) renders the **OIDC-standard `name` claim**, falling back to `sub` when it's absent. On the **trusted external-principal exchange** (the path Studio→Admin use to mint codeoid embedded-SSO tokens, `audience=codeoid`), the minted principal is an **ephemeral service identity with no name of its own**, so `credential.go` set no `name` claim — the human's display name lived only in the Highflame-specific `user_name` claim, which standards-based clients don't read.

> Contrast: running locally, you authenticate *as a registered ZeroID identity* that has its own `Identity.Name` (e.g. `yash-web`), so `name` is present and renders fine. Only the external-principal path was affected.

## Fix

When the principal has no name of its own, mirror the acting user's display name (`user_name`) into the reserved `name` claim:

```go
if req.Identity.Name != "" {
    _ = token.Set("name", req.Identity.Name)
} else if req.UserName != "" {
    _ = token.Set("name", req.UserName)   // OIDC-standard; what codeoid reads
}
```

- **`else if`** ⇒ a real identity name (agent/service tokens) is never clobbered.
- Fires only when `user_name` is present ⇒ tokens without one keep `name` absent (no empty-string coercion).
- `name` is a zeroid-**reserved** claim (can't be set via `additional_claims`), so this mint layer is the correct place to populate it.
- **No client-side change**: codeoid and any standards-based consumer immediately render the user's name.

## Tests

Extended `tests/integration/audience_profile_test.go`:
- `user_name` mirrors into `name` on the codeoid-audience exchange (and `user_name`/`sub` unaffected).
- no `user_name` ⇒ `name` stays absent (no regression).

`GOEXPERIMENT=jsonv2 go test ./tests/integration/ -run TestExternalPrincipalExchange_AudienceProfile` → all pass. `go vet ./...` + `gofmt` clean.

## Rollout

Standards-only change to the mint. After merge + release, bump the zeroid pin in `highflame-authn` and deploy to dev1; the codeoid top bar then shows the user's name with no codeoid image repin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)