### PR TITLE
fix(middleware): enforce DPoP sender-constraint on bound agent tokens

### DIFF
--- a/internal/middleware/agent_auth.go
+++ b/internal/middleware/agent_auth.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/lestrrat-go/jwx/v4/jwa"
 	"github.com/lestrrat-go/jwx/v4/jwt"
+
+	"github.com/highflame-ai/zeroid/pkg/dpop"
 	"github.com/rs/zerolog/log"
 
 	"github.com/highflame-ai/zeroid/internal/jwtalg"
@@ -25,6 +27,9 @@ type AgentClaims struct {
 	Scopes     []string
 	JTI        string
 	IdentityID string
+	// DPoPJKT is the cnf.jkt thumbprint the token was bound to at issuance,
+	// empty for unbound tokens.
+	DPoPJKT string
 }
 
 type agentClaimsKey struct{}
@@ -42,6 +47,13 @@ type AgentAuthConfig struct {
 	// for legacy deployments that haven't migrated to issuer-anchored
 	// discovery).
 	ResourceMetadataURL string
+
+	// DPoPVerifier enforces sender-constraint when a token carries cnf.jkt.
+	// ZeroID mints cnf.jkt whenever a DPoP proof accompanies the token
+	// request (credential.go), so a bound token presented as a bare Bearer
+	// header is a stolen-token replay: accept it and the binding minted at
+	// issuance is never enforced. Nil disables enforcement.
+	DPoPVerifier *dpop.Verifier
 }
 
 // AgentAuthMiddleware validates ES256 Bearer tokens issued by ZeroID and injects agent claims into context.
@@ -110,6 +122,27 @@ func AgentAuthMiddleware(cfg AgentAuthConfig) func(http.Handler) http.Handler {
 				return
 			}
 
+			// Sender-constraint: a token bound to a DPoP key at issuance must
+			// arrive with a matching proof, or any bearer of a leaked token
+			// replays it. Unbound tokens are unaffected.
+			if claims.DPoPJKT != "" && cfg.DPoPVerifier != nil {
+				proofJWT := r.Header.Get("DPoP")
+				if proofJWT == "" {
+					writeAgentAuthError(w, "invalid_token", "token is DPoP-bound; DPoP proof header is required", "token is DPoP-bound; DPoP proof header is required", cfg.ResourceMetadataURL)
+					return
+				}
+				if _, err := cfg.DPoPVerifier.ValidateBoundToToken(r.Context(), dpop.ValidateRequest{
+					ProofJWT:    proofJWT,
+					Method:      r.Method,
+					URL:         EffectiveRequestURL(r.Context()),
+					AccessToken: tokenStr,
+				}, claims.DPoPJKT); err != nil {
+					log.Warn().Err(err).Str("path", r.URL.Path).Msg("Agent DPoP proof rejected")
+					writeAgentAuthError(w, "invalid_token", "invalid DPoP proof", "invalid DPoP proof", cfg.ResourceMetadataURL)
+					return
+				}
+			}
+
 			ctx := r.Context()
 			ctx = SetTenant(ctx, claims.AccountID, claims.ProjectID)
 			ctx = context.WithValue(ctx, agentClaimsKey{}, claims)
@@ -153,6 +186,13 @@ func extractAgentClaims(token jwt.Token) AgentClaims {
 	}
 	if v, err := jwt.Get[string](token, "identity_id"); err == nil {
 		claims.IdentityID = v
+	}
+	if v, err := jwt.Get[map[string]string](token, "cnf"); err == nil {
+		claims.DPoPJKT = v["jkt"]
+	} else if v, err := jwt.Get[map[string]any](token, "cnf"); err == nil {
+		if jkt, ok := v["jkt"].(string); ok {
+			claims.DPoPJKT = jkt
+		}
 	}
 	// scopes can be []string or []any depending on issuance shape; try both.
 	if v, err := jwt.Get[[]string](token, "scopes"); err == nil {

--- a/internal/middleware/agent_auth_dpop_test.go
+++ b/internal/middleware/agent_auth_dpop_test.go
@@ -1,0 +1,68 @@
+package middleware
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v4/jwa"
+	"github.com/lestrrat-go/jwx/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/pkg/dpop"
+)
+
+func mintAgentToken(t *testing.T, key *ecdsa.PrivateKey, issuer string, withCnf bool) string {
+	t.Helper()
+	tok := jwt.New()
+	require.NoError(t, tok.Set(jwt.IssuerKey, issuer))
+	require.NoError(t, tok.Set(jwt.ExpirationKey, time.Now().Add(time.Hour)))
+	require.NoError(t, tok.Set("account_id", "acct-1"))
+	require.NoError(t, tok.Set("project_id", "proj-1"))
+	if withCnf {
+		require.NoError(t, tok.Set("cnf", map[string]string{"jkt": "thumbprint-of-agent-key"}))
+	}
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.ES256(), key))
+	require.NoError(t, err)
+	return string(signed)
+}
+
+func TestAgentAuthMiddleware_DPOPBinding(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	verifier, err := dpop.NewVerifier(dpop.Config{Store: dpop.NewMemoryStore()})
+	require.NoError(t, err)
+
+	cfg := AgentAuthConfig{
+		PublicKey:    &key.PublicKey,
+		Issuer:       "https://issuer.test",
+		DPoPVerifier: verifier,
+	}
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := AgentAuthMiddleware(cfg)(okHandler)
+
+	t.Run("unbound token passes without DPoP header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/agents/self", nil)
+		req.Header.Set("Authorization", "Bearer "+mintAgentToken(t, key, "https://issuer.test", false))
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNoContent, rr.Code)
+	})
+
+	t.Run("bound token without DPoP header is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/agents/self", nil)
+		req.Header.Set("Authorization", "Bearer "+mintAgentToken(t, key, "https://issuer.test", true))
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+}

--- a/server.go
+++ b/server.go
@@ -428,6 +428,9 @@ func NewServer(cfg Config, opts ...ServerOption) (*Server, error) {
 	agentAuthCfg := internalMiddleware.AgentAuthConfig{
 		PublicKey: jwksSvc.PublicKey(),
 		Issuer:    cfg.Token.Issuer,
+		// Enforce cnf.jkt sender-constraint on bound tokens (minted at
+		// issuance when a proof accompanied the token request).
+		DPoPVerifier: dpopVerifier,
 		// RFC 9728 §5.1 breadcrumb on 401s — points cold-start clients at the PRM
 		// document so they can chain resource → PRM → AS metadata.
 		ResourceMetadataURL: cfg.Token.Issuer + "/.well-known/oauth-protected-resource",


### PR DESCRIPTION
## Problem

`AgentAuthMiddleware` verified ES256 signature, issuer, and exp — but never read the token's `cnf.jkt` claim and never required a `DPoP` proof header. Meanwhile `credential.go:479` mints `cnf.jkt` whenever a DPoP proof accompanies the token request, and `pkg/dpop` ships `ValidateBoundToToken` (documented as *"use this on resource servers where the access token claim must match the presented proof key"*) with **zero production callers**.

Net effect: DPoP binding existed at issuance and was silently dropped at verification. A leaked bound token replayed as a plain `Bearer` — no proof of key possession — which is precisely the stolen-token scenario DPoP exists to defeat (RFC 9449 §6.1).

## Fix

When the validated token carries `cnf.jkt` and a `DPoPVerifier` is configured:

- Require the `DPoP` header (401 `invalid_token` otherwise).
- Validate the proof via the existing `ValidateBoundToToken`: `htu` from `EffectiveRequestURL` (the middleware already in place for this), `ath` against the presented token, thumbprint match against `cnf.jkt`, replay protection via the shared store.

Unbound tokens (no `cnf.jkt`) are unaffected — this only closes the gap for tokens ZeroID already chose to bind.

## Tests

New `agent_auth_dpop_test.go`: unbound token passes without a proof header; bound token without a proof header is rejected. `go build ./...` and the middleware tests pass (note: repo requires `GOEXPERIMENT=jsonv2`, per the Makefile).

Made with Cursor

Made with [Cursor](https://cursor.com)