### PR TITLE
feat: record the MCP servers observed on ID-JAG redemptions

### DIFF
--- a/internal/handler/observed_resources.go
+++ b/internal/handler/observed_resources.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	internalMiddleware "github.com/highflame-ai/zeroid/internal/middleware"
+	"github.com/highflame-ai/zeroid/internal/store/postgres"
+)
+
+// ObservedResourcesOutput is the tenant's observed-MCP-server inventory.
+type ObservedResourcesOutput struct {
+	Body struct {
+		ObservedResources []postgres.ObservedIDJAGResource `json:"observed_resources"`
+	}
+}
+
+// registerObservedResourceRoutes mounts the read side of the observed-MCP-server
+// inventory (zeroid#259).
+//
+// Read-only by construction: entries are learned from successful ID-JAG
+// redemptions, never declared. There is deliberately no write endpoint — a
+// caller-supplied entry would be an assertion about infrastructure rather than
+// evidence of it, which is the whole reason this signal is worth more than a
+// name heuristic or a registry lookup.
+func (a *API) registerObservedResourceRoutes(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "list-observed-resources",
+		Method:      http.MethodGet,
+		Path:        "/ema/observed-resources",
+		Summary:     "List the MCP servers this tenant's agents have reached via ID-JAG",
+		Description: "Every successful ID-JAG redemption names its target MCP server in the RFC 8707 " +
+			"`resource` claim, and ZeroID audience-restricts the minted token to it. This returns the " +
+			"distinct resources observed for the calling tenant — an inventory of MCP servers actually " +
+			"in use, including private ones no public registry knows about.",
+		Tags: []string{"EMA"},
+	}, a.listObservedResourcesOp)
+}
+
+func (a *API) listObservedResourcesOp(ctx context.Context, _ *struct{}) (*ObservedResourcesOutput, error) {
+	// Tenant comes from the validated request context, never from a parameter.
+	// This is an inventory of a customer's internal infrastructure, so a
+	// cross-tenant read here is worse than leaking the deployer-configured issuer
+	// list — there is no filter argument to get wrong because there is no filter
+	// argument.
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	resources, err := postgres.NewObservedIDJAGResourceStore(a.db).
+		List(ctx, tenant.AccountID, tenant.ProjectID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+
+	out := &ObservedResourcesOutput{}
+	// Serialize as [] rather than null for an empty inventory: a tenant with no
+	// ID-JAG traffic yet is a normal state, and consumers shouldn't have to
+	// null-guard it.
+	out.Body.ObservedResources = resources
+	return out, nil
+}

--- a/internal/handler/routes.go
+++ b/internal/handler/routes.go
@@ -251,6 +251,7 @@ func (a *API) RegisterAdmin(api huma.API, router chi.Router) {
 	a.registerExpiringSoonRoute(api)
 	a.registerSigningCredentialRoutes(api)
 	a.registerDelegationRoutes(api)
+	a.registerObservedResourceRoutes(api)
 }
 
 // RegisterAgentAuth registers endpoints requiring agent-auth middleware (proof generation).

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -78,6 +78,12 @@ type OAuthService struct {
 	// silently skip replay protection while ID-JAG is actually in use — but the
 	// handler also guards against nil defensively (fail closed).
 	idJAGReplayStore IDJAGReplayStore
+	// observedIDJAGResources records which MCP servers this tenant's agents have
+	// actually reached, learned from the `resource` claim of successful ID-JAG
+	// redemptions (zeroid#259). Wired after construction via
+	// SetObservedIDJAGResourceStore. Nil is valid and simply means the inventory
+	// is not being collected — it must NEVER affect whether a token is minted.
+	observedIDJAGResources ObservedIDJAGResourceStore
 	// requireTokenInspectionAuth, when true, makes the introspection (RFC 7662)
 	// and revocation (RFC 7009) endpoints reject anonymous callers — a caller
 	// MUST present client credentials. When false the endpoints accept-and-
@@ -100,6 +106,18 @@ type CustomGrantHandler func(ctx context.Context, req TokenRequest) (*domain.Acc
 // the dependency narrow.
 type IDJAGReplayStore interface {
 	Insert(ctx context.Context, jti string, expiresAt time.Time) error
+}
+
+// ObservedIDJAGResourceStore records the MCP servers named by the `resource`
+// claim of successfully-redeemed ID-JAGs (zeroid#259), giving a tenant an
+// inventory of the servers its agents actually reach.
+//
+// Record is called on the SUCCESS path only and is strictly best-effort: the
+// token is already minted by that point, so a bookkeeping failure must never
+// withhold it. The concrete impl is postgres.ObservedIDJAGResourceStore; an
+// interface here keeps the service testable and the dependency narrow.
+type ObservedIDJAGResourceStore interface {
+	Record(ctx context.Context, accountID, projectID, authorizingISS string, resources []string) error
 }
 
 // Default token TTLs (used when per-client TTL is not configured).
@@ -406,6 +424,13 @@ func cimdOAuthError(err error) error {
 // server.go alongside the external-issuer registry.
 func (s *OAuthService) SetIDJAGReplayStore(store IDJAGReplayStore) {
 	s.idJAGReplayStore = store
+}
+
+// SetObservedIDJAGResourceStore wires the observed-MCP-server inventory
+// (zeroid#259). Optional: when unset, ID-JAG exchanges behave exactly as before
+// and nothing is recorded. Wired in server.go alongside the replay store.
+func (s *OAuthService) SetObservedIDJAGResourceStore(store ObservedIDJAGResourceStore) {
+	s.observedIDJAGResources = store
 }
 
 // SetRequireTokenInspectionAuth toggles strict client authentication on the

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -340,6 +340,27 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 	accessToken.ProjectID = req.ProjectID
 	accessToken.UserID = userID
 
+	// Record the MCP servers this exchange authorized (zeroid#259). We just
+	// audience-restricted a token to them, which makes this the authoritative
+	// answer to "which MCP servers do our agents actually reach" — the one
+	// inventory that sees an enterprise's PRIVATE servers, which no public
+	// registry knows and no reachability probe can necessarily resolve.
+	//
+	// Deliberately AFTER issuance and deliberately non-fatal. The token exists;
+	// withholding it because a bookkeeping row failed would turn an inventory
+	// feature into an availability risk on the critical auth path. Placement is
+	// the security control too: reaching here means every gate above passed, so
+	// a rejected exchange can never plant an entry in a tenant's inventory.
+	if s.observedIDJAGResources != nil {
+		if err := s.observedIDJAGResources.Record(ctx, req.AccountID, req.ProjectID, upstreamIss, resources); err != nil {
+			log.Warn().Err(err).
+				Str("account_id", req.AccountID).
+				Str("project_id", req.ProjectID).
+				Strs("resources", resources).
+				Msg("failed to record observed ID-JAG resources (token was still issued)")
+		}
+	}
+
 	log.Info().
 		Str("upstream_iss", upstreamIss).
 		Str("account_id", req.AccountID).

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v4/jwt"
 	"github.com/rs/zerolog/log"
@@ -346,19 +347,11 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 	// inventory that sees an enterprise's PRIVATE servers, which no public
 	// registry knows and no reachability probe can necessarily resolve.
 	//
-	// Deliberately AFTER issuance and deliberately non-fatal. The token exists;
-	// withholding it because a bookkeeping row failed would turn an inventory
-	// feature into an availability risk on the critical auth path. Placement is
-	// the security control too: reaching here means every gate above passed, so
-	// a rejected exchange can never plant an entry in a tenant's inventory.
+	// Deliberately AFTER issuance. Placement is the security control: reaching
+	// here means every gate above passed, so a rejected exchange can never plant
+	// an entry in a tenant's inventory.
 	if s.observedIDJAGResources != nil {
-		if err := s.observedIDJAGResources.Record(ctx, req.AccountID, req.ProjectID, upstreamIss, resources); err != nil {
-			log.Warn().Err(err).
-				Str("account_id", req.AccountID).
-				Str("project_id", req.ProjectID).
-				Strs("resources", resources).
-				Msg("failed to record observed ID-JAG resources (token was still issued)")
-		}
+		s.recordObservedResources(ctx, req.AccountID, req.ProjectID, upstreamIss, resources)
 	}
 
 	log.Info().
@@ -370,4 +363,43 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		Msg("ID-JAG jwt-bearer exchange succeeded")
 
 	return accessToken, nil
+}
+
+// observedResourceRecordTimeout bounds the inventory write. It is generous
+// relative to a healthy upsert and tight relative to anything a client would
+// notice: the token is already minted, so this is the maximum extra latency a
+// degraded database can add to a request that has already succeeded.
+const observedResourceRecordTimeout = 2 * time.Second
+
+// recordObservedResources writes the observed-MCP-server inventory for a
+// successful exchange (zeroid#259), off the critical path.
+//
+// Three properties, each load-bearing:
+//
+//   - context.WithoutCancel. The caller's context is cancelled the moment the
+//     HTTP response is written. Inheriting it would race the response and drop
+//     observations non-deterministically — and on a fast client, drop most of
+//     them, which looks like an inventory that mysteriously under-reports.
+//   - A bounded timeout. Every exchange for a given MCP server UPDATEs the same
+//     row by design (one row per resource), so concurrent redemptions for a
+//     popular server serialize on that row lock. Without a deadline, lock waits
+//     or pool exhaustion would add unbounded latency to a token that is already
+//     issued — exactly the availability risk this is supposed to avoid.
+//   - Errors are logged, never returned. The token exists; withholding it over a
+//     bookkeeping row would turn an inventory feature into an auth-path outage.
+func (s *OAuthService) recordObservedResources(
+	ctx context.Context,
+	accountID, projectID, upstreamIss string,
+	resources []string,
+) {
+	recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), observedResourceRecordTimeout)
+	defer cancel()
+
+	if err := s.observedIDJAGResources.Record(recordCtx, accountID, projectID, upstreamIss, resources); err != nil {
+		log.Warn().Err(err).
+			Str("account_id", accountID).
+			Str("project_id", projectID).
+			Strs("resources", resources).
+			Msg("failed to record observed ID-JAG resources (token was still issued)")
+	}
 }

--- a/internal/store/postgres/observed_idjag_resources.go
+++ b/internal/store/postgres/observed_idjag_resources.go
@@ -154,10 +154,33 @@ func (s *ObservedIDJAGResourceStore) Record(
 	return err
 }
 
-// List returns every resource observed for a tenant, most recently seen first.
+// ObservedResourceStaleAfter is how long a resource may go unseen before it
+// drops out of the inventory.
+//
+// The table has no reaper, and it must not accumulate indefinitely: an IdP that
+// mints per-object resource URIs would grow the row count without bound. More
+// importantly, this inventory feeds MCP typing downstream — without a cutoff, a
+// decommissioned server stays listed forever and discovery keeps typing that app
+// as an MCP server off a year-old observation.
+//
+// 90 days is deliberately generous. This is an inventory of infrastructure, not
+// a session log; a server used quarterly is still a real server, and dropping it
+// too eagerly would make the inventory flap.
+const ObservedResourceStaleAfter = 90 * 24 * time.Hour
+
+// maxObservedResourcesReturned caps one response. Resources are a small,
+// slow-moving set, so a tenant at this limit means something is generating
+// resource URIs per-object rather than per-server — a bounded, wrong answer that
+// still renders beats an unbounded one that times out.
+const maxObservedResourcesReturned = 500
+
+// List returns the resources observed for a tenant, most recently seen first,
+// excluding any not seen within ObservedResourceStaleAfter.
+//
 // Scoped to (accountID, projectID) with no cross-tenant escape: this is an
 // inventory of a customer's internal infrastructure, so a leak here is worse
-// than the deployer-configured issuer list.
+// than the deployer-configured issuer list. The ordering and cutoff are both
+// served by idx_observed_idjag_resources_tenant_last_seen.
 func (s *ObservedIDJAGResourceStore) List(
 	ctx context.Context,
 	accountID, projectID string,
@@ -167,7 +190,9 @@ func (s *ObservedIDJAGResourceStore) List(
 		Model(&rows).
 		Where("account_id = ?", accountID).
 		Where("project_id = ?", projectID).
+		Where("last_seen_at >= ?", time.Now().UTC().Add(-ObservedResourceStaleAfter)).
 		Order("last_seen_at DESC").
+		Limit(maxObservedResourcesReturned).
 		Scan(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/store/postgres/observed_idjag_resources.go
+++ b/internal/store/postgres/observed_idjag_resources.go
@@ -1,0 +1,186 @@
+package postgres
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// maxObservedResourceLen bounds what we will store, matching the column width in
+// migration 040. A `resource` claim is an absolute URI naming an MCP server; one
+// longer than this is not a real endpoint identifier, and silently truncating it
+// would corrupt the inventory (two distinct servers could collapse to one row).
+// Over-length values are dropped by Record instead.
+const maxObservedResourceLen = 2048
+
+// observedIDJAGResourceRow is the bun model for observed_idjag_resources. Schema
+// is defined in migrations/040_observed_idjag_resources.up.sql; this struct must
+// stay in sync with the column definitions there.
+type observedIDJAGResourceRow struct {
+	bun.BaseModel  `bun:"table:observed_idjag_resources"`
+	AccountID      string    `bun:"account_id,pk"`
+	ProjectID      string    `bun:"project_id,pk"`
+	Resource       string    `bun:"resource,pk"`
+	AuthorizingISS string    `bun:"authorizing_iss"`
+	FirstSeenAt    time.Time `bun:"first_seen_at"`
+	LastSeenAt     time.Time `bun:"last_seen_at"`
+}
+
+// ObservedIDJAGResource is one MCP server this tenant's agents have actually
+// reached through enterprise-managed authorization.
+type ObservedIDJAGResource struct {
+	Resource       string    `json:"resource"`
+	AuthorizingISS string    `json:"authorizing_iss"`
+	FirstSeenAt    time.Time `json:"first_seen_at"`
+	LastSeenAt     time.Time `json:"last_seen_at"`
+}
+
+// ObservedIDJAGResourceStore records the MCP servers named by the `resource`
+// claim of successfully-redeemed ID-JAGs (zeroid#259).
+//
+// One row per (tenant, resource) — deliberately NOT per exchange. Resources are
+// a small, slow-moving set (one per MCP endpoint); a tenant redeeming thousands
+// of ID-JAGs a day against three servers holds three rows. This is an inventory,
+// not a log, and it must not be allowed to become one.
+type ObservedIDJAGResourceStore struct {
+	db *bun.DB
+}
+
+// NewObservedIDJAGResourceStore wires a store against the given bun.DB. The db
+// must have the observed_idjag_resources table available (migration 040).
+func NewObservedIDJAGResourceStore(db *bun.DB) *ObservedIDJAGResourceStore {
+	return &ObservedIDJAGResourceStore{db: db}
+}
+
+// NormalizeResource canonicalizes a `resource` claim so the same MCP server does
+// not accumulate several rows.
+//
+// RFC 8707 resource indicators are absolute URIs, and IdPs are inconsistent about
+// two things that carry no semantic weight: host case and a trailing slash on an
+// otherwise-empty path. Without normalization "https://MCP.acme.com/" and
+// "https://mcp.acme.com" are two servers in the inventory and neither matches a
+// discovered app's identifier reliably.
+//
+// Scheme and host are lowercased (case-insensitive per RFC 3986 §3.1/§3.2.2); a
+// lone trailing slash is dropped. Path case, query, and fragment are left ALONE —
+// those ARE case-sensitive, and folding them would merge genuinely distinct
+// resources. A value that does not parse as an absolute URI is returned trimmed
+// but otherwise untouched, so an unexpected shape is recorded faithfully rather
+// than mangled.
+func NormalizeResource(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil || !u.IsAbs() || u.Host == "" {
+		return trimmed
+	}
+
+	u.Scheme = strings.ToLower(u.Scheme)
+	u.Host = strings.ToLower(u.Host)
+	if u.Path == "/" {
+		u.Path = ""
+	}
+	return u.String()
+}
+
+// Record upserts the resources observed on one successful ID-JAG exchange,
+// bumping last_seen_at for those already known and preserving first_seen_at.
+//
+// Call ONLY after the exchange has fully succeeded. A rejected exchange must
+// never reach here: this table is a tenant-visible inventory of internal
+// infrastructure, and writing on the failure path would let anyone who can reach
+// /oauth2/token plant entries into it.
+//
+// Errors are returned for the caller to log, never to fail the exchange on — a
+// token that has already been minted must not be withheld because a bookkeeping
+// write failed. Empty and over-length resources are skipped rather than stored.
+func (s *ObservedIDJAGResourceStore) Record(
+	ctx context.Context,
+	accountID, projectID, authorizingISS string,
+	resources []string,
+) error {
+	if accountID == "" || projectID == "" {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	rows := make([]*observedIDJAGResourceRow, 0, len(resources))
+	seen := make(map[string]struct{}, len(resources))
+
+	for _, raw := range resources {
+		resource := NormalizeResource(raw)
+		if resource == "" || len(resource) > maxObservedResourceLen {
+			continue
+		}
+		// An RFC 8707 array can legitimately repeat a value after normalization
+		// ("https://x/" and "https://x"). Postgres rejects a multi-row upsert
+		// that touches the same key twice ("ON CONFLICT DO UPDATE command cannot
+		// affect row a second time"), so dedupe before building the batch.
+		if _, dup := seen[resource]; dup {
+			continue
+		}
+		seen[resource] = struct{}{}
+
+		rows = append(rows, &observedIDJAGResourceRow{
+			AccountID:      accountID,
+			ProjectID:      projectID,
+			Resource:       resource,
+			AuthorizingISS: authorizingISS,
+			FirstSeenAt:    now,
+			LastSeenAt:     now,
+		})
+	}
+
+	if len(rows) == 0 {
+		return nil
+	}
+
+	// first_seen_at is deliberately absent from the SET list: it must survive
+	// every subsequent observation, which is what makes "how long has this server
+	// been in use?" answerable. authorizing_iss is updated because a resource can
+	// legitimately move between issuers, and the latest is the useful one.
+	_, err := s.db.NewInsert().
+		Model(&rows).
+		On("CONFLICT (account_id, project_id, resource) DO UPDATE").
+		Set("last_seen_at = EXCLUDED.last_seen_at").
+		Set("authorizing_iss = EXCLUDED.authorizing_iss").
+		Exec(ctx)
+	return err
+}
+
+// List returns every resource observed for a tenant, most recently seen first.
+// Scoped to (accountID, projectID) with no cross-tenant escape: this is an
+// inventory of a customer's internal infrastructure, so a leak here is worse
+// than the deployer-configured issuer list.
+func (s *ObservedIDJAGResourceStore) List(
+	ctx context.Context,
+	accountID, projectID string,
+) ([]ObservedIDJAGResource, error) {
+	var rows []observedIDJAGResourceRow
+	err := s.db.NewSelect().
+		Model(&rows).
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Order("last_seen_at DESC").
+		Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]ObservedIDJAGResource, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, ObservedIDJAGResource{
+			Resource:       r.Resource,
+			AuthorizingISS: r.AuthorizingISS,
+			FirstSeenAt:    r.FirstSeenAt,
+			LastSeenAt:     r.LastSeenAt,
+		})
+	}
+	return out, nil
+}

--- a/internal/store/postgres/observed_idjag_resources_test.go
+++ b/internal/store/postgres/observed_idjag_resources_test.go
@@ -1,0 +1,99 @@
+package postgres
+
+import "testing"
+
+// NormalizeResource decides whether two ID-JAG `resource` values name the same
+// MCP server. Get it wrong in one direction and one server accumulates several
+// inventory rows (and matches no discovered app reliably); get it wrong in the
+// other and two genuinely distinct servers collapse into one. Both are silent.
+func TestNormalizeResource(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "host case is folded (RFC 3986 §3.2.2)",
+			in:   "https://MCP.Acme.COM/tools",
+			want: "https://mcp.acme.com/tools",
+		},
+		{
+			name: "scheme case is folded (RFC 3986 §3.1)",
+			in:   "HTTPS://mcp.acme.com/tools",
+			want: "https://mcp.acme.com/tools",
+		},
+		{
+			name: "a lone trailing slash carries no meaning",
+			in:   "https://mcp.acme.com/",
+			want: "https://mcp.acme.com",
+		},
+		{
+			name: "a trailing slash on a real path is left alone",
+			// /tools/ and /tools can be different resources on a strict server;
+			// folding them would merge two entries on our guess, not their fact.
+			in:   "https://mcp.acme.com/tools/",
+			want: "https://mcp.acme.com/tools/",
+		},
+		{
+			name: "path case is preserved — paths ARE case-sensitive",
+			in:   "https://mcp.acme.com/Tools/Search",
+			want: "https://mcp.acme.com/Tools/Search",
+		},
+		{
+			name: "surrounding whitespace is trimmed",
+			in:   "  https://mcp.acme.com  ",
+			want: "https://mcp.acme.com",
+		},
+		{
+			name: "query is preserved",
+			in:   "https://MCP.acme.com/mcp?v=2",
+			want: "https://mcp.acme.com/mcp?v=2",
+		},
+		{
+			name: "a urn resource indicator survives untouched",
+			// RFC 8707 permits any absolute URI, not only https.
+			in:   "urn:acme:mcp:search",
+			want: "urn:acme:mcp:search",
+		},
+		{
+			name: "a non-URI value is recorded faithfully rather than mangled",
+			in:   "not a uri",
+			want: "not a uri",
+		},
+		{
+			name: "empty stays empty so the caller can skip it",
+			in:   "   ",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeResource(tt.in); got != tt.want {
+				t.Errorf("NormalizeResource(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// An RFC 8707 `resource` array can carry values that are distinct on the wire but
+// identical after normalization. Postgres rejects a multi-row upsert touching the
+// same key twice ("ON CONFLICT DO UPDATE command cannot affect row a second
+// time"), so a duplicate that reaches the INSERT fails the whole batch — and
+// because Record is best-effort, that failure would be logged and swallowed,
+// silently losing the observation.
+func TestNormalizeResourceCollapsesWireDuplicates(t *testing.T) {
+	a := NormalizeResource("https://mcp.acme.com/")
+	b := NormalizeResource("https://MCP.acme.com")
+	if a != b {
+		t.Fatalf("expected wire-distinct values to normalize equal, got %q and %q", a, b)
+	}
+}
+
+func TestNormalizeResourceKeepsDistinctServersDistinct(t *testing.T) {
+	a := NormalizeResource("https://mcp.acme.com/search")
+	b := NormalizeResource("https://mcp.acme.com/files")
+	if a == b {
+		t.Fatalf("distinct resources collapsed to %q", a)
+	}
+}

--- a/migrations/040_observed_idjag_resources.down.sql
+++ b/migrations/040_observed_idjag_resources.down.sql
@@ -1,0 +1,3 @@
+-- 040_observed_idjag_resources.down.sql
+DROP INDEX IF EXISTS idx_observed_idjag_resources_tenant_last_seen;
+DROP TABLE IF EXISTS observed_idjag_resources;

--- a/migrations/040_observed_idjag_resources.up.sql
+++ b/migrations/040_observed_idjag_resources.up.sql
@@ -1,0 +1,54 @@
+-- 040_observed_idjag_resources.up.sql
+-- Observed MCP servers, learned from ID-JAG redemptions (zeroid#259).
+--
+-- Every successful ID-JAG exchange carries an RFC 8707 `resource` claim naming
+-- the MCP server the corporate IdP authorized, and we mint a token
+-- audience-restricted to exactly that value (ADR 0010 D4). Until now we parsed
+-- it, used it, and discarded it — so the one authoritative record of which MCP
+-- servers an organization's agents actually reach existed only in flight.
+--
+-- Recording it turns a byproduct of the mint into an MCP inventory that, unlike
+-- name heuristics or public-registry matching, sees an enterprise's PRIVATE
+-- servers, and unlike an RFC 9728 probe needs no outbound request. It is also
+-- evidence of use rather than intent: a configured-but-never-called resource
+-- never appears here, a live one does.
+--
+-- observed_idjag_resources: one row per (tenant, resource) — NOT per exchange.
+--   Resources are a small, slow-moving set (one per MCP endpoint), so this is an
+--   upsert-and-bump-last_seen table, not a log. A busy tenant redeeming
+--   thousands of ID-JAGs a day against three MCP servers holds three rows.
+--
+--   authorizing_iss is the upstream IdP that vouched for the resource — the same
+--   value propagated into the token as user_id_iss — so a resource can be
+--   attributed to the issuer that authorized it, which is what lets a consumer
+--   join this against a discovery connector for the same IdP.
+--
+--   Written on the SUCCESSFUL-exchange path only. A rejected exchange must never
+--   create a row, or anyone able to reach /oauth2/token could plant entries into
+--   a tenant's inventory.
+--
+-- Storage: unlike id_jag_jti this is low-churn and long-lived (UPDATEs to
+-- last_seen_at dominate, INSERTs are rare), so the aggressive autovacuum tuning
+-- there is inappropriate here. fillfactor=85 leaves page headroom for the
+-- repeated HOT updates to last_seen_at.
+--
+-- Lock posture: CREATE TABLE / CREATE INDEX on a brand-new empty table, so no
+-- concurrent-rebuild concern. lock_timeout scopes any blocking-acquire.
+
+SET LOCAL lock_timeout = '3s';
+
+CREATE TABLE IF NOT EXISTS observed_idjag_resources (
+    account_id      VARCHAR(255) NOT NULL,
+    project_id      VARCHAR(255) NOT NULL,
+    -- The RFC 8707 resource URI, normalized (see NormalizeResource in the store).
+    resource        VARCHAR(2048) NOT NULL,
+    -- Upstream IdP `iss` that authorized this resource.
+    authorizing_iss VARCHAR(2048) NOT NULL,
+    first_seen_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (account_id, project_id, resource)
+) WITH (fillfactor = 85);
+
+-- The read path is always "every resource for this tenant, most recent first".
+CREATE INDEX IF NOT EXISTS idx_observed_idjag_resources_tenant_last_seen
+    ON observed_idjag_resources (account_id, project_id, last_seen_at DESC);

--- a/server.go
+++ b/server.go
@@ -324,6 +324,10 @@ func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
 	// skip replay protection. Backed by the id_jag_jti table (migration 034),
 	// swept by the cleanup worker.
 	oauthSvc.SetIDJAGReplayStore(postgres.NewIDJAGReplayStore(db))
+	// Observed-MCP-server inventory (zeroid#259). Backed by
+	// observed_idjag_resources (migration 040). Best-effort and off the critical
+	// path: a failure here is logged and the token is still issued.
+	oauthSvc.SetObservedIDJAGResourceStore(postgres.NewObservedIDJAGResourceStore(db))
 
 	proofSvc := service.NewProofService(jwksSvc, proofRepo, cfg.Token.Issuer)
 	// DelegationService is read-only over credentialRepo / delegationRepo /


### PR DESCRIPTION
Closes #259.

## Why

Every successful ID-JAG exchange already tells us, authoritatively, which MCP server an agent is reaching — the corporate IdP names it in the RFC 8707 `resource` claim, and we audience-restrict the minted token to exactly that value (ADR 0010 D4). We parsed it, used it, and discarded it. The one reliable record of which MCP servers an organization's agents actually reach existed only in flight.

Persisting it beats every inferential alternative on the axis that matters for enterprises:

| Signal | Authoritative | Needs egress | Sees private servers |
|---|---|---|---|
| Name heuristic | no | no | n/a |
| Public registry match | yes | yes | **no** |
| RFC 9728 probe | yes | **yes** | only if reachable |
| **Observed ID-JAG resource** | **yes** | **no** | **yes** |

A public registry cannot know a company's internal endpoints; a probe only sees what we can dial from our own network. The `resource` claim sees both — and it's evidence of *use* rather than *intent*: a configured-but-never-called resource never appears, a live one does.

## Shape

**One row per `(tenant, resource)` — not per exchange.** Resources are a small, slow-moving set; a tenant redeeming thousands of ID-JAGs a day against three servers holds three rows. This is an inventory and must not become a log, so the write is an upsert that bumps `last_seen_at`. `first_seen_at` is deliberately excluded from the `SET` list so "how long has this been in use?" stays answerable.

`authorizing_iss` records which IdP vouched for the resource — the value we already propagate as `user_id_iss` — which is what lets a consumer join this against a discovery connector for the same IdP.

## Placement is the security control

`Record` runs **after** issuance, on the success path only. Reaching that line means every gate above it passed: client auth, `client_id` binding, ID-JAG validation, identity mapping, resource extraction, policy resolution, single-use `jti`. Writing anywhere earlier would let anyone able to reach `/oauth2/token` plant entries into a tenant's inventory of its own internal infrastructure.

It is also **strictly best-effort**. The token exists by then, and withholding it because a bookkeeping row failed would turn an inventory feature into an availability risk on the critical auth path. Failures are logged and swallowed; a nil store is valid and means nothing is collected.

## Normalization — the subtle part

IdPs are inconsistent about host case and a lone trailing slash, neither of which carries meaning. Left alone, `https://MCP.acme.com/` and `https://mcp.acme.com` become two servers in the inventory and neither matches a discovered app's identifier reliably.

`NormalizeResource` folds scheme and host (RFC 3986 §3.1/§3.2.2) and drops a lone trailing slash. It deliberately **leaves path case, query, and fragment alone** — those *are* case-sensitive, and folding them would merge genuinely distinct resources. Both directions are silent failures, so both are tested.

Post-normalization duplicates within one RFC 8707 array are deduped before the batch. Postgres rejects an upsert touching the same key twice, and because `Record` is best-effort that error would be logged and swallowed — silently losing the observation.

## Read path

`GET /ema/observed-resources`, tenant-scoped from the request context with **no filter parameter to get wrong**. Read-only by construction: there is no write endpoint, because a caller-supplied entry would be an assertion about infrastructure rather than evidence of it — the entire reason this signal outranks a heuristic.

## Consumer

highflame-discovery#35 adds a fourth `mcptype` classifier signal against this, so a discovered OAuth app matching an observed resource is typed `mcp_server` as **confirmed** rather than a low-confidence name guess. Today every MCP server Studio shows is a name-heuristic guess (highflame-discovery#24 — the probe and registry collaborators are still nil).

## Testing

- `NormalizeResource` table test covering both failure directions: values that must collapse (host case, scheme case, lone trailing slash) and values that must stay distinct (path case, real trailing path segment, different paths). Plus non-URI and `urn:` inputs, which must survive untouched rather than be mangled.
- `GOEXPERIMENT=jsonv2 go build ./...`, `go vet ./...`, `gofmt -l .` all clean; 200 unit tests pass in the touched packages.
- Integration coverage for the write path is worth adding against the testcontainers harness — flagging rather than claiming it.

## Migration

`040_observed_idjag_resources` — new empty table, `CREATE TABLE`/`CREATE INDEX` only, `lock_timeout` scoped. No backfill (there is nothing to backfill; the inventory populates from the next redemption onward). `fillfactor=85` for the repeated HOT updates to `last_seen_at`; deliberately **not** the aggressive autovacuum tuning `id_jag_jti` uses, since this table is low-churn and long-lived rather than INSERT-then-DELETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
