### PR TITLE
fix: grant codeoid audience the pipeline scopes for the embedded UI

### DIFF
--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -154,6 +154,11 @@ const audienceAgentSandbox = "agent-sandbox"
 var defaultAudienceScopeProfiles = map[string][]string{
 	// codeoid: the web-operator scope set the codeoid daemon re-verifies (via
 	// JWKS) and reads from the `scopes` claim to authorize embedded-UI actions.
+	// The `pipeline:*` scopes drive the embedded /packs Pack Browser + /pipeline
+	// runner (pack.list needs pipeline:read); without them the embedded UI renders
+	// but every pipeline verb is rejected "Missing scope: pipeline:read". Unlike
+	// the api-key exchange flow (which widens its own request), the embed-handoff
+	// token is used verbatim, so this server-side profile is the only lever.
 	audienceCodeoid: {
 		"session:list",
 		"session:create",
@@ -166,6 +171,10 @@ var defaultAudienceScopeProfiles = map[string][]string{
 		"session:read",
 		"session:dispatch",
 		"fs:read",
+		"pipeline:read",
+		"pipeline:create",
+		"pipeline:answer",
+		"pipeline:manage",
 	},
 	// agent-sandbox: just `nhi:manage` — the one capability a broker's token needs
 	// to register a per-sandbox identity on the user's behalf.
@@ -191,6 +200,10 @@ var allowedProfileScopes = map[string]bool{
 	"session:dispatch":  true,
 	"fs:read":           true,
 	"nhi:manage":        true,
+	"pipeline:read":     true,
+	"pipeline:create":   true,
+	"pipeline:answer":   true,
+	"pipeline:manage":   true,
 }
 
 // ResolveAudienceScopeProfiles merges deployer-configured audience profiles over

--- a/tests/integration/audience_profile_test.go
+++ b/tests/integration/audience_profile_test.go
@@ -24,6 +24,10 @@ var codeoidScopeProfile = []string{
 	"session:read",
 	"session:dispatch",
 	"fs:read",
+	"pipeline:read",
+	"pipeline:create",
+	"pipeline:answer",
+	"pipeline:manage",
 }
 
 // agentSandboxScopeProfile mirrors defaultAudienceScopeProfiles["agent-sandbox"]:


### PR DESCRIPTION
## Problem
Running `/packs` (or `/pipeline`) in the **embedded** codeoid UI (Studio handoff / dev1) fails with **`Missing scope: pipeline:read`**, even after highflame-forge #42.

A decoded embed token shows `aud: ["codeoid"]` ✅ but `scopes: [session:*, fs:read]` — **no `pipeline:*`**.

## Root cause
The `codeoid` audience scope profile in `internal/service/oauth.go` (`defaultAudienceScopeProfiles`) — the fixed `scopes` claim minted on the trusted **external-principal token exchange** — lists only `session:*` + `fs:read`. The codeoid daemon reads that claim to authorize embedded-UI actions, so `pipeline.pack.list` (needs `pipeline:read`) is rejected.

**Why the other fixes don't cover this path:**
- codeoid#215 widened the web UI's `DEFAULT_WEB_SCOPES` — only helps the **api-key exchange** flow (the UI widens its own request).
- highflame-forge #42 raised the **Forge-mint** badge ceiling — only the local Forge-mint path.
- This token is the **embed handoff**, used *verbatim* (`exchanged:false`). Its scopes come entirely from this server-side audience profile — the only lever.

## Fix
Add `pipeline:read`, `pipeline:create`, `pipeline:answer`, `pipeline:manage` to:
1. `defaultAudienceScopeProfiles[codeoid]` — the granted set, and
2. `allowedProfileScopes` — the bound every profile (default **or** deployer config) is validated against. Without (2), the default would fail startup (fail-closed), and a deployer override couldn't grant these either.

Scope set mirrors codeoid's web-operator set. `pipeline:manage` is owner-tier (trust a pack + run its command gates), but those gates run inside the already-isolated sandbox, so the blast radius is contained.

## Verification
- `go build` + full `internal/service` tests green (with `GOEXPERIMENT=jsonv2`, matching the repo's jwx/v4 toolchain); `gofmt` clean.
- The existing `oauth_audience_test.go` invariant (every default-profile scope must be in `allowedProfileScopes`) passes — both edits landed together.

## Note
Deployers who **override** the codeoid profile via `audience_scope_profiles` config (e.g. dev1 in highflame-cloud) must add the pipeline scopes there too — this PR only moves the built-in default + the allowlist bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)