### PR TITLE
feat: add state filter to API keys list endpoint

### DIFF
--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -45,6 +45,7 @@ type APIKeyOutput struct {
 type APIKeyListInput struct {
 	Product       string `query:"product" doc:"Filter by product namespace"`
 	ApplicationID string `query:"application_id" doc:"Filter by application identity ID"`
+	State         string `query:"state" doc:"Filter by key state (active, revoked, expired)"`
 	Label         string `query:"label" doc:"Filter by identity label (key:value, e.g. env:production)"`
 	Page          int    `query:"page" default:"1" doc:"Page number"`
 	Limit         int    `query:"limit" default:"20" doc:"Items per page (max 100)"`
@@ -171,7 +172,7 @@ func (a *API) listAPIKeysOp(ctx context.Context, input *APIKeyListInput) (*APIKe
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	keys, total, err := a.apiKeySvc.ListKeys(ctx, tenant.AccountID, tenant.ProjectID, input.ApplicationID, input.Product, input.Label, input.Page, input.Limit)
+	keys, total, err := a.apiKeySvc.ListKeys(ctx, tenant.AccountID, tenant.ProjectID, input.ApplicationID, input.Product, input.State, input.Label, input.Page, input.Limit)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list API keys")
 		return nil, huma.Error500InternalServerError("failed to list API keys")

--- a/internal/service/apikey.go
+++ b/internal/service/apikey.go
@@ -222,7 +222,7 @@ func (s *APIKeyService) ListExpiringSoon(ctx context.Context, accountID, project
 }
 
 // ListKeys returns paginated API keys for an account/project.
-func (s *APIKeyService) ListKeys(ctx context.Context, accountID, projectID, applicationID, product, label string, page, limit int) ([]*domain.APIKey, int, error) {
+func (s *APIKeyService) ListKeys(ctx context.Context, accountID, projectID, applicationID, product, state, label string, page, limit int) ([]*domain.APIKey, int, error) {
 	if page < 1 {
 		page = 1
 	}
@@ -231,7 +231,7 @@ func (s *APIKeyService) ListKeys(ctx context.Context, accountID, projectID, appl
 	}
 	offset := (page - 1) * limit
 
-	return s.repo.ListByAccountProject(ctx, accountID, projectID, applicationID, product, label, limit, offset)
+	return s.repo.ListByAccountProject(ctx, accountID, projectID, applicationID, product, state, label, limit, offset)
 }
 
 // GetKey returns an API key by ID, scoped to the given tenant. Cross-tenant

--- a/internal/store/postgres/apikey.go
+++ b/internal/store/postgres/apikey.go
@@ -77,7 +77,7 @@ func (r *APIKeyRepository) GetByID(ctx context.Context, id, accountID, projectID
 // optionally filtered by application ID, product, or identity label.
 // The label parameter accepts "key:value" format (e.g. "env:production")
 // and filters by joining on the identities table using JSONB containment.
-func (r *APIKeyRepository) ListByAccountProject(ctx context.Context, accountID, projectID, applicationID, product, label string, limit, offset int) ([]*domain.APIKey, int, error) {
+func (r *APIKeyRepository) ListByAccountProject(ctx context.Context, accountID, projectID, applicationID, product, state, label string, limit, offset int) ([]*domain.APIKey, int, error) {
 	var keys []*domain.APIKey
 
 	q := r.db.NewSelect().
@@ -95,6 +95,9 @@ func (r *APIKeyRepository) ListByAccountProject(ctx context.Context, accountID, 
 	}
 	if product != "" {
 		q = q.Where("sk.product = ?", product)
+	}
+	if state != "" {
+		q = q.Where("sk.state = ?", state)
 	}
 	if label != "" {
 		parts := strings.SplitN(label, ":", 2)


### PR DESCRIPTION
## Summary
- Adds `state` query parameter to `GET /api-keys` endpoint for filtering by key state (`active`, `revoked`, `expired`)
- When omitted, returns all keys (backward compatible)

## Changes
- `internal/handler/apikey.go` — Added `State` field to `APIKeyListInput`
- `internal/service/apikey.go` — Pass `state` through to repo
- `internal/store/postgres/apikey.go` — Added `WHERE sk.state = ?` clause when state is non-empty

## Test plan
- [ ] `GET /api-keys?state=active` returns only active keys
- [ ] `GET /api-keys?state=revoked` returns only revoked keys
- [ ] `GET /api-keys` (no state param) returns all keys as before

Resolves highflame-ai/highflame-studio#1272

🤖 Generated with [Claude Code](https://claude.com/claude-code)