### PR TITLE
fix: reject empty owner in owner-scoped cascade revocation (closes #275)

### DIFF
--- a/internal/service/credential.go
+++ b/internal/service/credential.go
@@ -639,7 +639,30 @@ func (s *CredentialService) RevokeAllActiveForIdentity(ctx context.Context, iden
 // Fires one RevocationNotifier event per affected JTI after the revocation
 // commits, exactly like RevokeAllActiveForIdentity, so Shield's deny-set picks
 // them up within seconds.
+//
+// Both ownerUserID and accountID are REQUIRED and rejected when empty. This is
+// a hard guard, not defensive tidiness: identities.owner_user_id is NOT NULL
+// (001_init_schema), so an ownerless identity — the documented posture for
+// `discovered` ones (identity-lifecycle.md "Ownership: relaxed for discovered
+// only") — stores the empty string. An empty ownerUserID would therefore match
+// EVERY ownerless identity in the account and cascade-revoke each one's whole
+// delegation subtree. The realistic trigger is the intended caller: an IdP
+// offboarding webhook whose user-id field arrives blank, turning "revoke one
+// departing human's agents" into a tenant-wide outage of exactly the workloads
+// nobody watches. Revocation is not reversible, so this fails closed.
+//
+// The identity-scoped sibling is protected only incidentally — its uuid cast
+// rejects "" with a 22P02 — so the guard lives here explicitly rather than
+// relying on that accident holding for a TEXT column. Mirrored in SQL by
+// migration 042 so it survives a caller that bypasses this service.
 func (s *CredentialService) RevokeAllActiveForOwner(ctx context.Context, ownerUserID, accountID, reason string) (int64, error) {
+	if ownerUserID == "" || accountID == "" {
+		return 0, fmt.Errorf(
+			"RevokeAllActiveForOwner requires a non-empty owner_user_id and account_id (got owner=%q account=%q): "+
+				"an empty owner matches every ownerless identity in the account",
+			ownerUserID, accountID)
+	}
+
 	if reason == "" {
 		reason = "owner_deactivated"
 	}

--- a/internal/service/credential_revoke_owner_test.go
+++ b/internal/service/credential_revoke_owner_test.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRevokeAllActiveForOwner_RejectsEmptyOwner pins the guard that keeps a
+// blank owner from cascade-revoking every ownerless identity in an account.
+//
+// Why this matters: identities.owner_user_id is VARCHAR(255) NOT NULL, so an
+// ownerless identity stores the empty string rather than NULL — and ownerless is a documented
+// posture for `discovered` identities, not an anomaly. Migration 041's seed
+// predicate is a plain equality on that column, so an empty owner selects every
+// one of them and walks each delegation subtree. The realistic trigger is an IdP
+// offboarding webhook whose user-id field arrives blank.
+//
+// The receiver is built with a nil repo ON PURPOSE. The guard must short-circuit
+// before any repository call, so a nil-pointer panic here is a real failure
+// signal: it means the guard did not fire and execution reached the DB layer.
+func TestRevokeAllActiveForOwner_RejectsEmptyOwner(t *testing.T) {
+	t.Parallel()
+
+	svc := &CredentialService{} // repo intentionally nil — see doc comment
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		ownerUser string
+		accountID string
+	}{
+		{"empty owner", "", "acct-123"},
+		{"empty account", "user-42", ""},
+		{"both empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			n, err := svc.RevokeAllActiveForOwner(ctx, tc.ownerUser, tc.accountID, "owner_deactivated")
+
+			if err == nil {
+				t.Fatalf("expected an error for owner=%q account=%q; a blank owner must never "+
+					"reach the cascade — it matches every ownerless identity in the account",
+					tc.ownerUser, tc.accountID)
+			}
+			if n != 0 {
+				t.Errorf("revoked count = %d, want 0 — nothing may be revoked on the reject path", n)
+			}
+		})
+	}
+}
+
+// TestRevokeAllActiveForOwner_GuardPrecedesReasonDefault documents ordering: the
+// argument guard runs before the reason default, so a caller passing an empty
+// reason AND an empty owner still gets the argument error rather than having the
+// blank owner silently carried into the query with a defaulted reason.
+func TestRevokeAllActiveForOwner_GuardPrecedesReasonDefault(t *testing.T) {
+	t.Parallel()
+
+	svc := &CredentialService{} // nil repo: reaching it would panic
+	if _, err := svc.RevokeAllActiveForOwner(context.Background(), "", "", ""); err == nil {
+		t.Fatal("expected an error when owner, account and reason are all empty")
+	}
+}

--- a/migrations/042_revoke_by_owner_reject_empty.down.sql
+++ b/migrations/042_revoke_by_owner_reject_empty.down.sql
@@ -1,0 +1,54 @@
+-- 042_revoke_by_owner_reject_empty.down.sql
+-- Restores the migration-041 function body (no empty-owner guard). Same
+-- signature and return type, so CREATE OR REPLACE suffices — mirroring how
+-- 031's down restores the 029 bodies.
+--
+-- WARNING: rolling this back reintroduces the hole 042 closed — calling
+-- revoke_credentials_by_owner with an empty p_owner_user_id again matches every
+-- ownerless identity in the account (owner_user_id is NOT NULL, so ownerless
+-- rows store '') and cascade-revokes each one's whole delegation subtree.
+-- Revoked credentials cannot be un-revoked. The service-layer guard in
+-- internal/service/credential.go still applies to callers that go through it;
+-- this rollback only removes the in-database backstop.
+
+CREATE OR REPLACE FUNCTION revoke_credentials_by_owner(
+    p_owner_user_id TEXT,
+    p_account_id    TEXT,
+    p_revoked_at    TIMESTAMPTZ,
+    p_reason        TEXT
+) RETURNS TABLE(
+    jti         VARCHAR(255),
+    identity_id UUID,
+    account_id  VARCHAR(255),
+    project_id  VARCHAR(255),
+    expires_at  TIMESTAMPTZ
+) AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE chain(id, jti, depth) AS (
+        SELECT ic.id, ic.jti, 0
+        FROM issued_credentials ic
+        JOIN identities i ON i.id = ic.identity_id
+        WHERE i.owner_user_id = p_owner_user_id
+          AND i.account_id    = p_account_id
+        UNION ALL
+        SELECT ic.id, ic.jti, chain.depth + 1
+        FROM issued_credentials ic
+        JOIN chain ON ic.parent_jti = chain.jti
+        WHERE chain.depth < 50
+    )
+    CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+    , revoked AS (
+        UPDATE issued_credentials ic
+        SET is_revoked    = TRUE,
+            revoked_at    = p_revoked_at,
+            revoke_reason = p_reason
+        WHERE ic.id IN (SELECT c.id FROM chain c WHERE NOT c.is_cycle)
+          AND ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+        RETURNING ic.jti, ic.identity_id, ic.account_id, ic.project_id, ic.expires_at
+    )
+    SELECT r.jti, r.identity_id, r.account_id, r.project_id, r.expires_at
+    FROM revoked r;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/042_revoke_by_owner_reject_empty.up.sql
+++ b/migrations/042_revoke_by_owner_reject_empty.up.sql
@@ -1,0 +1,91 @@
+-- 042_revoke_by_owner_reject_empty.up.sql
+-- Guard revoke_credentials_by_owner (migration 041) against an empty owner.
+--
+-- identities.owner_user_id is VARCHAR(255) NOT NULL (001_init_schema), so an
+-- ownerless identity does not store NULL — it stores ''. Ownerless is a real,
+-- documented posture, not an anomaly: discovered identities are created without
+-- an owner on purpose (identity-lifecycle.md "Ownership: relaxed for discovered
+-- only"), and internal/store/postgres/identity.go queries them with an explicit
+-- (owner_user_id IS NULL OR owner_user_id = '') facet.
+--
+-- 041's seed predicate is a plain equality:
+--
+--     WHERE i.owner_user_id = p_owner_user_id
+--       AND i.account_id    = p_account_id
+--
+-- so calling it with p_owner_user_id = '' selects EVERY ownerless identity in
+-- the account and cascade-revokes each one's entire delegation subtree. The
+-- realistic trigger is the intended caller — an IdP offboarding webhook whose
+-- user-id field arrives blank — turning "revoke one departing human's agents"
+-- into a tenant-wide outage of the workloads least likely to be monitored.
+-- Revoked credentials cannot be un-revoked.
+--
+-- internal/service/credential.go rejects the empty owner before reaching the
+-- repo. This mirrors it in SQL so the guarantee survives a caller that goes
+-- straight to the function — a direct psql session, another service, or a repo
+-- method added later. Defense in depth is cheap here and the failure mode is
+-- not recoverable.
+--
+-- RAISE EXCEPTION rather than returning zero rows: a blank owner is a caller
+-- bug, and silently succeeding with "revoked 0 credentials" would let a broken
+-- offboarding integration look healthy indefinitely. Failing loudly surfaces it
+-- on the first malformed event.
+--
+-- Everything else — the recursive walk, CYCLE guard, depth cap 50, liveness
+-- filters on the final UPDATE only, and the RETURNING projection — is carried
+-- over from 041 verbatim. CREATE OR REPLACE keeps the signature stable, so no
+-- caller changes.
+
+CREATE OR REPLACE FUNCTION revoke_credentials_by_owner(
+    p_owner_user_id TEXT,
+    p_account_id    TEXT,
+    p_revoked_at    TIMESTAMPTZ,
+    p_reason        TEXT
+) RETURNS TABLE(
+    jti         VARCHAR(255),
+    identity_id UUID,
+    account_id  VARCHAR(255),
+    project_id  VARCHAR(255),
+    expires_at  TIMESTAMPTZ
+) AS $$
+BEGIN
+    IF p_owner_user_id IS NULL OR p_owner_user_id = '' THEN
+        RAISE EXCEPTION
+            'revoke_credentials_by_owner: p_owner_user_id must be non-empty (an empty owner matches every ownerless identity in the account)'
+            USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    IF p_account_id IS NULL OR p_account_id = '' THEN
+        RAISE EXCEPTION
+            'revoke_credentials_by_owner: p_account_id must be non-empty (tenant scope is required)'
+            USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    RETURN QUERY
+    WITH RECURSIVE chain(id, jti, depth) AS (
+        SELECT ic.id, ic.jti, 0
+        FROM issued_credentials ic
+        JOIN identities i ON i.id = ic.identity_id
+        WHERE i.owner_user_id = p_owner_user_id
+          AND i.account_id    = p_account_id
+        UNION ALL
+        SELECT ic.id, ic.jti, chain.depth + 1
+        FROM issued_credentials ic
+        JOIN chain ON ic.parent_jti = chain.jti
+        WHERE chain.depth < 50
+    )
+    CYCLE jti SET is_cycle TO TRUE DEFAULT FALSE USING cycle_path
+    , revoked AS (
+        UPDATE issued_credentials ic
+        SET is_revoked    = TRUE,
+            revoked_at    = p_revoked_at,
+            revoke_reason = p_reason
+        WHERE ic.id IN (SELECT c.id FROM chain c WHERE NOT c.is_cycle)
+          AND ic.is_revoked = FALSE
+          AND ic.expires_at > p_revoked_at
+        RETURNING ic.jti, ic.identity_id, ic.account_id, ic.project_id, ic.expires_at
+    )
+    SELECT r.jti, r.identity_id, r.account_id, r.project_id, r.expires_at
+    FROM revoked r;
+END;
+$$ LANGUAGE plpgsql;

--- a/tests/integration/revoke_by_owner_test.go
+++ b/tests/integration/revoke_by_owner_test.go
@@ -1,0 +1,207 @@
+// Coverage for the owner-scoped cascade revocation SQL (migrations 041/042).
+//
+// Migration 041 shipped with no test at all — a recursive CTE with CYCLE
+// detection, a depth cap, and a data-modifying CTE with RETURNING, whose first
+// execution in anger would also have been its first execution ever. Migration
+// 042 adds the empty-owner guard. This file covers both.
+//
+// The bug 042 closes (issue #275): identities.owner_user_id is VARCHAR(255)
+// NOT NULL, so an ownerless identity stores '' rather than NULL. Ownerless is
+// a documented posture for `discovered` identities, not an anomaly. 041's seed
+// predicate is a plain equality on that column, so calling it with an empty
+// owner selected EVERY ownerless identity in the account and cascade-revoked
+// each one's whole delegation subtree — a tenant-wide outage triggered by, say,
+// an IdP offboarding webhook with a blank user-id field.
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/highflame-ai/zeroid/domain"
+)
+
+// seedIdentityWithCredential inserts an identity (owned or ownerless) plus one
+// live credential, and returns the identity id and the credential's JTI.
+//
+// ownerUserID is written verbatim — passing "" produces exactly the ownerless
+// row shape the production `discovered` path creates, which is the whole point
+// of this file.
+func seedIdentityWithCredential(t *testing.T, ownerUserID, label string) (identityID, jti string) {
+	t.Helper()
+	ctx := context.Background()
+
+	identityID = uuidV4(t)
+	ident := &domain.Identity{
+		ID:           identityID,
+		AccountID:    testAccountID,
+		ProjectID:    testProjectID,
+		ExternalID:   label,
+		Name:         label,
+		WIMSEURI:     "spiffe://zeroid.test/" + testAccountID + "/" + testProjectID + "/agent/" + label,
+		IdentityType: domain.IdentityTypeAgent,
+		TrustLevel:   domain.TrustLevelFirstParty,
+		Status:       domain.IdentityStatusActive,
+		OwnerUserID:  ownerUserID,
+		// allowed_scopes is NOT NULL; bun sends NULL for a nil slice.
+		AllowedScopes: []string{},
+	}
+	_, err := testDB.NewInsert().Model(ident).Exec(ctx)
+	require.NoError(t, err, "insert identity %q", label)
+
+	jti = seedOwnedCredential(t, identityID, label+"-jti", "")
+	return identityID, jti
+}
+
+// seedOwnedCredential inserts one live credential for an identity. parentJTI wires
+// the delegation edge the recursive walk follows; empty means a root.
+func seedOwnedCredential(t *testing.T, identityID, jti, parentJTI string) string {
+	t.Helper()
+
+	cred := &domain.IssuedCredential{
+		ID:         uuidV4(t),
+		IdentityID: &identityID,
+		AccountID:  testAccountID,
+		ProjectID:  testProjectID,
+		JTI:        jti,
+		Subject:    "spiffe://zeroid.test/subject/" + jti,
+		IssuedAt:   time.Now().Add(-time.Minute),
+		ExpiresAt:  time.Now().Add(time.Hour), // live: the UPDATE requires expires_at > now
+		TTLSeconds: 3600,
+		IsRevoked:  false,
+		GrantType:  domain.GrantTypeClientCredentials,
+		ParentJTI:  parentJTI,
+		// scopes is NOT NULL; bun sends NULL for a nil slice.
+		Scopes: []string{},
+	}
+	_, err := testDB.NewInsert().Model(cred).Exec(context.Background())
+	require.NoError(t, err, "insert credential %q", jti)
+	return jti
+}
+
+// callRevokeByOwner invokes the SQL function directly, bypassing the service
+// guard, so this exercises the in-database backstop specifically.
+func callRevokeByOwner(t *testing.T, ownerUserID, accountID, reason string) ([]string, error) {
+	t.Helper()
+
+	var revoked []string
+	err := testDB.NewRaw(
+		"SELECT jti FROM revoke_credentials_by_owner(?, ?, ?, ?)",
+		ownerUserID, accountID, time.Now(), reason,
+	).Scan(context.Background(), &revoked)
+	return revoked, err
+}
+
+func credentialIsRevoked(t *testing.T, jti string) bool {
+	t.Helper()
+
+	var isRevoked bool
+	err := testDB.NewSelect().
+		Model((*domain.IssuedCredential)(nil)).
+		Column("is_revoked").
+		Where("jti = ?", jti).
+		Scan(context.Background(), &isRevoked)
+	require.NoError(t, err, "read is_revoked for %q", jti)
+	return isRevoked
+}
+
+// TestRevokeByOwner_EmptyOwnerIsRejected is the issue #275 regression.
+//
+// Without migration 042 this call revokes every ownerless identity's
+// credentials in the account. With it, the function raises and touches nothing.
+func TestRevokeByOwner_EmptyOwnerIsRejected(t *testing.T) {
+	// Two ownerless identities — the production shape for `discovered` ones.
+	_, ownerlessA := seedIdentityWithCredential(t, "", "ownerless-a-"+shortID(t))
+	_, ownerlessB := seedIdentityWithCredential(t, "", "ownerless-b-"+shortID(t))
+
+	// A delegated child under one of them, so a cascade would reach further
+	// than the seed rows themselves.
+	childOfA := seedOwnedCredential(t, mustIdentityOf(t, ownerlessA), "ownerless-a-child-"+shortID(t), ownerlessA)
+
+	revoked, err := callRevokeByOwner(t, "", testAccountID, "owner_deactivated")
+
+	require.Error(t, err,
+		"an empty owner must be rejected by the function — it matches every ownerless "+
+			"identity in the account (owner_user_id is NOT NULL, so ownerless rows store '')")
+	assert.Empty(t, revoked, "nothing may be returned on the reject path")
+
+	for _, jti := range []string{ownerlessA, ownerlessB, childOfA} {
+		assert.False(t, credentialIsRevoked(t, jti),
+			"issue #275: credential %q belongs to an OWNERLESS identity and must survive "+
+				"a blank-owner call; revoked credentials cannot be un-revoked", jti)
+	}
+}
+
+// TestRevokeByOwner_EmptyAccountIsRejected covers the tenant-scope half of the
+// guard. An empty account would drop the only tenant boundary the function has.
+func TestRevokeByOwner_EmptyAccountIsRejected(t *testing.T) {
+	owner := "user-empty-acct-" + shortID(t)
+	_, jti := seedIdentityWithCredential(t, owner, "empty-acct-"+shortID(t))
+
+	revoked, err := callRevokeByOwner(t, owner, "", "owner_deactivated")
+
+	require.Error(t, err, "an empty account_id must be rejected — tenant scope is required")
+	assert.Empty(t, revoked)
+	assert.False(t, credentialIsRevoked(t, jti))
+}
+
+// TestRevokeByOwner_RevokesOwnedAndDescendants is migration 041's happy path,
+// previously untested: a real owner revokes their own identities' credentials
+// AND the delegated subtree, while other owners and ownerless identities in the
+// same account are untouched.
+func TestRevokeByOwner_RevokesOwnedAndDescendants(t *testing.T) {
+	owner := "user-offboard-" + shortID(t)
+	otherOwner := "user-stays-" + shortID(t)
+
+	// The departing human's agent, plus a sub-agent it delegated to, plus a
+	// grandchild — the chain the recursive walk must follow.
+	ownedID, ownedJTI := seedIdentityWithCredential(t, owner, "owned-"+shortID(t))
+	childJTI := seedOwnedCredential(t, ownedID, "owned-child-"+shortID(t), ownedJTI)
+	grandchildJTI := seedOwnedCredential(t, ownedID, "owned-grandchild-"+shortID(t), childJTI)
+
+	// Bystanders that must NOT be touched.
+	_, otherJTI := seedIdentityWithCredential(t, otherOwner, "other-"+shortID(t))
+	_, ownerlessJTI := seedIdentityWithCredential(t, "", "bystander-ownerless-"+shortID(t))
+
+	revoked, err := callRevokeByOwner(t, owner, testAccountID, "owner_deactivated")
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{ownedJTI, childJTI, grandchildJTI}, revoked,
+		"the owner's credential and its whole delegation subtree must be returned exactly once each")
+
+	for _, jti := range []string{ownedJTI, childJTI, grandchildJTI} {
+		assert.True(t, credentialIsRevoked(t, jti), "%q should be revoked", jti)
+	}
+	assert.False(t, credentialIsRevoked(t, otherJTI),
+		"another owner's credential must be untouched")
+	assert.False(t, credentialIsRevoked(t, ownerlessJTI),
+		"an ownerless identity must be untouched when a real owner is offboarded")
+}
+
+// mustIdentityOf resolves the identity_id behind a JTI so a test can attach a
+// delegated child to the same identity.
+func mustIdentityOf(t *testing.T, jti string) string {
+	t.Helper()
+
+	var id string
+	err := testDB.NewSelect().
+		Model((*domain.IssuedCredential)(nil)).
+		Column("identity_id").
+		Where("jti = ?", jti).
+		Scan(context.Background(), &id)
+	require.NoError(t, err)
+	return id
+}
+
+// shortID keeps seeded external_id / jti values unique across tests sharing the
+// one postgres container. Derived from a fresh UUID rather than a timestamp so
+// two seeds in the same nanosecond cannot collide on the jti unique index.
+func shortID(t *testing.T) string {
+	t.Helper()
+	return uuidV4(t)[:8]
+}


### PR DESCRIPTION
Closes #275.

## The bug

`RevokeAllActiveForOwner` accepted an empty `owner_user_id` and passed it straight into migration 041's seed predicate, which is a plain equality:

```sql
WHERE i.owner_user_id = p_owner_user_id
  AND i.account_id    = p_account_id
```

`identities.owner_user_id` is `VARCHAR(255) NOT NULL` (001_init_schema), so an ownerless identity stores `''` — **not** NULL. And ownerless is a documented posture for `discovered` identities, not an anomaly: `identity.go` calls ownership *"OPTIONAL — ownerless"* for them, and `postgres/identity.go` has an explicit `(owner_user_id IS NULL OR owner_user_id = '')` facet built on exactly that value.

So a blank owner matched **every ownerless identity in the account** and cascade-revoked each one's entire delegation subtree.

The realistic trigger is the intended caller: an IdP offboarding webhook whose user-id field arrives blank turns *"revoke one departing human's agents"* into a tenant-wide outage of precisely the workloads nobody is watching. Revoked credentials cannot be un-revoked.

## Reproduced against a real database

With migration 042 removed, seeding two ownerless identities plus a delegated child and calling with a blank owner:

```
WITHOUT MIGRATION 042 -> err=<nil>, revoked 3 credential(s):
  [ownerless-a-...-jti  ownerless-b-...-jti  ownerless-a-child-...]
```

No error, three credentials gone — including the delegated child, so the cascade reached past the seed rows. With 042 the function raises and nothing is touched.

## The fix — guards at both layers

They protect different callers, and the failure mode is unrecoverable, so both earn their place:

- **`internal/service/credential.go`** rejects an empty `owner_user_id` or `account_id` before reaching the repo.
- **Migration 042** mirrors it with `RAISE EXCEPTION` so the guarantee survives a caller that bypasses the service — a psql session, another service, or a repo method added later.

`RAISE` rather than returning zero rows on purpose: a blank owner is a caller bug, and silently reporting *"revoked 0 credentials"* would let a broken offboarding integration look healthy indefinitely.

**041 is untouched** — it's already merged, so 042 `CREATE OR REPLACE`s the function, mirroring how 031's down restores the 029 bodies. The down migration restores 041's body and carries an explicit warning that rolling back reintroduces the hole.

Everything else in the function — the recursive walk, CYCLE guard, depth cap 50, liveness filters on the final UPDATE only, and the RETURNING projection — is carried over verbatim. Signature unchanged, so no caller changes.

## Tests — migration 041's first coverage

041 shipped with none, which is the second half of #275. It's the most intricate SQL in the repo (recursive CTE + CYCLE detection + depth cap + data-modifying CTE with RETURNING), and its first execution in anger would have been its first execution ever.

`tests/integration/revoke_by_owner_test.go` (real Postgres):
- empty owner rejected; both ownerless credentials **and** the delegated child survive — **verified to fail without 042**
- empty account rejected (the tenant-scope half)
- happy path: owner's credential + child + grandchild revoked exactly once each, while another owner's credential and an ownerless identity in the same account are untouched

`internal/service/credential_revoke_owner_test.go`: the service guard, built with a **nil repo deliberately** — a panic there proves the guard failed to short-circuit before the DB layer. Mutation-checked: removing the guard makes them fail.

`go vet` clean, `gofmt` clean, unit suite green, full integration suite green (68s).

## Not in this PR

#275 also notes the primitive is **unreachable** — no caller, no `Server` method, no `hooks.go` wrapper. I've deliberately left that out: the identity-scoped sibling isn't exported either (it's reached from internal deactivation flows), so exposing this one means inventing a new public API shape, and choosing the offboarding entry point — Server method? admin endpoint? webhook handler? — is a design decision rather than a bug fix.

The issue's warning was that *"wiring a caller without first adding the guard is the dangerous ordering"*. This PR establishes the guard, so whichever entry point is chosen can now be wired safely. Happy to follow up once we've picked the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)