### PR TITLE
feat: owner-scoped cascade revocation for human offboarding

### DIFF
--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -628,6 +628,29 @@ func (s *CredentialService) RevokeAllActiveForIdentity(ctx context.Context, iden
 	return int64(len(revoked)), nil
 }
 
+// RevokeAllActiveForOwner revokes every active credential belonging to an
+// identity owned by ownerUserID within accountID, cascading to any delegated
+// descendants via the parent_jti chain. Returns the total number revoked. This
+// is the offboarding primitive: when a human is deactivated in the IdP, an
+// offboarding handler calls this so every agent that person owns — and every
+// sub-agent those agents delegated to — stops working immediately rather than
+// surviving until TTL.
+//
+// Fires one RevocationNotifier event per affected JTI after the revocation
+// commits, exactly like RevokeAllActiveForIdentity, so Shield's deny-set picks
+// them up within seconds.
+func (s *CredentialService) RevokeAllActiveForOwner(ctx context.Context, ownerUserID, accountID, reason string) (int64, error) {
+	if reason == "" {
+		reason = "owner_deactivated"
+	}
+	revoked, err := s.repo.RevokeAllActiveForOwner(ctx, ownerUserID, accountID, reason)
+	if err != nil {
+		return 0, err
+	}
+	s.dispatchRevocations(ctx, revoked, reason)
+	return int64(len(revoked)), nil
+}
+
 // dispatchRevocations maps the repository's affected-row projection into
 // RevocationEvents and hands them to the shared dispatcher. The dispatcher
 // itself owns the async/sync decision, the notifier-installed check, and the

--- a/internal/store/postgres/credential.go
+++ b/internal/store/postgres/credential.go
@@ -135,6 +135,33 @@ func (r *CredentialRepository) RevokeAllActiveForIdentity(ctx context.Context, i
 	return rows, nil
 }
 
+// RevokeAllActiveForOwner revokes every non-expired, non-revoked credential
+// belonging to an identity owned by ownerUserID within accountID, and cascades
+// to every downstream delegated credential in the parent_jti chain. This is the
+// primitive for human offboarding: deactivating a person revokes every agent
+// that person owns (and their sub-agents) at once. Implemented via the
+// revoke_credentials_by_owner DB function (migration 041), which mirrors the
+// identity cascade's atomic single-statement update and returned-row semantics.
+//
+// Scoped by (ownerUserID, accountID) for tenant safety. Returns the affected
+// credentials, one entry per revoked JTI, each stamped with the revoked_at
+// timestamp; len(result) is the total number revoked.
+func (r *CredentialRepository) RevokeAllActiveForOwner(ctx context.Context, ownerUserID, accountID, reason string) ([]RevokedCredential, error) {
+	now := time.Now()
+	var rows []RevokedCredential
+	db := dbOrTx(ctx, r.db)
+	if err := db.NewRaw(
+		"SELECT jti, identity_id, account_id, project_id, expires_at FROM revoke_credentials_by_owner(?, ?, ?, ?)",
+		ownerUserID, accountID, now, reason,
+	).Scan(ctx, &rows); err != nil {
+		return nil, fmt.Errorf("failed to cascade-revoke credentials for owner %s in account %s: %w", ownerUserID, accountID, err)
+	}
+	for i := range rows {
+		rows[i].RevokedAt = now
+	}
+	return rows, nil
+}
+
 // Revoke marks a credential as revoked and cascades the revocation to every
 // downstream delegated credential in the parent_jti chain (RFC 8693 descendants).
 // account_id and project_id are enforced on the anchor as tenant-safety guards.

--- a/migrations/041_revoke_credentials_by_owner.down.sql
+++ b/migrations/041_revoke_credentials_by_owner.down.sql
@@ -1,0 +1,2 @@
+-- 041_revoke_credentials_by_owner.down.sql
+DROP FUNCTION IF EXISTS revoke_credentials_by_owner(TEXT, TEXT, TIMESTAMPTZ, TEXT);

--- a/migrations/041_revoke_credentials_by_owner.up.sql
+++ b/migrations/041_revoke_credentials_by_owner.up.sql
@@ -1,0 +1,64 @@
+-- 041_revoke_credentials_by_owner.up.sql
+-- Owner-scoped cascade revocation: revoke every active credential belonging to
+-- an identity owned by a given human (identities.owner_user_id) within one
+-- account, plus every delegated descendant reachable through the parent_jti
+-- chain.
+--
+-- This is the missing primitive for human offboarding: when a person is
+-- deactivated in the IdP, an offboarding handler can revoke every agent that
+-- person owns — and every sub-agent those agents delegated to — in one atomic
+-- statement, instead of the tokens surviving until their natural TTL.
+--
+-- Scoped by (owner_user_id, account_id) for tenant safety: a deactivation event
+-- carries the account context, and this never reaches across accounts even if
+-- the same owner id somehow appeared elsewhere.
+--
+-- Traversal/return semantics mirror revoke_credentials_cascade (migration 031):
+-- the recursive walk crosses dead intermediates (no liveness filter in the
+-- traversal), the final UPDATE alone decides which visited rows flip (only
+-- not-yet-revoked, not-yet-expired), and the returned set is exactly the rows
+-- that were live and are now revoked — so the RevocationNotifier fan-out stays
+-- accurate and already-dead rows emit no events. Cycle guard + depth cap 50
+-- match the identity/credential cascades.
+
+CREATE OR REPLACE FUNCTION revoke_credentials_by_owner(
+    p_owner_user_id TEXT,
+    p_account_id    TEXT,
+    p_revoked_at    TIMESTAMPTZ,
+    p_reason        TEXT
+) RETURNS TABLE(
+    jti         VARCHAR(255),
+    identity_id UUID,
+    account_id  VARCHAR(255),
+    project_id  VARCHAR(255),
+    expires_at  TIMESTAMPTZ
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE chain(id, jti, depth) AS (
+        SELECT ic.id, ic.jti, 0
+        FROM issued_credentials ic
+        JOIN identities i ON i.id = ic.identity_id
+        WHERE i.owner_user_id = p_owner_user_id
+          AND i.account_id    = p_account_id
+        UNION ALL
+        SELECT ic.id, ic.jti, chain.depth + 1
+        FROM issued_credentials ic
+        JOIN chain ON ic.parent_jti = chain.jti
+        WHERE chain.depth < 50
+    )
+    CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+    , revoked AS (
+        UPDATE issued_credentials ic
+        SET is_revoked    = TRUE,
+            revoked_at    = p_revoked_at,
+            revoke_reason = p_reason
+        WHERE ic.id IN (SELECT c.id FROM chain c WHERE NOT c.is_cycle)
+          AND ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+        RETURNING ic.jti, ic.identity_id, ic.account_id, ic.project_id, ic.expires_at
+    )
+    SELECT r.jti, r.identity_id, r.account_id, r.project_id, r.expires_at
+    FROM revoked r;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/041_revoke_credentials_by_owner.up.sql
+++ b/migrations/041_revoke_credentials_by_owner.up.sql
@@ -20,6 +20,14 @@
 -- that were live and are now revoked — so the RevocationNotifier fan-out stays
 -- accurate and already-dead rows emit no events. Cycle guard + depth cap 50
 -- match the identity/credential cascades.
+--
+-- Multi-anchor note (intentional): unlike the single-identity 031 seed, this
+-- seed can contain both a parent agent and a child the same human owns, so a
+-- credential may be reached both as a seed row and as a descendant and its
+-- subtree walked once per owned ancestor. This is correctness-safe — the final
+-- UPDATE is set-membership on ic.id, so each physical row flips once and each
+-- flipped row is RETURNed once (no double-revoke, no duplicate notifier event)
+-- — and bounded: the depth cap 50 caps the re-visits at a small constant factor.
 
 CREATE OR REPLACE FUNCTION revoke_credentials_by_owner(
     p_owner_user_id TEXT,


### PR DESCRIPTION
## What

Adds `revoke_credentials_by_owner` — the missing enforcement primitive for **human offboarding** ("deactivate a person, every agent they own dies").

Today credential revocation anchors on a **credential JTI** (`Revoke`) or an **identity ID** (`RevokeAllActiveForIdentity`). There is no way to revoke every agent a given human owns. So when a person is deactivated in the IdP, the agents that act on their behalf keep working until their tokens expire.

## Change

- **migration 041** `revoke_credentials_by_owner(p_owner_user_id, p_account_id, p_revoked_at, p_reason)` — anchors the recursive cascade on every credential whose identity has `owner_user_id = p_owner_user_id AND account_id = p_account_id`, then walks `parent_jti` to delegated sub-agents. It is a direct structural mirror of `revoke_credentials_cascade` (migration 031): crosses dead intermediates (no liveness filter in the traversal), the final `UPDATE` alone flips not-yet-revoked/not-yet-expired rows, same `RETURNS TABLE(jti, identity_id, account_id, project_id, expires_at)` shape, same cycle guard + depth cap 50. Scoped by `(owner_user_id, account_id)` for tenant safety — never reaches across accounts.
- **store** `CredentialRepository.RevokeAllActiveForOwner` — mirrors `RevokeAllActiveForIdentity`, stamps `RevokedAt`.
- **service** `CredentialService.RevokeAllActiveForOwner` — default reason `owner_deactivated`; fires one `RevocationNotifier` event per affected JTI via the shared dispatcher, exactly like the identity path, so Shield's revocation deny-set denies the tokens within seconds (CAP-IDN-007).

## Why this shape

The last-mile enforcement already exists (Shield's `authn.revocations` deny-set + quarantine set are merged). What was missing is a *trigger that revokes by human*. This PR is that primitive; it deliberately stops at the service boundary.

## Scope / follow-ups (not in this PR)

- **IdP trigger wiring** — a Clerk `organizationMembership.deleted`/`user.deleted` webhook or a SCIM `active=false` deprovision handler that calls this service. That's the offboarding integration (ADR 0015 admin#1220 Slice 2), a webhook/SCIM adapter — not a new enforcement mechanism.
- **HTTP endpoint + integration test** — the existing revocation integration harness is HTTP-driven and there is no owner-revoke endpoint yet, so the primitive isn't reachable from that harness. An internal management endpoint + a mirror of `TestRevocationNotifier_FiresOnCredentialRevokeCascade` (register two identities under one owner, delegate, revoke-by-owner, assert both JTIs revoked and events fired) should land with the trigger.

## Verification

`gofmt` clean; the SQL mirrors the proven migration-031 function. **Local `go build`/full test run is blocked by this environment's Go 1.26 toolchain issue** (`encoding/json/v2` build constraints via a transitive `jwx/v4` import) — unrelated to this change; CI's toolchain builds it. Requesting a `migration-analyzer` review of the SQL for locking/safety and a CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
