### PR TITLE
fix: stamp the RFC 8707 resource binding as its own claim (shield#366)

### DIFF
--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -127,6 +127,13 @@ const defaultExternalPrincipalRefreshTokenTTL = 12 * 3600
 var reservedClaims = map[string]bool{
 	// RFC 7519 registered claims
 	"iss": true, "sub": true, "aud": true, "exp": true, "nbf": true, "iat": true, "jti": true,
+	// RFC 8707 resource binding. Shield reads `resource` as proof that ZeroID
+	// recorded a resource restriction AT THE MINT and enforces INV-IDN-006 on
+	// it — so the claim only means that if ZeroID is the only party who can set
+	// it. Reserving it keeps the presence of the claim load-bearing: a caller
+	// must never be able to make a token look resource-bound when it isn't, or
+	// to widen a real binding by overriding it through additional_claims.
+	"resource": true,
 	// ZeroID identity claims
 	"account_id": true, "project_id": true, "user_id": true, "owner_user_id": true,
 	"external_id": true, "identity_type": true, "sub_type": true, "trust_level": true,

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -214,6 +214,20 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		}
 	}
 
+	// RFC 8707 resource binding (D4), stamped as its own claim so downstream
+	// PEPs have an EXPLICIT signal that this token was resource-bound at the
+	// mint. `aud` carries the same value for RFC 8707 §2 conformance, but it
+	// cannot serve as the signal: ZeroID stamps `aud` on every token it issues,
+	// defaulting to the issuer URL to satisfy JWT-SVID §3, so a non-empty `aud`
+	// says nothing about whether a binding exists. Shield treating it as if it
+	// did denied every MCP-targeted request in prod (shield#366). Presence of
+	// THIS claim is the discriminator; its absence means "not resource-bound".
+	//
+	// Set after the PropagateClaims loop so a deployer that lists "resource" in
+	// propagate_claims cannot clobber the value we validated above, and
+	// reserved in reservedClaims so additional_claims cannot inject or widen it.
+	customClaims["resource"] = resources
+
 	// Resolve the identity's credential policy when we have a real identity row
 	// so issuance enforces the same policy ceiling (allowed scopes, max TTL,
 	// trust level, policy expiry) as every other grant.

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -40,6 +40,64 @@ func isIDJAGAssertion(assertion string) bool {
 	return hdr.Typ == idJAGTyp
 }
 
+// buildIDJAGCustomClaims assembles the custom claim set for an ID-JAG-minted
+// access token. Extracted from idJAGBearer so the claim set — notably the
+// RFC 8707 resource binding, which is security-load-bearing — is unit-testable
+// without a full mint (the repo's other ID-JAG tests are all fail-closed and
+// never reach issuance).
+//
+// role and privilege_scope are reservedClaims (an untrusted caller can never
+// inject them via additional_claims), but here ZeroID itself sources them from
+// the IdP-verified ID-JAG, so they are set directly into CustomClaims — which
+// bypasses the additional_claims blocklist by design, the same pattern the
+// trusted broker path uses.
+func buildIDJAGCustomClaims(
+	rawClaims map[string]any,
+	cfg domain.ExternalIssuerConfig,
+	upstreamIss string,
+	resources []string,
+) map[string]any {
+	customClaims := map[string]any{
+		"token_exchange": "id_jag",
+		"user_id_iss":    upstreamIss,
+	}
+
+	// Map IdP group/role claims into Cedar principal attributes (D3). OPTIONAL —
+	// present only when the ID-JAG carries the claim AND ClaimMapping routes it.
+	if role, ok := extractMappedClaimString(rawClaims, cfg.ClaimMapping["role"]); ok && role != "" {
+		customClaims["role"] = role
+	}
+
+	if ps, ok := extractMappedClaimStrings(rawClaims, cfg.ClaimMapping["privilege_scope"]); ok && len(ps) > 0 {
+		customClaims["privilege_scope"] = ps
+	}
+
+	// Honest propagation of RFC 9068 authentication-context claims — only
+	// forward auth_time/acr/amr when the deployer asked for them AND the ID-JAG
+	// actually set them. Never default-fill.
+	for _, claim := range cfg.PropagateClaims {
+		if v, present := rawClaims[claim]; present {
+			customClaims[claim] = v
+		}
+	}
+
+	// RFC 8707 resource binding (D4), stamped as its own claim so downstream PEPs
+	// have an EXPLICIT signal that this token was resource-bound at the mint.
+	// `aud` carries the same value for RFC 8707 §2 conformance, but it cannot
+	// serve as the signal: ZeroID stamps `aud` on every token it issues,
+	// defaulting to the issuer URL to satisfy JWT-SVID §3, so a non-empty `aud`
+	// says nothing about whether a binding exists. Shield treating it as if it did
+	// denied every MCP-targeted request in prod (shield#366). Presence of THIS
+	// claim is the discriminator; its absence means "not resource-bound".
+	//
+	// Set LAST, after the PropagateClaims loop, so a deployer who lists "resource"
+	// in propagate_claims cannot clobber the value validated by the caller. Also
+	// in reservedClaims, so additional_claims cannot inject or widen it.
+	customClaims["resource"] = resources
+
+	return customClaims
+}
+
 // idJAGBearer mints an audience-restricted ZeroID access token from an MCP
 // ID-JAG presented at POST /oauth2/token with
 // grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer (ADR 0010 D2-D4).
@@ -188,45 +246,14 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 	// itself sources them from the IdP-verified ID-JAG, so we set them directly
 	// into CustomClaims (which bypasses the additional_claims blocklist by
 	// design — same pattern the trusted broker path uses for role/privilege_scope).
-	customClaims := map[string]any{
-		"token_exchange": "id_jag",
-		"user_id_iss":    upstreamIss,
-	}
-	if role, ok := extractMappedClaimString(rawClaims, cfg.ClaimMapping["role"]); ok && role != "" {
-		customClaims["role"] = role
-	}
-	if ps, ok := extractMappedClaimStrings(rawClaims, cfg.ClaimMapping["privilege_scope"]); ok && len(ps) > 0 {
-		customClaims["privilege_scope"] = ps
-	}
+	customClaims := buildIDJAGCustomClaims(rawClaims, cfg, upstreamIss, resources)
+
 	// trust_level, when the IdP supplies it via ClaimMapping, overrides the
 	// synthetic identity's default so the minted trust_level claim reflects the
 	// IdP's assessment (e.g. an Okta group → verified_third_party).
 	if tl, ok := extractMappedClaimString(rawClaims, cfg.ClaimMapping["trust_level"]); ok && tl != "" {
 		identity.TrustLevel = domain.TrustLevel(tl)
 	}
-
-	// Honest propagation of RFC 9068 authentication-context claims — only
-	// forward auth_time/acr/amr when the deployer asked for them AND the ID-JAG
-	// actually set them. Never default-fill.
-	for _, claim := range cfg.PropagateClaims {
-		if v, present := rawClaims[claim]; present {
-			customClaims[claim] = v
-		}
-	}
-
-	// RFC 8707 resource binding (D4), stamped as its own claim so downstream
-	// PEPs have an EXPLICIT signal that this token was resource-bound at the
-	// mint. `aud` carries the same value for RFC 8707 §2 conformance, but it
-	// cannot serve as the signal: ZeroID stamps `aud` on every token it issues,
-	// defaulting to the issuer URL to satisfy JWT-SVID §3, so a non-empty `aud`
-	// says nothing about whether a binding exists. Shield treating it as if it
-	// did denied every MCP-targeted request in prod (shield#366). Presence of
-	// THIS claim is the discriminator; its absence means "not resource-bound".
-	//
-	// Set after the PropagateClaims loop so a deployer that lists "resource" in
-	// propagate_claims cannot clobber the value we validated above, and
-	// reserved in reservedClaims so additional_claims cannot inject or widen it.
-	customClaims["resource"] = resources
 
 	// Resolve the identity's credential policy when we have a real identity row
 	// so issuance enforces the same policy ceiling (allowed scopes, max TTL,

--- a/internal/service/oauth_id_jag_resource_test.go
+++ b/internal/service/oauth_id_jag_resource_test.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// TestBuildIDJAGCustomClaims_StampsResourceBinding pins the claim that
+// INV-IDN-006 enforcement depends on. Shield gates entirely on the presence of
+// `resource`, so if this stops being stamped the invariant silently stops
+// enforcing — an un-enforced security control, which fails quiet.
+func TestBuildIDJAGCustomClaims_StampsResourceBinding(t *testing.T) {
+	t.Parallel()
+
+	cfg := domain.ExternalIssuerConfig{ClaimMapping: map[string]string{"user_id": "sub"}}
+	resources := []string{"https://gw.example.com/mcp/github"}
+
+	got := buildIDJAGCustomClaims(map[string]any{}, cfg, "https://corp-idp.example", resources)
+
+	res, ok := got["resource"].([]string)
+	if !ok {
+		t.Fatalf("resource claim missing or not []string: %#v", got["resource"])
+	}
+	if len(res) != 1 || res[0] != resources[0] {
+		t.Errorf("resource = %#v, want %#v", res, resources)
+	}
+
+	// The provenance marker stays — it is what distinguishes an ID-JAG mint in
+	// audit, even though enforcement no longer keys on it.
+	if got["token_exchange"] != "id_jag" {
+		t.Errorf("token_exchange = %v, want id_jag", got["token_exchange"])
+	}
+}
+
+// TestBuildIDJAGCustomClaims_PropagateClaimsCannotClobberResource is the reason
+// the resource stamp is written LAST.
+//
+// PropagateClaims is deployer config. If a deployer lists "resource" there, the
+// propagation loop copies the RAW ID-JAG value straight through — bypassing
+// extractResourceClaim, which is what normalizes the RFC 8707 shapes and fails
+// closed on an absent/empty binding. Ordering is the whole defense: written
+// first, the loop would overwrite the validated value with an unvalidated one.
+func TestBuildIDJAGCustomClaims_PropagateClaimsCannotClobberResource(t *testing.T) {
+	t.Parallel()
+
+	cfg := domain.ExternalIssuerConfig{
+		ClaimMapping:    map[string]string{"user_id": "sub"},
+		PropagateClaims: []string{"resource", "acr"},
+	}
+
+	// The raw assertion carries a WIDER resource set than the one the caller
+	// validated and passed in. If propagation won.
+	raw := map[string]any{
+		"resource": []any{"https://gw.example.com/mcp/github", "https://gw.example.com/mcp/slack"},
+		"acr":      "phr",
+	}
+	validated := []string{"https://gw.example.com/mcp/github"}
+
+	got := buildIDJAGCustomClaims(raw, cfg, "https://corp-idp.example", validated)
+
+	res, ok := got["resource"].([]string)
+	if !ok {
+		t.Fatalf("resource claim must be the validated []string, got %#v", got["resource"])
+	}
+	if len(res) != 1 || res[0] != validated[0] {
+		t.Errorf("resource = %#v, want %#v — propagate_claims must NOT be able to "+
+			"widen or replace the validated RFC 8707 binding", res, validated)
+	}
+
+	// Propagation still works for claims that are not the binding.
+	if got["acr"] != "phr" {
+		t.Errorf("acr = %v, want phr (unrelated propagation must be unaffected)", got["acr"])
+	}
+}
+
+// TestBuildIDJAGCustomClaims_RoleAndPrivilegeScope guards the claims that were
+// already there, so the extraction refactor is provably behavior-preserving.
+func TestBuildIDJAGCustomClaims_RoleAndPrivilegeScope(t *testing.T) {
+	t.Parallel()
+
+	cfg := domain.ExternalIssuerConfig{
+		ClaimMapping: map[string]string{
+			"user_id":         "sub",
+			"role":            "groups_role",
+			"privilege_scope": "groups_ps",
+		},
+	}
+	raw := map[string]any{
+		"groups_role": "admin",
+		"groups_ps":   []any{"tenant:read", "tenant:write"},
+	}
+
+	got := buildIDJAGCustomClaims(raw, cfg, "https://corp-idp.example", []string{"https://gw/mcp/github"})
+
+	if got["role"] != "admin" {
+		t.Errorf("role = %v, want admin", got["role"])
+	}
+	ps, ok := got["privilege_scope"].([]string)
+	if !ok || len(ps) != 2 {
+		t.Errorf("privilege_scope = %#v, want two entries", got["privilege_scope"])
+	}
+
+	// Absent mappings must not default-fill.
+	bare := buildIDJAGCustomClaims(map[string]any{}, cfg, "https://corp-idp.example", []string{"x"})
+	if _, present := bare["role"]; present {
+		t.Error("role must be absent when the IdP did not supply it (never default-fill)")
+	}
+	if _, present := bare["privilege_scope"]; present {
+		t.Error("privilege_scope must be absent when the IdP did not supply it")
+	}
+}

--- a/internal/service/revocation_test.go
+++ b/internal/service/revocation_test.go
@@ -189,3 +189,16 @@ func TestReservedClaims_BlockAuthorizationClaims(t *testing.T) {
 		}
 	}
 }
+
+// TestReservedClaims_BlockResourceBinding enforces the security invariant the
+// RFC 8707 `resource` claim depends on. Shield gates INV-IDN-006 on presence of
+// the claim as proof that ZeroID recorded a resource restriction at the mint, so
+// the claim only carries that meaning while ZeroID is the sole party able to set
+// it. Left unreserved, a caller could forge a binding on a token that has none,
+// or widen a real one by overriding it through additional_claims.
+func TestReservedClaims_BlockResourceBinding(t *testing.T) {
+	if !reservedClaims["resource"] {
+		t.Error("claim \"resource\" MUST be reserved — additional_claims must never " +
+			"be able to forge or widen an RFC 8707 resource binding (shield#366)")
+	}
+}

--- a/pkg/authjwt/claims.go
+++ b/pkg/authjwt/claims.go
@@ -261,7 +261,7 @@ func extractClaims(token jwt.Token) *Claims {
 	// Known ZeroID claims — mapped to typed fields.
 	knownKeys := map[string]struct{}{
 		"iss": {}, "sub": {}, "aud": {}, "iat": {}, "exp": {}, "nbf": {}, "jti": {},
-		"resource": {},
+		"resource":   {},
 		"account_id": {}, "project_id": {},
 		"user_id": {}, "owner_user_id": {},
 		"external_id": {}, "identity_type": {}, "sub_type": {}, "trust_level": {},
@@ -273,9 +273,17 @@ func extractClaims(token jwt.Token) *Claims {
 	}
 
 	// RFC 8707 resource binding. Per RFC 8707 the value is a single URI string
-	// OR an array of them; ZeroID mints the array shape, but accept both so an
-	// unexpected shape degrades to "bound" rather than silently to "unbound" —
-	// the failure direction matters, since empty means enforce nothing.
+	// OR an array of them. ZeroID mints the array shape; the string branch
+	// exists so that form is not silently read as "unbound", which is the
+	// direction that matters — empty means a PEP enforces nothing.
+	//
+	// Be precise about the limit of that guarantee: a value which is NEITHER
+	// shape (a number, an object) still yields empty, i.e. unbound, i.e. fail
+	// OPEN. That is tolerable only because ZeroID is the sole issuer behind
+	// this verifier and always writes []string, and the value is signature-
+	// verified before it gets here — it is not a general fail-closed property.
+	// An issuer that could emit other shapes would need this to return an error
+	// rather than a zero value.
 	c.Resource = getStringSlice("resource")
 	if len(c.Resource) == 0 {
 		if single := getString("resource"); single != "" {

--- a/pkg/authjwt/claims.go
+++ b/pkg/authjwt/claims.go
@@ -26,6 +26,18 @@ type Claims struct {
 	ExpiresAt time.Time `json:"exp"`
 	JWTID     string    `json:"jti"`
 
+	// Resource is the RFC 8707 `resource` claim — the resource(s) this token
+	// was bound to AT THE MINT. Non-empty ONLY when ZeroID recorded an explicit
+	// binding (today: the ID-JAG grant, ADR 0010 D4). ZeroID reserves the claim,
+	// so a caller cannot inject or widen it via additional_claims.
+	//
+	// This — not Audience — is what a PEP must gate resource enforcement on.
+	// ZeroID stamps `aud` on every token it issues, defaulting to the issuer URL
+	// when nothing was requested (JWT-SVID §3), so a non-empty Audience carries
+	// no information about whether the token is resource-restricted. Empty here
+	// means "not resource-bound"; enforce nothing.
+	Resource []string `json:"resource,omitempty"`
+
 	// Tenant scoping
 	AccountID string `json:"account_id"`
 	ProjectID string `json:"project_id,omitempty"`
@@ -249,6 +261,7 @@ func extractClaims(token jwt.Token) *Claims {
 	// Known ZeroID claims — mapped to typed fields.
 	knownKeys := map[string]struct{}{
 		"iss": {}, "sub": {}, "aud": {}, "iat": {}, "exp": {}, "nbf": {}, "jti": {},
+		"resource": {},
 		"account_id": {}, "project_id": {},
 		"user_id": {}, "owner_user_id": {},
 		"external_id": {}, "identity_type": {}, "sub_type": {}, "trust_level": {},
@@ -257,6 +270,17 @@ func extractClaims(token jwt.Token) *Claims {
 		"grant_type":   {}, "scopes": {}, "delegation_depth": {},
 		"act":        {},
 		"mission_id": {},
+	}
+
+	// RFC 8707 resource binding. Per RFC 8707 the value is a single URI string
+	// OR an array of them; ZeroID mints the array shape, but accept both so an
+	// unexpected shape degrades to "bound" rather than silently to "unbound" —
+	// the failure direction matters, since empty means enforce nothing.
+	c.Resource = getStringSlice("resource")
+	if len(c.Resource) == 0 {
+		if single := getString("resource"); single != "" {
+			c.Resource = []string{single}
+		}
 	}
 
 	// Tenant

--- a/pkg/authjwt/resource_claim_test.go
+++ b/pkg/authjwt/resource_claim_test.go
@@ -1,0 +1,80 @@
+package authjwt_test
+
+import (
+	"context"
+	"testing"
+)
+
+// TestResourceClaim verifies the RFC 8707 `resource` claim lands in the typed
+// Resource field. A PEP gates resource enforcement on this field, so it must
+// not require digging through Custom.
+func TestResourceClaim(t *testing.T) {
+	ks := newTestKeySet(t)
+	issuer := "https://auth.test.com"
+	v := newVerifier(t, ks, issuer)
+
+	c := baseClaims(issuer)
+	c["resource"] = []string{"https://gw.example.com/mcp/github"}
+
+	claims, err := v.Verify(context.Background(), ks.signRS256(t, c))
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if len(claims.Resource) != 1 || claims.Resource[0] != "https://gw.example.com/mcp/github" {
+		t.Errorf("Resource = %#v, want [https://gw.example.com/mcp/github]", claims.Resource)
+	}
+
+	// Known claim → typed home only, never duplicated into Custom.
+	if _, ok := claims.GetCustom("resource"); ok {
+		t.Error("resource leaked into Custom (should be typed-only)")
+	}
+}
+
+// TestResourceClaimSingleString covers RFC 8707's other legal shape: a single
+// URI string rather than an array. ZeroID mints the array, but a bare string
+// must not degrade to "unbound" — that direction fails open.
+func TestResourceClaimSingleString(t *testing.T) {
+	ks := newTestKeySet(t)
+	issuer := "https://auth.test.com"
+	v := newVerifier(t, ks, issuer)
+
+	c := baseClaims(issuer)
+	c["resource"] = "https://gw.example.com/mcp/github"
+
+	claims, err := v.Verify(context.Background(), ks.signRS256(t, c))
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if len(claims.Resource) != 1 || claims.Resource[0] != "https://gw.example.com/mcp/github" {
+		t.Errorf("Resource = %#v, want the single string normalized to a one-element slice", claims.Resource)
+	}
+}
+
+// TestResourceClaimAbsent is the shield#366 regression at the library boundary.
+// baseClaims carries an `aud` (ZeroID stamps one on EVERY token, defaulting to
+// the issuer URL for JWT-SVID §3) but no `resource`. Resource must stay empty:
+// it is the sole signal a PEP may gate resource enforcement on, and a non-empty
+// `aud` must never be mistaken for a binding.
+func TestResourceClaimAbsent(t *testing.T) {
+	ks := newTestKeySet(t)
+	issuer := "https://auth.test.com"
+	v := newVerifier(t, ks, issuer)
+
+	c := baseClaims(issuer) // has `aud`, no `resource`
+
+	claims, err := v.Verify(context.Background(), ks.signRS256(t, c))
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	if len(claims.Audience) == 0 {
+		t.Fatal("precondition: baseClaims must carry an aud for this regression to mean anything")
+	}
+
+	if len(claims.Resource) != 0 {
+		t.Errorf("Resource = %#v, want empty — a token with aud but no `resource` "+
+			"is NOT resource-bound (shield#366)", claims.Resource)
+	}
+}


### PR DESCRIPTION
First of three PRs closing highflame-ai/highflame-shield#366. Spec: highflame-ai/highflame-architecture#258.

## Problem

`idJAGBearer` audience-restricts the minted token by writing the ID-JAG's `resource` claim into `aud` (`oauth_id_jag.go:284`) and dropping the name. Downstream that's unrecoverable, because ZeroID stamps `aud` on **every** token it issues — defaulting to the issuer URL to satisfy JWT-SVID §3 (`credential.go:436-440`):

```go
aud := req.Audience
if len(aud) == 0 {
    aud = []string{s.issuer}   // <- indistinguishable from a real restriction
}
```

Shield read a non-empty `aud` as "resource-bound" and hard-denied every MCP-targeted guard request on the JWT path in prod:

```
{"target_server":"slack","token_audience":["https://auth.highflame.ai"],
 "msg":"audience binding denied request before Cedar"}
```

## Change

Carry the binding under its own name so presence of the claim — never the shape of a value — is the discriminator.

| | before | after |
|---|---|---|
| ID-JAG token | `aud: [".../mcp/github"]` | `aud: [".../mcp/github"]`, `resource: [".../mcp/github"]` |
| every other token | `aud: ["https://auth..."]` | unchanged, no `resource` |

- **`oauth_id_jag.go`** — stamp `resource` alongside `aud`. `aud` is untouched, so RFC 8707 §2 conformance and any correct `aud` validator are unaffected. Set *after* the `PropagateClaims` loop so a deployer listing `"resource"` in `propagate_claims` can't clobber the validated value.
- **`oauth.go`** — `resource` joins `reservedClaims`. This one is load-bearing: Shield gates enforcement on presence of the claim as proof the *mint* recorded a binding, and that only holds while ZeroID is the sole party able to set it. Unreserved, a caller could forge a binding on a token that has none, or widen a real one by overriding it through `additional_claims`.
- **`pkg/authjwt`** — typed `Resource []string` so consumers gate on it without reaching into `Custom`. Accepts both RFC 8707 shapes (array, single string); an unexpected shape degrades to *bound* rather than silently to *unbound*, since empty means enforce nothing.

## Tests

`pkg/authjwt/resource_claim_test.go` — array shape, single-string shape, and the shield#366 regression: a token **with** `aud` and **without** `resource` must leave `Resource` empty.

`revocation_test.go` — extends the existing `TestReservedClaims_*` pattern to assert `resource` is reserved.

The "the mint actually stamps it" assertion goes in the regression suite, extending `tests/api/admin/test_id_jag_mas.py`, which already exercises the real mint end-to-end and already asserts `aud == resource`. The repo-local ID-JAG tests are all failure-path and never reach a successful mint.

`go build ./...`, `go vet`, full `internal/service` and `pkg/authjwt` suites green (`GOEXPERIMENT=jsonv2`).

## Next

Needs a `pkg/authjwt` tag before Shield can consume it — Shield is currently pinned to `v1.4.0`, latest is `v1.8.0`.

Refs highflame-ai/highflame-shield#366

🤖 Generated with [Claude Code](https://claude.com/claude-code)