### PR TITLE
fix: bind every value of a repeated list filter, not just the first

### DIFF
--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -92,6 +92,14 @@ type GetAgentOutput struct {
 
 // splitCSV expands comma-separated values in a []string slice so callers can
 // use either ?status=a,b or ?status=a&status=b.
+//
+// This only holds if the query tag carries `explode`. huma disables explode by
+// default for query params, and its non-explode slice path reads
+// strings.Split(ctx.Query(name), ",") — ctx.Query returns the FIRST occurrence
+// only, so a repeated ?status=a&status=b silently binds to just ["a"] before
+// this function ever sees it. Every multi-value filter below is therefore
+// tagged `,explode`, which makes huma collect all occurrences and leaves the
+// comma form to splitCSV. Both spellings then reach the repo intact.
 func splitCSV(vals []string) []string {
 	var out []string
 	for _, v := range vals {
@@ -107,15 +115,15 @@ func splitCSV(vals []string) []string {
 
 type ListAgentsInput struct {
 	AgentType      string   `query:"agent_type" doc:"Filter by agent type"`
-	IdentityType   []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
+	IdentityType   []string `query:"identity_type,explode" doc:"Filter by identity type. Repeat or comma-separate for multiple (e.g. agent,application)."`
 	Label          string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
-	TrustLevel     []string `query:"trust_level" doc:"Filter by trust level. Comma-separated for multiple."`
+	TrustLevel     []string `query:"trust_level,explode" doc:"Filter by trust level. Repeat or comma-separate for multiple."`
 	IsActive       string   `query:"is_active" doc:"Filter by active status"`
 	Search         string   `query:"search" doc:"Search by name or external_id"`
 	Metadata       string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
 	IdentityClass  string   `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
 	Origin         string   `query:"origin" doc:"Filter by provenance: an exact ecosystem (e.g. okta) or \"external\" for any discovered (non-native) identity"`
-	Status         []string `query:"status" doc:"Filter by lifecycle status. Comma-separated for multiple."`
+	Status         []string `query:"status,explode" doc:"Filter by lifecycle status. Repeat or comma-separate for multiple."`
 	OwnerUserID    string   `query:"owner_user_id" doc:"Filter by owner user ID"`
 	Ownerless      string   `query:"ownerless" doc:"Filter for identities with no owner (true or false)"`
 	Limit          int      `query:"limit" default:"20" doc:"Items per page (max 100)"`

--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -80,16 +80,22 @@ type GetIdentityByWIMSEInput struct {
 	URI string `query:"uri" required:"true" doc:"WIMSE/SPIFFE URI to resolve (e.g. spiffe://highflame.io/acme/prod/agent/claude-bot)"`
 }
 
+// Multi-value filters are tagged `,explode` for the reason documented on
+// splitCSV in agent.go: without it huma reads only the first occurrence of a
+// repeated param, so ?status=a&status=b silently narrows to ["a"]. Kept in
+// lockstep with ListAgentsInput — these two list surfaces are the same filter
+// contract and drift between them is invisible until a caller picks the wrong
+// spelling.
 type ListIdentitiesInput struct {
-	IdentityType  []string `query:"identity_type" doc:"Filter by identity type. Comma-separated for multiple (e.g. agent,application)."`
+	IdentityType  []string `query:"identity_type,explode" doc:"Filter by identity type. Repeat or comma-separate for multiple (e.g. agent,application)."`
 	Label         string   `query:"label" doc:"Filter by label (key:value, e.g. product:guardrails)"`
-	TrustLevel    []string `query:"trust_level" doc:"Filter by trust level. Comma-separated for multiple (e.g. unverified,verified_third_party)."`
+	TrustLevel    []string `query:"trust_level,explode" doc:"Filter by trust level. Repeat or comma-separate for multiple (e.g. unverified,verified_third_party)."`
 	IsActive      string   `query:"is_active" doc:"Filter by active status"`
 	Search        string   `query:"search" doc:"Search by name or external_id"`
 	Metadata      string   `query:"metadata" doc:"Filter by metadata: \"key\" (key present) or \"key:value\" (containment), e.g. redteam_target"`
 	IdentityClass string   `query:"identity_class" doc:"Filter by identity class: \"custom\" (user-created) or \"code_agent\" (auto-registered by hooks)"`
 	Origin        string   `query:"origin" doc:"Filter by provenance: an exact ecosystem (e.g. okta) or \"external\" for any discovered (non-native) identity"`
-	Status        []string `query:"status" doc:"Filter by exact lifecycle status. Comma-separated for multiple (e.g. discovered,pending,active)."`
+	Status        []string `query:"status,explode" doc:"Filter by exact lifecycle status. Repeat or comma-separate for multiple (e.g. discovered,pending,active)."`
 	OwnerUserID   string   `query:"owner_user_id" doc:"Filter by owner user ID"`
 	Ownerless     string   `query:"ownerless" doc:"Filter for identities with no owner (true or false)"`
 	Limit         int      `query:"limit" default:"20" doc:"Items per page (max 100)"`

--- a/internal/handler/list_filter_binding_test.go
+++ b/internal/handler/list_filter_binding_test.go
@@ -1,0 +1,142 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The multi-value list filters are bound by huma from the query string, and
+// that binding — not splitCSV — is where repeated params were being dropped.
+//
+// huma disables `explode` by default for query params. Its non-explode slice
+// path is strings.Split(ctx.Query(name), ","), and ctx.Query returns only the
+// FIRST occurrence, so ?status=a&status=b bound to ["a"] and the other values
+// vanished before any handler code ran. splitCSV's own unit tests pass a
+// []string{"a","b"} directly and therefore could never catch it: they assert
+// the layer below the break.
+//
+// These tests drive a real request through huma so both spellings are pinned at
+// the layer that actually decodes them. They fail if anyone drops `,explode`
+// from the struct tags.
+
+// bindListAgentsInput runs a GET through huma and returns the bound input.
+func bindListAgentsInput(t *testing.T, rawQuery string) ListAgentsInput {
+	t.Helper()
+
+	var got ListAgentsInput
+	_, api := humatest.New(t)
+	huma.Register(api, huma.Operation{
+		OperationID: "test-list-agents",
+		Method:      http.MethodGet,
+		Path:        "/agents/registry",
+	}, func(_ context.Context, in *ListAgentsInput) (*struct{}, error) {
+		got = *in
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/agents/registry?" + rawQuery)
+	// An empty output body yields 204; anything >= 300 means huma rejected the
+	// query (a 422 validation failure is the shape a bad tag would produce).
+	require.Less(t, resp.Code, 300, "request failed (%d): %s", resp.Code, resp.Body.String())
+
+	return got
+}
+
+// bindListIdentitiesInput is the sibling surface, kept in lockstep.
+func bindListIdentitiesInput(t *testing.T, rawQuery string) ListIdentitiesInput {
+	t.Helper()
+
+	var got ListIdentitiesInput
+	_, api := humatest.New(t)
+	huma.Register(api, huma.Operation{
+		OperationID: "test-list-identities",
+		Method:      http.MethodGet,
+		Path:        "/identities",
+	}, func(_ context.Context, in *ListIdentitiesInput) (*struct{}, error) {
+		got = *in
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/identities?" + rawQuery)
+	// An empty output body yields 204; anything >= 300 means huma rejected the
+	// query (a 422 validation failure is the shape a bad tag would produce).
+	require.Less(t, resp.Code, 300, "request failed (%d): %s", resp.Code, resp.Body.String())
+
+	return got
+}
+
+func TestListAgentsInput_RepeatedStatusBindsEveryValue(t *testing.T) {
+	// The exact shape Studio's inventory sends on every page load. Before
+	// `,explode` this bound to ["active"], so the inventory silently filtered to
+	// active-only and pending/expired agents were invisible (studio#1405).
+	in := bindListAgentsInput(t, "status=active&status=pending&status=expired")
+	assert.Equal(t, []string{"active", "pending", "expired"}, splitCSV(in.Status))
+}
+
+func TestListAgentsInput_CommaSeparatedStatusStillBinds(t *testing.T) {
+	// The documented spelling must keep working — `,explode` changes how huma
+	// collects occurrences, and splitCSV is what keeps the comma form valid.
+	in := bindListAgentsInput(t, "status=active,pending,expired")
+	assert.Equal(t, []string{"active", "pending", "expired"}, splitCSV(in.Status))
+}
+
+func TestListAgentsInput_BothSpellingsAgree(t *testing.T) {
+	repeated := bindListAgentsInput(t, "status=active&status=pending")
+	comma := bindListAgentsInput(t, "status=active,pending")
+	assert.Equal(t, splitCSV(comma.Status), splitCSV(repeated.Status))
+}
+
+func TestListAgentsInput_RepeatedIdentityTypeAndTrustLevelBind(t *testing.T) {
+	// These work today only because Studio happens to comma-join them. Pin the
+	// repeated form too, so switching a caller's spelling can't silently narrow
+	// the filter the way status did.
+	in := bindListAgentsInput(t,
+		"identity_type=agent&identity_type=application&trust_level=unverified&trust_level=first_party")
+	assert.Equal(t, []string{"agent", "application"}, splitCSV(in.IdentityType))
+	assert.Equal(t, []string{"unverified", "first_party"}, splitCSV(in.TrustLevel))
+}
+
+func TestListAgentsInput_MixedRepeatedAndCommaBinds(t *testing.T) {
+	in := bindListAgentsInput(t, "status=active,pending&status=expired")
+	assert.Equal(t, []string{"active", "pending", "expired"}, splitCSV(in.Status))
+}
+
+func TestListAgentsInput_SingleValueAndAbsentFilterUnchanged(t *testing.T) {
+	in := bindListAgentsInput(t, "status=discovered")
+	assert.Equal(t, []string{"discovered"}, splitCSV(in.Status))
+
+	// The adoption inbox sends exactly one status; absent filters must stay nil
+	// so the repo applies its default "exclude discovered" branch.
+	none := bindListAgentsInput(t, "limit=20")
+	assert.Nil(t, splitCSV(none.Status))
+	assert.Nil(t, splitCSV(none.IdentityType))
+	assert.Nil(t, splitCSV(none.TrustLevel))
+}
+
+func TestListAgentsInput_ScalarFiltersUnaffected(t *testing.T) {
+	// origin is a single string by contract; adding explode to its neighbours
+	// must not disturb it or the pagination params.
+	in := bindListAgentsInput(t, "origin=okta&search=bot&limit=50&offset=100")
+	assert.Equal(t, "okta", in.Origin)
+	assert.Equal(t, "bot", in.Search)
+	assert.Equal(t, 50, in.Limit)
+	assert.Equal(t, 100, in.Offset)
+}
+
+func TestListIdentitiesInput_RepeatedFiltersBindEveryValue(t *testing.T) {
+	in := bindListIdentitiesInput(t,
+		"status=discovered&status=pending&identity_type=agent&identity_type=mcp_server")
+	assert.Equal(t, []string{"discovered", "pending"}, splitCSV(in.Status))
+	assert.Equal(t, []string{"agent", "mcp_server"}, splitCSV(in.IdentityType))
+}
+
+func TestListIdentitiesInput_CommaSeparatedStillBinds(t *testing.T) {
+	in := bindListIdentitiesInput(t, "status=discovered,pending")
+	assert.Equal(t, []string{"discovered", "pending"}, splitCSV(in.Status))
+}

--- a/internal/handler/list_filter_binding_test.go
+++ b/internal/handler/list_filter_binding_test.go
@@ -130,13 +130,20 @@ func TestListAgentsInput_ScalarFiltersUnaffected(t *testing.T) {
 }
 
 func TestListIdentitiesInput_RepeatedFiltersBindEveryValue(t *testing.T) {
+	// Covers all three multi-value filters on this surface. Every tag this PR
+	// touches needs a case that fails without it — otherwise the suite passes
+	// while the regression it exists to prevent is back.
 	in := bindListIdentitiesInput(t,
-		"status=discovered&status=pending&identity_type=agent&identity_type=mcp_server")
+		"status=discovered&status=pending"+
+			"&identity_type=agent&identity_type=mcp_server"+
+			"&trust_level=unverified&trust_level=first_party")
 	assert.Equal(t, []string{"discovered", "pending"}, splitCSV(in.Status))
 	assert.Equal(t, []string{"agent", "mcp_server"}, splitCSV(in.IdentityType))
+	assert.Equal(t, []string{"unverified", "first_party"}, splitCSV(in.TrustLevel))
 }
 
 func TestListIdentitiesInput_CommaSeparatedStillBinds(t *testing.T) {
-	in := bindListIdentitiesInput(t, "status=discovered,pending")
+	in := bindListIdentitiesInput(t, "status=discovered,pending&trust_level=unverified,first_party")
 	assert.Equal(t, []string{"discovered", "pending"}, splitCSV(in.Status))
+	assert.Equal(t, []string{"unverified", "first_party"}, splitCSV(in.TrustLevel))
 }


### PR DESCRIPTION
`?status=active&status=pending&status=expired` bound to `["active"]`. Every value after the first was dropped silently — no error, no warning, just a narrower result set than the caller asked for.

## Root cause

huma disables `explode` by default for query params ([`huma.go:156-158`](https://github.com/danielgtaylor/huma/blob/v2.37.3/huma.go#L156-L158)):

```go
// If `in` is `query` then `explode` defaults to true. Parsing is *much*
// easier if we use comma-separated values, so we disable explode by default.
if slices.Contains(split[1:], "explode") { pfi.Explode = true }
```

and its non-explode slice path is:

```go
case reflect.Slice:
    if p.Explode {
        values = (&u).Query()[p.Name]      // all occurrences
    } else {
        values = strings.Split(value, ",")  // value = ctx.Query(name) → FIRST occurrence only
    }
```

So the repeated spelling collapsed before any handler code ran. `splitCSV` then re-split a one-element slice and produced one value.

## The fix

Tag the multi-value filters `,explode` on both list surfaces. huma then collects every occurrence, `splitCSV` keeps the comma spelling working, and both forms reach the repo intact — which is what `splitCSV`'s doc comment already promised ("so callers can use either `?status=a,b` or `?status=a&status=b`").

`identity_type` and `trust_level` get the same treatment. They work today only because their one caller happens to comma-join them; without `explode`, anyone switching spelling would hit the same silent narrowing. `origin` is unchanged — it is a single string by contract.

## Why this mattered downstream

Studio's agent inventory sends `status` as repeated params, and it has to: Admin's `ListAgents` shape-checks each value against `^[a-z][a-z0-9_]*$`, so the comma form 400s at the proxy. The two encodings were broken in opposite directions and Studio picked the quiet one.

Its default status filter is `active + pending + expired`, so **every inventory page load was being narrowed to active-only** — pending and expired agents invisible behind chips that claimed to include them, and an agent adopted from the Unmanaged queue never appearing in the inventory the adoption banner points at.

## Tests

`internal/handler/list_filter_binding_test.go` drives real requests through huma and pins both spellings at the layer that actually decodes them.

The existing `splitCSV` unit tests could not have caught this — `TestSplitCSV_RepeatedQueryParam` passes `[]string{"active", "pending"}` straight in, asserting the layer *below* the break. The new tests cover: repeated, comma, mixed, both-spellings-agree, single value, absent filter stays nil (so the repo's default "exclude discovered" branch still fires), and scalar filters/pagination unaffected.

Verified the guard actually bites — reverting `,explode` on `status` alone:

```
--- FAIL: TestListAgentsInput_RepeatedStatusBindsEveryValue
    expected: []string{"active", "pending", "expired"}
    actual  : []string{"active"}
```

## Deploy note

zeroid is a library; `highflame-authn` imports it via `zeroid.NewServer`. This needs a release tag and an authn `go.mod` bump before it reaches dev1 — happy to cut that once this merges, or leave it to the usual release cadence.

## Test plan

- [x] `go test ./...` — all 9 packages pass (`GOEXPERIMENT=jsonv2`)
- [x] `go vet ./...` — clean
- [x] `gofmt -l internal/handler/` — clean
- [x] `CGO_ENABLED=0 GOOS=linux go build ./...` — clean
- [x] New tests verified failing without the fix
- [ ] Post-merge on dev1: Studio inventory with default filters returns pending + expired rows alongside active

Fixes highflame-ai/highflame-studio#1405

🤖 Generated with [Claude Code](https://claude.com/claude-code)