### PR TITLE
devops: scope the pkg/dpop drift guard to Go build inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,31 @@ jobs:
       # the pinned tag) while in-repo tests passed against the NEW
       # local source — a silent regression. Fail loudly instead.
       #
+      # Scoped to files that can actually cause that regression: *.go,
+      # go.mod, go.sum. The hazard this guard exists for is a BINARY
+      # built against different code than consumers resolve from the
+      # proxy, and only Go build inputs can produce it.
+      #
+      # *_test.go is deliberately left in the blocking set even though
+      # it never reaches a binary. It is still published module source,
+      # a divergence there means pkg/dpop changed materially, and "any
+      # .go file means cut a pkg/dpop release" is a rule a maintainer
+      # can hold in their head. Cheap conservatism on a rare case.
+      #
+      # It used to diff all of pkg/dpop/, which meant a one-line
+      # README correction (#176, pkg/dpop/README.md) blocked EVERY
+      # zeroid release until someone cut a pkg/dpop version for it.
+      # v1.8.6 and v1.8.7 both failed here and published nothing —
+      # two releases silently un-shipped by a docs edit. A tripwire
+      # that halts the release train over prose is a tripwire people
+      # learn to route around, which costs more than the drift it
+      # was watching for.
+      #
+      # Non-build drift is still REPORTED, just not fatal: it's real
+      # (pkg.go.dev serves the README from the pinned tag, so docs lag
+      # until the next genuine pkg/dpop release) but it cannot corrupt
+      # a binary, so it does not get a veto over shipping.
+      #
       # pkg/authjwt is NOT checked because it's imported only from
       # tests/integration. Go does not follow test imports across
       # module boundaries, so its version reference (currently
@@ -132,15 +157,34 @@ jobs:
             echo "::error::Either fix go.mod to reference an existing pkg/dpop tag, or run release-dpop.yml."
             exit 1
           fi
-          if ! git diff --quiet "${TAG}" -- pkg/dpop/; then
-            echo "::error::pkg/dpop/ source has drifted from ${TAG} but go.mod still references it."
+
+          # Build inputs only — these are what a shipped binary is made of.
+          # Git pathspec wildcards cross '/' by default (unlike shell globs), so
+          # 'pkg/dpop/*.go' also covers any future subpackage. Verified against
+          # a nested pkg/dpop/internal/sub/x.go.
+          BUILD_PATHS=('pkg/dpop/*.go' 'pkg/dpop/go.mod' 'pkg/dpop/go.sum')
+          BUILD_DRIFT=$(git diff --name-only "${TAG}" -- "${BUILD_PATHS[@]}")
+          # Everything else under pkg/dpop/ (README, docs, examples).
+          OTHER_DRIFT=$(git diff --name-only "${TAG}" -- pkg/dpop/ \
+            "${BUILD_PATHS[@]/#/:(exclude)}")
+
+          if [[ -n "${BUILD_DRIFT}" ]]; then
+            echo "::error::pkg/dpop/ build inputs have drifted from ${TAG} but go.mod still references it:"
+            while IFS= read -r f; do echo "::error::  ${f}"; done <<< "${BUILD_DRIFT}"
             echo "::error::Releasing zeroid now would ship a binary using the OLD pkg/dpop ${REF}, while in-repo tests passed against the NEW local source. Silent regression risk."
             echo "::error::Fix by running release-dpop.yml first to cut a new pkg/dpop release and update zeroid/go.mod's reference:"
             echo "::error::  gh workflow run release-dpop.yml --field version=<next-dpop-vX.Y.Z>"
             echo "::error::  # ...review + merge the PR opened by release-dpop, then re-publish this release."
             exit 1
           fi
-          echo "✓ pkg/dpop/ source matches ${TAG} — safe to release"
+
+          if [[ -n "${OTHER_DRIFT}" ]]; then
+            echo "::warning::pkg/dpop/ has non-build drift from ${TAG} (docs only — not blocking this release):"
+            while IFS= read -r f; do echo "::warning::  ${f}"; done <<< "${OTHER_DRIFT}"
+            echo "::warning::pkg.go.dev serves these from the pinned tag, so they stay stale until the next pkg/dpop release. Fold a version bump in when convenient: make release-dpop VERSION=<next-dpop-vX.Y.Z>"
+          fi
+
+          echo "✓ pkg/dpop/ build inputs match ${TAG} — safe to release"
 
   tag-submodules:
     needs:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,7 +39,7 @@ make next-version
 
 ## When you change pkg/dpop/
 
-If you've modified anything under `pkg/dpop/`, **cut a new pkg/dpop release first**, BEFORE the next zeroid release:
+If you've modified **Go build inputs** under `pkg/dpop/` — any `*.go` (tests included), `go.mod`, or `go.sum` — **cut a new pkg/dpop release first**, BEFORE the next zeroid release:
 
 ```bash
 # 1. Cut a new pkg/dpop release (tags pkg/dpop/vX.Y.Z + opens a PR
@@ -56,7 +56,8 @@ make release-dpop VERSION=v1.6.1
 If you skip step 1-2 and try to cut a zeroid release directly, `release.yml`'s drift guard fails with a clear error:
 
 ```
-::error::pkg/dpop/ source has drifted from pkg/dpop/v1.6.0 but go.mod still references it.
+::error::pkg/dpop/ build inputs have drifted from pkg/dpop/v1.6.0 but go.mod still references it:
+::error::  pkg/dpop/verifier.go
 ::error::Releasing zeroid now would ship a binary using the OLD pkg/dpop v1.6.0, while
 ::error::in-repo tests passed against the NEW local source. Silent regression risk.
 ::error::Fix by running release-dpop.yml first to cut a new pkg/dpop release and update
@@ -66,6 +67,29 @@ If you skip step 1-2 and try to cut a zeroid release directly, `release.yml`'s d
 ```
 
 This is the safety net — you can't silently ship a zeroid binary built against a different pkg/dpop than what consumers will resolve from the proxy.
+
+### Docs-only changes under pkg/dpop/ do not block a release
+
+A change to `pkg/dpop/README.md` (or anything else that isn't a Go build input)
+is **reported as a warning and does not fail the release**:
+
+```
+::warning::pkg/dpop/ has non-build drift from pkg/dpop/v1.6.0 (docs only — not blocking this release):
+::warning::  pkg/dpop/README.md
+::warning::pkg.go.dev serves these from the pinned tag, so they stay stale until the next
+::warning::pkg/dpop release. Fold a version bump in when convenient.
+```
+
+The drift is real — pkg.go.dev renders the README from the pinned tag, so the
+correction isn't visible to consumers until the next genuine `pkg/dpop` release —
+but it cannot corrupt a binary, so it doesn't get a veto over shipping. Fold a
+`make release-dpop` in when convenient.
+
+This scoping exists because the guard used to diff all of `pkg/dpop/`. A one-line
+README correction (#176) consequently blocked **every** zeroid release: v1.8.6 and
+v1.8.7 both failed here and published nothing, so two releases were silently
+un-shipped by a prose edit. A tripwire that halts the release train over docs is
+one people learn to route around, which costs more than the drift it was watching.
 
 ---
 


### PR DESCRIPTION
`release.yml`'s pkg/dpop drift guard diffed the **whole** `pkg/dpop/` directory, so a documentation edit blocked every zeroid release. Two have already been lost to it.

## What happened

#176 corrected one line of `pkg/dpop/README.md` — dropping a claim that the `bh` body-hash claim has its own IETF draft:

```diff
-- [draft-ietf-oauth-dpop-bh](...) — body-hash extension claim
++ The `bh` body-hash proof claim is a ZeroID extension — no RFC or IETF draft of its own. …
```

Correct change. But it landed without the release-dpop dance, and the guard treats any file under `pkg/dpop/` as source:

```bash
if ! git diff --quiet "${TAG}" -- pkg/dpop/; then   # <- markdown included
```

`git diff --stat pkg/dpop/v1.6.0 v1.8.7 -- pkg/dpop/` is that one file, one line. No Go code changed.

## Cost so far

| tag | release run | outcome |
|---|---|---|
| v1.8.5 | ✅ | last artifact actually published (2026-08-10 00:01Z) |
| **v1.8.6** | ❌ this step | nothing published |
| **v1.8.7** | ❌ this step | nothing published |

`highflame-validate` failing means `tag-submodules`, `goreleaser`, `sast` and `trigger` all **skip** — no binary, no image. So v1.8.6 and v1.8.7 are silently un-shipped, and anyone assuming their contents are deployed is wrong.

## The fix

Block on what can actually cause the harm; report the rest.

The guard's own rationale is a **binary** built against different code than consumers resolve from the proxy. Only Go build inputs can produce that, so:

- **Blocking** — `pkg/dpop/*.go`, `pkg/dpop/go.mod`, `pkg/dpop/go.sum`. Now also lists the offending files.
- **Warning, non-fatal** — anything else under `pkg/dpop/` (README, docs). The drift is real, and the warning says so: pkg.go.dev renders the README from the pinned tag, so a correction stays invisible to consumers until the next genuine pkg/dpop release. But it cannot corrupt a binary, so it doesn't get a veto over shipping.

A tripwire that halts the release train over prose is one people learn to route around, which costs more than the drift it was watching for.

### Two deliberate calls

- **`*_test.go` stays blocking** even though it never reaches a binary. It's still published module source, a divergence there means pkg/dpop changed materially, and "any `.go` file means cut a pkg/dpop release" is a rule that fits in a maintainer's head. Cheap conservatism on a rare case. The comment says so rather than leaving the rationale looking self-contradictory.
- **Git pathspec wildcards cross `/`** (unlike shell globs), so `'pkg/dpop/*.go'` already covers any future subpackage — no `**` needed. Verified against a nested `pkg/dpop/internal/sub/x.go`.

## Verification

Extracted the step verbatim from the YAML and ran it against the real working tree:

| scenario | exit | result |
|---|---|---|
| real current state (README-only drift) | 0 | ✅ warns, does not block |
| `pkg/dpop/proof.go` modified | 1 | ✅ blocks |
| `pkg/dpop/go.mod` modified | 1 | ✅ blocks |
| `pkg/dpop/go.sum` modified | 1 | ✅ blocks |
| `pkg/dpop/verifier_test.go` modified | 1 | ✅ blocks |
| `.go` **and** README together | 1 | ✅ blocks (build wins) |

`release.yml` also re-parsed as YAML with all five `highflame-validate` steps intact, and the extracted script passes `bash -n`.

## Follow-ups after this merges

1. **Re-publish v1.8.7** so zeroid#283 (the repeated-query-filter fix) actually ships — it's been sitting un-released.
2. **`make release-dpop VERSION=v1.6.1`** so the corrected README reaches pkg.go.dev. No longer urgent once this lands — it's hygiene, not a blocker.

## Test plan

- [x] Guard verified across all six scenarios above
- [x] `release.yml` parses as YAML; steps unchanged in count and order
- [x] Extracted step passes `bash -n`
- [ ] Re-publish v1.8.7 and confirm `highflame-validate` passes with the docs warning, and that goreleaser + docker push run

🤖 Generated with [Claude Code](https://claude.com/claude-code)