### PR TITLE
feat: add include_parents to the agents list to hydrate off-page parents

### DIFF
--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -100,20 +100,21 @@ func splitCSV(vals []string) []string {
 }
 
 type ListAgentsInput struct {
-	AgentType     string   `query:"agent_type" doc:"Filter by agent type"`
-	IdentityType  []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
-	Label         string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
-	TrustLevel    []string `query:"trust_level" doc:"Filter by trust level. Comma-separated for multiple."`
-	IsActive      string   `query:"is_active" doc:"Filter by active status"`
-	Search        string   `query:"search" doc:"Search by name or external_id"`
-	Metadata      string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
-	IdentityClass string   `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
-	Origin        string   `query:"origin" doc:"Filter by provenance: an exact ecosystem (e.g. okta) or \"external\" for any discovered (non-native) identity"`
-	Status        []string `query:"status" doc:"Filter by lifecycle status. Comma-separated for multiple."`
-	OwnerUserID   string   `query:"owner_user_id" doc:"Filter by owner user ID"`
-	Ownerless     string   `query:"ownerless" doc:"Filter for identities with no owner (true or false)"`
-	Limit         int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
-	Offset        int      `query:"offset" default:"0" doc:"Offset for pagination"`
+	AgentType      string   `query:"agent_type" doc:"Filter by agent type"`
+	IdentityType   []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
+	Label          string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
+	TrustLevel     []string `query:"trust_level" doc:"Filter by trust level. Comma-separated for multiple."`
+	IsActive       string   `query:"is_active" doc:"Filter by active status"`
+	Search         string   `query:"search" doc:"Search by name or external_id"`
+	Metadata       string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
+	IdentityClass  string   `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
+	Origin         string   `query:"origin" doc:"Filter by provenance: an exact ecosystem (e.g. okta) or \"external\" for any discovered (non-native) identity"`
+	Status         []string `query:"status" doc:"Filter by lifecycle status. Comma-separated for multiple."`
+	OwnerUserID    string   `query:"owner_user_id" doc:"Filter by owner user ID"`
+	Ownerless      string   `query:"ownerless" doc:"Filter for identities with no owner (true or false)"`
+	Limit          int      `query:"limit" default:"20" doc:"Items per page (max 100)"`
+	Offset         int      `query:"offset" default:"0" doc:"Offset for pagination"`
+	IncludeParents bool     `query:"include_parents" doc:"Also return, in \"parents\", the parent agents of any sub-agents on this page whose parent is not itself on the page, so a paginated caller can nest them. Context only: not counted in total/limit/offset."`
 }
 
 type ListAgentsOutput struct {
@@ -417,7 +418,7 @@ func (a *API) listAgentsOp(ctx context.Context, input *ListAgentsInput) (*ListAg
 		return nil, huma.Error400BadRequest("invalid ownerless filter: must be true or false")
 	}
 
-	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, identityTypes, input.Label, trustLevels, input.IsActive, input.Search, input.Metadata, input.IdentityClass, input.Origin, statuses, input.OwnerUserID, input.Ownerless, input.Limit, input.Offset)
+	resp, err := a.agentSvc.ListAgents(ctx, tenant.AccountID, tenant.ProjectID, identityTypes, input.Label, trustLevels, input.IsActive, input.Search, input.Metadata, input.IdentityClass, input.Origin, statuses, input.OwnerUserID, input.Ownerless, input.Limit, input.Offset, input.IncludeParents)
 	if err != nil {
 		return nil, mapErr(err)
 	}

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -124,6 +124,10 @@ type AgentListResponse struct {
 	Total  int             `json:"total"`
 	Limit  int             `json:"limit"`
 	Offset int             `json:"offset"`
+	// Parents holds parent agents hydrated for sub-agents on this page whose parent
+	// is not itself on the page, so a paginated caller can nest them. Context only
+	// — NOT counted in Total/Limit/Offset.
+	Parents []AgentResponse `json:"parents,omitempty"`
 }
 
 // UpdateAgentRequest holds PATCH fields for updating an agent.
@@ -261,7 +265,7 @@ func (s *AgentService) GetAgent(ctx context.Context, id, accountID, projectID st
 
 // ListAgents lists agents for a tenant, optionally filtered by identity_type(s),
 // label, and metadata (key presence or key:value).
-func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label string, trustLevels []string, isActive, search, metadata, identityClass, origin string, statuses []string, ownerUserID, ownerless string, limit, offset int) (*AgentListResponse, error) {
+func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID string, identityTypes []string, label string, trustLevels []string, isActive, search, metadata, identityClass, origin string, statuses []string, ownerUserID, ownerless string, limit, offset int, includeParents bool) (*AgentListResponse, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
 	}
@@ -270,8 +274,7 @@ func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID stri
 	}
 
 	// origin/status surface the unified native∪discovered inventory through the
-	// agent registry list (the endpoint admin/Studio proxy) — same filters the
-	// identities list exposes.
+	// agent registry list endpoint — the same filters the identities list exposes.
 	identities, total, err := s.identitySvc.ListIdentities(ctx, accountID, projectID, identityTypes, label, trustLevels, isActive, search, metadata, identityClass, origin, statuses, ownerUserID, ownerless, limit, offset)
 	if err != nil {
 		return nil, err
@@ -301,11 +304,17 @@ func (s *AgentService) ListAgents(ctx context.Context, accountID, projectID stri
 		agents[i].DelegationDepth = depthMap[id.ID]
 	}
 
+	var parents []AgentResponse
+	if includeParents {
+		parents = s.hydrateParents(ctx, accountID, projectID, identities)
+	}
+
 	return &AgentListResponse{
-		Agents: agents,
-		Total:  total,
-		Limit:  limit,
-		Offset: offset,
+		Agents:  agents,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+		Parents: parents,
 	}, nil
 }
 
@@ -583,6 +592,82 @@ func identityToAgentResponse(identity *domain.Identity, keyPrefix string) AgentR
 		CreatedBy:          identity.CreatedBy,
 		UpdatedAt:          identity.UpdatedAt,
 	}
+}
+
+// agentMeta is the subset of an agent's opaque metadata this service reads to
+// resolve agent → sub-agent hierarchy: a sub-agent points at its parent agent via
+// the parent_external_id key.
+type agentMeta struct {
+	ParentExternalID string `json:"parent_external_id"`
+}
+
+// hydrateParents returns the parent agents of any sub-agents in page whose parent
+// is not itself on the page — an agent is treated as a sub-agent when its metadata
+// carries a parent_external_id. It walks the ancestor chain so nested sub-agents
+// also resolve. Parents are fetched by external_id regardless of status/filter, so
+// a sub-agent whose parent is on another page — or filtered out (e.g. deactivated)
+// — can still be nested under it by a paginated caller.
+func (s *AgentService) hydrateParents(ctx context.Context, accountID, projectID string, page []*domain.Identity) []AgentResponse {
+	present := make(map[string]bool, len(page))
+	for _, id := range page {
+		present[id.ExternalID] = true
+	}
+
+	missing := missingParentExternalIDs(page, present)
+	var hydrated []AgentResponse
+
+	// Ancestor chains are shallow; cap rounds so a pathological/cyclic
+	// parent_external_id can never loop forever.
+	const maxRounds = 8
+	for round := 0; round < maxRounds && len(missing) > 0; round++ {
+		fetched, err := s.identitySvc.ListByExternalIDs(ctx, accountID, projectID, missing)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to hydrate parent agents, continuing without")
+
+			break
+		}
+		if len(fetched) == 0 {
+			break
+		}
+		for _, id := range fetched {
+			present[id.ExternalID] = true
+			hydrated = append(hydrated, identityToAgentResponse(id, s.getKeyPrefix(ctx, id.ID)))
+		}
+		missing = missingParentExternalIDs(fetched, present)
+	}
+
+	return hydrated
+}
+
+// missingParentExternalIDs collects the distinct parent_external_id of every
+// sub-agent in ids (an agent whose metadata sets parent_external_id) whose parent
+// is not already in present.
+func missingParentExternalIDs(ids []*domain.Identity, present map[string]bool) []string {
+	seen := make(map[string]bool)
+
+	var out []string
+
+	for _, id := range ids {
+		if len(id.Metadata) == 0 {
+			continue
+		}
+
+		var meta agentMeta
+		if err := json.Unmarshal(id.Metadata, &meta); err != nil {
+			continue
+		}
+		if meta.ParentExternalID == "" {
+			continue
+		}
+		if present[meta.ParentExternalID] || seen[meta.ParentExternalID] {
+			continue
+		}
+
+		seen[meta.ParentExternalID] = true
+		out = append(out, meta.ParentExternalID)
+	}
+
+	return out
 }
 
 func (s *AgentService) getKeyPrefix(ctx context.Context, identityID string) string {

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -613,6 +613,13 @@ func (s *IdentityService) ListIdentities(ctx context.Context, accountID, project
 	return s.repo.List(ctx, accountID, projectID, identityTypes, label, trustLevels, isActive, search, metadata, identityClass, origin, statuses, ownerUserID, ownerless, limit, offset)
 }
 
+// ListByExternalIDs fetches identities by external_id within a tenant, used to
+// hydrate the parent agents of sub-agents so a paginated caller can nest them
+// regardless of pagination/filtering.
+func (s *IdentityService) ListByExternalIDs(ctx context.Context, accountID, projectID string, externalIDs []string) ([]*domain.Identity, error) {
+	return s.repo.ListByExternalIDs(ctx, accountID, projectID, externalIDs)
+}
+
 // GetFacets returns grouped counts for each filterable identity dimension.
 func (s *IdentityService) GetFacets(ctx context.Context, accountID, projectID string) (*postgres.IdentityFacets, error) {
 	return s.repo.GetFacets(ctx, accountID, projectID)

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -226,6 +226,28 @@ func (r *IdentityRepository) List(ctx context.Context, accountID, projectID stri
 	return identities, total, nil
 }
 
+// ListByExternalIDs fetches identities by external_id within a tenant. external_id
+// is UNIQUE per (account, project) and indexed, so this is an indexed lookup. Used
+// to hydrate the parent agents of sub-agents that landed on a list page without
+// their parent, so a paginated caller can still nest them. It deliberately applies
+// no status/class filter: a sub-agent's parent must resolve even when the parent
+// would otherwise be filtered out (e.g. deactivated).
+func (r *IdentityRepository) ListByExternalIDs(ctx context.Context, accountID, projectID string, externalIDs []string) ([]*domain.Identity, error) {
+	if len(externalIDs) == 0 {
+		return nil, nil
+	}
+	var identities []*domain.Identity
+	db := dbOrTx(ctx, r.db)
+	if err := db.NewSelect().Model(&identities).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("external_id IN (?)", bun.List(externalIDs)).
+		Scan(ctx); err != nil {
+		return nil, fmt.Errorf("failed to list identities by external_ids: %w", err)
+	}
+	return identities, nil
+}
+
 // FacetValue is a single value+count pair in a faceted aggregation.
 type FacetValue struct {
 	Value string `json:"value"`

--- a/tests/integration/agent_include_parents_test.go
+++ b/tests/integration/agent_include_parents_test.go
@@ -1,0 +1,133 @@
+// Tests for GET /agents/registry?include_parents=true — parent hydration that
+// lets a paginated/filtered caller nest sub-agents under their parent agent even
+// when the parent is off-page or filtered out.
+
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// registerAgentWithParent registers an agent via POST /agents/register, scoped to
+// `suite` via a label, and returns its id. A non-empty parentExternalID makes it a
+// sub-agent (its metadata carries parent_external_id).
+func registerAgentWithParent(t *testing.T, suite, externalID, parentExternalID string) string {
+	t.Helper()
+
+	meta := map[string]any{}
+	if parentExternalID != "" {
+		meta["parent_external_id"] = parentExternalID
+	}
+
+	resp := post(t, adminPath("/agents/register"), map[string]any{
+		"external_id": externalID,
+		"name":        externalID,
+		"sub_type":    "autonomous",
+		"trust_level": "first_party",
+		"created_by":  "test-user",
+		"labels":      map[string]string{"suite": suite},
+		"metadata":    meta,
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "registerAgentWithParent: expected 201")
+
+	body := decode(t, resp)
+	ident := body["identity"].(map[string]any)
+
+	return ident["id"].(string)
+}
+
+// agentFamily creates a parent agent (created first, so it sorts older) and a
+// sub-agent whose parent_external_id points at it, both scoped to a fresh suite
+// label. Returns the suite label, the parent external_id, the sub-agent
+// external_id, and the parent's identity id.
+func agentFamily(t *testing.T) (suite, parentExt, childExt, parentID string) {
+	t.Helper()
+
+	suite = uid("agent-nest")
+	parentExt = uid("agent-parent")
+	childExt = parentExt + "-sub-a1"
+	parentID = registerAgentWithParent(t, suite, parentExt, "")
+	registerAgentWithParent(t, suite, childExt, parentExt)
+
+	return suite, parentExt, childExt, parentID
+}
+
+func agentExternalIDs(agents []any) []string {
+	out := make([]string, 0, len(agents))
+	for _, a := range agents {
+		out = append(out, a.(map[string]any)["external_id"].(string))
+	}
+
+	return out
+}
+
+// TestListAgents_IncludeParents_HydratesFilteredOutParent is the core case: the
+// parent agent is DEACTIVATED, so status=active filters it out of the page
+// entirely. include_parents must still hydrate it so a caller can nest the
+// (active) sub-agent under it.
+func TestListAgents_IncludeParents_HydratesFilteredOutParent(t *testing.T) {
+	suite, parentExt, childExt, parentID := agentFamily(t)
+
+	// Deactivate the parent agent (DELETE = deactivate, per the identities API).
+	deact, err := doRaw(t, http.MethodDelete, adminPath("/identities/"+parentID), nil, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, deact.StatusCode)
+	_ = deact.Body.Close()
+
+	resp := get(t, adminPath("/agents/registry?label=suite:"+suite+"&status=active&include_parents=true"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	// The status=active page contains only the sub-agent — the parent is filtered out.
+	agents := body["agents"].([]any)
+	require.Equal(t, []string{childExt}, agentExternalIDs(agents))
+
+	// ...but the parent agent is hydrated as context so a caller can nest.
+	require.Contains(t, body, "parents")
+	parents := body["parents"].([]any)
+	require.Len(t, parents, 1, "filtered-out parent agent must be hydrated")
+	parent := parents[0].(map[string]any)
+	assert.Equal(t, parentExt, parent["external_id"])
+	assert.NotEqual(t, "active", parent["status"], "hydrated parent is the deactivated agent")
+}
+
+// TestListAgents_IncludeParents_HydratesOffPageParent covers pagination: the
+// parent agent is simply on another page (limit=1), not filtered out.
+func TestListAgents_IncludeParents_HydratesOffPageParent(t *testing.T) {
+	suite, parentExt, childExt, _ := agentFamily(t)
+
+	// limit=1 + created_at DESC: page 1 holds the newer sub-agent; the parent is
+	// on page 2.
+	resp := get(t, adminPath("/agents/registry?label=suite:"+suite+"&limit=1&include_parents=true"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	agents := body["agents"].([]any)
+	require.Equal(t, []string{childExt}, agentExternalIDs(agents))
+	assert.Equal(t, float64(2), body["total"], "total counts real rows only, not hydrated parents")
+
+	parents := body["parents"].([]any)
+	require.Len(t, parents, 1, "off-page parent agent must be hydrated")
+	assert.Equal(t, parentExt, parents[0].(map[string]any)["external_id"])
+}
+
+// TestListAgents_IncludeParents_OmittedByDefault: without include_parents the
+// server must not hydrate — parents is absent/empty, preserving legacy behavior.
+func TestListAgents_IncludeParents_OmittedByDefault(t *testing.T) {
+	suite, _, childExt, _ := agentFamily(t)
+
+	resp := get(t, adminPath("/agents/registry?label=suite:"+suite+"&limit=1"), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body := decode(t, resp)
+
+	agents := body["agents"].([]any)
+	require.Equal(t, []string{childExt}, agentExternalIDs(agents))
+
+	if p, ok := body["parents"]; ok {
+		assert.Empty(t, p, "parents must be empty/absent unless include_parents=true")
+	}
+}


### PR DESCRIPTION
## Why
`GET /agents/registry` is paginated, so a **sub-agent** (an agent whose metadata carries a `parent_external_id`) can land on a page without its parent — or with the parent filtered out (e.g. a deactivated agent). A paginated caller rendering the agent → sub-agent hierarchy then can't nest it under its real parent.

## What
Opt-in `include_parents=true` query param. When set, after fetching the page the service:
- collects the `parent_external_id` of every sub-agent on the page whose parent isn't already present,
- hydrates those parent agents via an **indexed `external_id IN (...)`** lookup (`ListByExternalIDs`), walking the ancestor chain for nested sub-agents (bounded),
- returns them in an additive **`parents`** array.

Properties:
- **`parents` is context, not page rows** — excluded from `total`/`limit`/`offset`, so pagination math is unchanged.
- Parents are fetched **regardless of status/filter**, so a sub-agent whose parent is deactivated/filtered still resolves.
- **Backward compatible**: without the param, zero extra query and no `parents` field.

## Cost
One extra indexed `SELECT ... WHERE external_id IN (...)` per page, only when `include_parents=true` and the page contains sub-agents with off-page parents.

## Tests (integration, testcontainers Postgres)
- `HydratesFilteredOutParent` — parent deactivated (`status=active` filters it out) → still hydrated in `parents`.
- `HydratesOffPageParent` — parent on page 2 (`limit=1`) → hydrated; `total` still counts real rows only.
- `OmittedByDefault` — no param → no `parents`.

All pass; existing list/filter/agent integration tests unaffected. `go build` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)