### PR TITLE
feat: FederatedCredentialExchange — mint a provider-audienced agent assertion (ADR 0028)

### DIFF
--- a/hooks.go
+++ b/hooks.go
@@ -83,6 +83,14 @@ type AuthorizeRequest = service.AuthorizeRequest
 // See internal/service/principal.go for the canonical doc comment.
 type PrincipalResolver = service.PrincipalResolver
 
+// FederatedExchangeRequest is the input to Server.FederatedCredentialExchange —
+// the Workload-Identity-Federation broker path (ADR 0028). Re-exported from
+// internal/service so deployer code stays at the top-level public surface;
+// both names refer to the same type.
+//
+// See internal/service/federation.go for the canonical doc comment.
+type FederatedExchangeRequest = service.FederatedExchangeRequest
+
 // ErrPrincipalNotApplicable is the sentinel returned by a
 // PrincipalResolver that does not apply to the current request. zeroid
 // moves to the next registered resolver; when every resolver returns

--- a/internal/service/federation.go
+++ b/internal/service/federation.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/oautherror"
+	"github.com/highflame-ai/zeroid/pkg/authjwt"
 )
 
 // FederatedExchangeRequest is the input to FederatedCredentialExchange — the
@@ -47,15 +49,36 @@ const (
 //   - It stamps a FREE-FORM provider audience, bypassing the audience-scope
 //     profile gate. Compensating controls: (1) the trusted-service gate — only
 //     an authenticated internal service (the AI gateway) can call this;
-//     (2) the audience is validated as an absolute https URL with a host and no
-//     userinfo; (3) the minted token carries NO ZeroID scopes, so it conveys
-//     zero authority against ZeroID/Highflame resources — it is usable ONLY as
-//     a bearer assertion at the external provider whose federation rule accepts
-//     its (sub, aud, iss).
+//     (2) the audience is validated as an absolute https URL with a public host
+//     (no userinfo, no loopback/private IP); (3) the token is stamped
+//     token_use=provider_federation, which the shared verifier (pkg/authjwt)
+//     REJECTS for Highflame authentication, and carries NO ZeroID scopes — so a
+//     leaked assertion cannot ride Highflame's own tenant-membership auth gates
+//     and conveys zero ZeroID authority. It is usable ONLY as a bearer assertion
+//     at the external provider whose federation rule accepts its (sub, aud, iss).
 //   - It records an RFC 8693 `act.sub` = the AUTHENTICATED service name (never
 //     a caller-supplied value), so the token is an honest delegation: `sub` is
 //     the agent, `act.sub` is the broker. It is never impersonation — the
 //     subject is never rewritten to the gateway.
+//
+// Trust boundary (audit round 1, accepted-and-documented):
+//   - The caller asserts `SubjectWIMSE` and the tenant (account/project); ZeroID
+//     does NOT re-verify the WIMSE against the identity store here (it mints for
+//     a synthetic identity). So a compromised trusted service could mint an
+//     assertion for an arbitrary agent WIMSE in an arbitrary tenant. The bound
+//     is the PROVIDER's federation rule (subject_prefix / audience), which only
+//     accepts subjects it recognizes — not ZeroID. A subject-belongs-to-tenant
+//     lookup (mirroring ExternalPrincipalExchange's ApplicationID branch) is a
+//     tracked hardening.
+//   - `act.sub` is the trusted-service NAME authenticated by the shared internal
+//     secret, so it identifies "a holder of the internal secret," not a specific
+//     binary. Any trusted internal service can call this (same trust boundary as
+//     the downstream-token routes); restricting the mint to the gateway service
+//     is a tracked hardening.
+//   - The free-form audience is validated (https, public host, no userinfo) but
+//     NOT allowlisted to known providers; an allowlist is a tracked hardening,
+//     lower priority now that the token_use marker makes a mis-audienced
+//     assertion useless against Highflame's own services.
 func (s *OAuthService) FederatedCredentialExchange(ctx context.Context, req FederatedExchangeRequest) (*domain.AccessToken, error) {
 	// Step 1: Trusted-service gate. The broker (actor) identity is taken from
 	// HERE, so a caller can never forge who brokered the assertion.
@@ -95,7 +118,11 @@ func (s *OAuthService) FederatedCredentialExchange(ctx context.Context, req Fede
 		Status:       domain.IdentityStatusActive,
 	}
 
-	custom := map[string]any{}
+	// Mark the assertion as federation-only so the shared verifier (pkg/authjwt)
+	// refuses it for Highflame authentication — it is handed to an external
+	// provider and must never ride Highflame's own tenant-membership auth gates
+	// if it leaks (audit round 1).
+	custom := map[string]any{"token_use": authjwt.TokenUseProviderFederation}
 	if req.ExternalID != "" {
 		custom["external_id"] = req.ExternalID
 	}
@@ -139,5 +166,18 @@ func validateFederationAudience(aud string) error {
 	if u.User != nil {
 		return errors.New("audience must not contain userinfo")
 	}
+	// A real provider audience is a public host. Refuse loopback / private /
+	// link-local literal IPs (audit round 1, H1) — they are never a legitimate
+	// federation provider and only serve to point an assertion somewhere it
+	// should not go.
+	if ip := net.ParseIP(u.Hostname()); ip != nil && !isPublicIP(ip) {
+		return errors.New("audience host must not be a loopback or private address")
+	}
 	return nil
+}
+
+// isPublicIP reports whether ip is a globally routable unicast address (not
+// loopback, private, link-local, or unspecified).
+func isPublicIP(ip net.IP) bool {
+	return ip.IsGlobalUnicast() && !ip.IsPrivate() && !ip.IsLinkLocalUnicast()
 }

--- a/internal/service/federation.go
+++ b/internal/service/federation.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+)
+
+// FederatedExchangeRequest is the input to FederatedCredentialExchange — the
+// Workload-Identity-Federation broker path (ADR 0028). A trusted internal
+// service (the AI gateway) asks ZeroID to mint a short-lived, provider-audienced
+// assertion for an agent it has already authenticated, so the assertion can be
+// presented to the provider's WIF token endpoint and exchanged for a short-lived
+// provider credential.
+type FederatedExchangeRequest struct {
+	AccountID string
+	ProjectID string
+	// SubjectWIMSE is the acting agent's SPIFFE/WIMSE id. It becomes the JWT
+	// `sub` — the principal the provider's federation rule matches on.
+	SubjectWIMSE string
+	// ExternalID is the agent's stable external id, recorded as a claim for
+	// audit correlation. Optional.
+	ExternalID string
+	// Audience is the provider audience to stamp (e.g. https://api.anthropic.com).
+	// Unlike ExternalPrincipalExchange this is a FREE-FORM audience, not a
+	// named scope profile, so it is validated strictly (see
+	// validateFederationAudience) and the token carries NO ZeroID scopes.
+	Audience string
+	// TTLSeconds bounds the assertion lifetime. Clamped to [60, 3600]; default 900.
+	TTLSeconds int
+}
+
+const (
+	federationDefaultTTL = 900
+	federationMinTTL     = 60
+	federationMaxTTL     = 3600
+)
+
+// FederatedCredentialExchange mints a short-lived, provider-audienced assertion
+// for the WIF broker path (ADR 0028 / CAP-IDN-023). It differs from
+// ExternalPrincipalExchange in two security-sensitive ways, both compensated:
+//
+//   - It stamps a FREE-FORM provider audience, bypassing the audience-scope
+//     profile gate. Compensating controls: (1) the trusted-service gate — only
+//     an authenticated internal service (the AI gateway) can call this;
+//     (2) the audience is validated as an absolute https URL with a host and no
+//     userinfo; (3) the minted token carries NO ZeroID scopes, so it conveys
+//     zero authority against ZeroID/Highflame resources — it is usable ONLY as
+//     a bearer assertion at the external provider whose federation rule accepts
+//     its (sub, aud, iss).
+//   - It records an RFC 8693 `act.sub` = the AUTHENTICATED service name (never
+//     a caller-supplied value), so the token is an honest delegation: `sub` is
+//     the agent, `act.sub` is the broker. It is never impersonation — the
+//     subject is never rewritten to the gateway.
+func (s *OAuthService) FederatedCredentialExchange(ctx context.Context, req FederatedExchangeRequest) (*domain.AccessToken, error) {
+	// Step 1: Trusted-service gate. The broker (actor) identity is taken from
+	// HERE, so a caller can never forge who brokered the assertion.
+	if s.trustedServiceValidator == nil {
+		return nil, oauthBadRequest(oautherror.InvalidGrant, "federated credential exchange is not configured")
+	}
+	brokerName, err := s.trustedServiceValidator(ctx)
+	if err != nil {
+		return nil, oauthBadRequestCause(oautherror.InvalidGrant, "caller is not a trusted service", err)
+	}
+
+	// Step 2: Validate shape. The trusted service authenticated the agent and
+	// resolved the tenant; ZeroID validates the free-form audience strictly.
+	if req.AccountID == "" || req.ProjectID == "" {
+		return nil, oauthBadRequest(oautherror.InvalidRequest, "account_id and project_id are required")
+	}
+	if req.SubjectWIMSE == "" {
+		return nil, oauthBadRequest(oautherror.InvalidRequest, "subject_wimse is required")
+	}
+	if err := validateFederationAudience(req.Audience); err != nil {
+		return nil, oauthBadRequestCause(oautherror.InvalidTarget, "invalid federation audience", err)
+	}
+
+	// Step 3: Clamp the TTL to the federation window.
+	ttl := federationDefaultTTL
+	if req.TTLSeconds > 0 {
+		ttl = min(max(req.TTLSeconds, federationMinTTL), federationMaxTTL)
+	}
+
+	// Step 4: Synthetic tenant-scoped identity. The subject is overridden to the
+	// agent's WIMSE, so no identity row is required (mirrors
+	// ExternalPrincipalExchange's no-ApplicationID path).
+	identity := &domain.Identity{
+		AccountID:    req.AccountID,
+		ProjectID:    req.ProjectID,
+		IdentityType: domain.IdentityTypeService,
+		Status:       domain.IdentityStatusActive,
+	}
+
+	custom := map[string]any{}
+	if req.ExternalID != "" {
+		custom["external_id"] = req.ExternalID
+	}
+
+	// Step 5: Issue. NO Scopes are set — the assertion conveys no ZeroID
+	// authority; its only power is what the provider's federation rule grants.
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+		Identity:        identity,
+		GrantType:       domain.GrantTypeTokenExchange,
+		Audience:        []string{req.Audience},
+		SubjectOverride: req.SubjectWIMSE,
+		DelegatedBy:     brokerName,
+		UseRS256:        true,
+		TTL:             ttl,
+		CustomClaims:    custom,
+	})
+	if err != nil {
+		return nil, oauthServerError("failed to issue federated assertion", err)
+	}
+
+	accessToken.AccountID = req.AccountID
+	accessToken.ProjectID = req.ProjectID
+	return accessToken, nil
+}
+
+// validateFederationAudience enforces that a free-form provider audience is an
+// absolute https URL with a host and no userinfo — mirroring the gateway-side
+// endpoint hardening, and stopping the profile-gate bypass from stamping
+// loopback / opaque / plaintext / userinfo-spoofed audiences.
+func validateFederationAudience(aud string) error {
+	u, err := url.Parse(aud)
+	if err != nil {
+		return fmt.Errorf("audience is not a valid URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return errors.New("audience must be an https URL")
+	}
+	if u.Host == "" {
+		return errors.New("audience must have a host")
+	}
+	if u.User != nil {
+		return errors.New("audience must not contain userinfo")
+	}
+	return nil
+}

--- a/internal/service/federation_test.go
+++ b/internal/service/federation_test.go
@@ -88,15 +88,20 @@ func TestValidateFederationAudience(t *testing.T) {
 	}
 
 	bad := map[string]string{
-		"empty":            "",
-		"http":             "http://api.anthropic.com",
-		"http loopback":    "http://127.0.0.1:8040/t",
-		"no scheme":        "api.anthropic.com",
-		"opaque":           "anthropic",
-		"no host":          "https:///path",
-		"userinfo spoof":   "https://api.anthropic.com:x@evil.example/h",
-		"userinfo present": "https://user@api.anthropic.com/t",
-		"ftp":              "ftp://api.anthropic.com",
+		"empty":             "",
+		"http":              "http://api.anthropic.com",
+		"http loopback":     "http://127.0.0.1:8040/t",
+		"https loopback":    "https://127.0.0.1/t",
+		"https ipv6 loop":   "https://[::1]/t",
+		"https private 10":  "https://10.0.0.5/t",
+		"https private 192": "https://192.168.1.1/t",
+		"https link-local":  "https://169.254.169.254/t",
+		"no scheme":         "api.anthropic.com",
+		"opaque":            "anthropic",
+		"no host":           "https:///path",
+		"userinfo spoof":    "https://api.anthropic.com:x@evil.example/h",
+		"userinfo present":  "https://user@api.anthropic.com/t",
+		"ftp":               "ftp://api.anthropic.com",
 	}
 	for name, a := range bad {
 		t.Run(name, func(t *testing.T) {

--- a/internal/service/federation_test.go
+++ b/internal/service/federation_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The gate + validation arms of FederatedCredentialExchange all return BEFORE
+// IssueCredential, so they are exercisable on a minimal OAuthService with no DB
+// or signing. The success mint (sub/act/aud) is covered end-to-end in authn's
+// integration test, which drives the real endpoint against a real store.
+
+func TestFederatedCredentialExchange_TrustedServiceGate(t *testing.T) {
+	req := FederatedExchangeRequest{
+		AccountID:    "acct-1",
+		ProjectID:    "proj-1",
+		SubjectWIMSE: "spiffe://highflame.io/ns/proj-1/agent-x",
+		Audience:     "https://api.anthropic.com",
+	}
+
+	t.Run("no validator configured is refused", func(t *testing.T) {
+		svc := &OAuthService{} // trustedServiceValidator == nil
+		_, err := svc.FederatedCredentialExchange(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not configured")
+	})
+
+	t.Run("untrusted caller is refused", func(t *testing.T) {
+		svc := &OAuthService{trustedServiceValidator: func(context.Context) (string, error) {
+			return "", errors.New("no trusted-service header")
+		}}
+		_, err := svc.FederatedCredentialExchange(context.Background(), req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a trusted service")
+	})
+}
+
+func TestFederatedCredentialExchange_ValidatesShape(t *testing.T) {
+	// Passes the gate, so validation failures surface (all before IssueCredential).
+	trusted := &OAuthService{trustedServiceValidator: func(context.Context) (string, error) {
+		return "firehog", nil
+	}}
+	base := FederatedExchangeRequest{
+		AccountID:    "acct-1",
+		ProjectID:    "proj-1",
+		SubjectWIMSE: "spiffe://highflame.io/ns/proj-1/agent-x",
+		Audience:     "https://api.anthropic.com",
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(r *FederatedExchangeRequest)
+		errSub string
+	}{
+		{"missing account", func(r *FederatedExchangeRequest) { r.AccountID = "" }, "account_id and project_id"},
+		{"missing project", func(r *FederatedExchangeRequest) { r.ProjectID = "" }, "account_id and project_id"},
+		{"missing subject wimse", func(r *FederatedExchangeRequest) { r.SubjectWIMSE = "" }, "subject_wimse is required"},
+		{"http audience", func(r *FederatedExchangeRequest) { r.Audience = "http://api.anthropic.com" }, "invalid federation audience"},
+		{"loopback audience", func(r *FederatedExchangeRequest) { r.Audience = "http://127.0.0.1/t" }, "invalid federation audience"},
+		{"opaque audience", func(r *FederatedExchangeRequest) { r.Audience = "anthropic" }, "invalid federation audience"},
+		{"userinfo audience", func(r *FederatedExchangeRequest) {
+			r.Audience = "https://api.anthropic.com:x@evil.example"
+		}, "invalid federation audience"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := base
+			tc.mutate(&r)
+			_, err := trusted.FederatedCredentialExchange(context.Background(), r)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errSub)
+		})
+	}
+}
+
+func TestValidateFederationAudience(t *testing.T) {
+	ok := []string{
+		"https://api.anthropic.com",
+		"https://api.anthropic.com/v1/oauth/token",
+		"https://sts.googleapis.com",
+	}
+	for _, a := range ok {
+		require.NoError(t, validateFederationAudience(a), a)
+	}
+
+	bad := map[string]string{
+		"empty":            "",
+		"http":             "http://api.anthropic.com",
+		"http loopback":    "http://127.0.0.1:8040/t",
+		"no scheme":        "api.anthropic.com",
+		"opaque":           "anthropic",
+		"no host":          "https:///path",
+		"userinfo spoof":   "https://api.anthropic.com:x@evil.example/h",
+		"userinfo present": "https://user@api.anthropic.com/t",
+		"ftp":              "ftp://api.anthropic.com",
+	}
+	for name, a := range bad {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, validateFederationAudience(a), a)
+		})
+	}
+}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -160,6 +160,12 @@ var reservedClaims = map[string]bool{
 	"user_email": true, "user_name": true,
 	// ZeroID internal claims
 	"act": true, "token_exchange": true, "trusted_by": true, "user_id_iss": true,
+	// `token_use` marks a special-purpose token (today: provider_federation,
+	// which the shared verifier REJECTS for Highflame auth). Only
+	// FederatedCredentialExchange may set it, via the internal CustomClaims
+	// interface — reserving it here keeps a trusted caller from injecting it
+	// through the ungated additional_claims map on any other grant.
+	"token_use": true,
 	// RFC 9449 — cnf.jkt is set only from a validated DPoP proof. Block
 	// callers from injecting it via additional_claims, which would otherwise
 	// let a trusted-service caller mint a token that appears DPoP-bound to

--- a/pkg/authjwt/claims.go
+++ b/pkg/authjwt/claims.go
@@ -15,6 +15,14 @@ import (
 	"github.com/lestrrat-go/jwx/v4/jwt"
 )
 
+// TokenUseProviderFederation marks a token minted by
+// Server.FederatedCredentialExchange (ADR 0028): a provider-audienced assertion
+// handed to an EXTERNAL Workload-Identity-Federation endpoint. It is a valid
+// ZeroID-signed token but MUST NEVER authenticate a caller to Highflame's own
+// services — Verify rejects any token carrying it (see verifier.go). The mint
+// stamps it as the `token_use` claim.
+const TokenUseProviderFederation = "provider_federation"
+
 // Claims represents the verified claims extracted from a ZeroID-issued JWT.
 // Fields align with ZeroID's TokenClaims in domain/token.go.
 type Claims struct {
@@ -25,6 +33,13 @@ type Claims struct {
 	IssuedAt  time.Time `json:"iat"`
 	ExpiresAt time.Time `json:"exp"`
 	JWTID     string    `json:"jti"`
+
+	// TokenUse marks a special-purpose token. Today the only value is
+	// TokenUseProviderFederation; empty for every normal ZeroID token. Verify
+	// fails closed on a federation assertion so it cannot ride Highflame's
+	// tenant-membership auth gates if it leaks from the provider it was minted
+	// for.
+	TokenUse string `json:"token_use,omitempty"`
 
 	// Resource is the RFC 8707 `resource` claim — the resource(s) this token
 	// was bound to AT THE MINT. Non-empty ONLY when ZeroID recorded an explicit
@@ -292,6 +307,7 @@ func extractClaims(token jwt.Token) *Claims {
 	}
 
 	// Tenant
+	c.TokenUse = getString("token_use")
 	c.AccountID = getString("account_id")
 	c.ProjectID = getString("project_id")
 

--- a/pkg/authjwt/verifier.go
+++ b/pkg/authjwt/verifier.go
@@ -184,7 +184,19 @@ func (v *Verifier) verify(ctx context.Context, tokenString string) (*Claims, err
 		return nil, err
 	}
 
-	return extractClaims(token), nil
+	claims := extractClaims(token)
+
+	// A federation assertion (ADR 0028) is minted for an EXTERNAL provider's WIF
+	// endpoint and, by design, handed to that provider. It is a valid
+	// ZeroID-signed token but MUST NEVER authenticate a caller to Highflame's own
+	// services — otherwise a leaked / provider-logged assertion could ride
+	// ZeroID's tenant-membership auth gates. Reject it here, in the shared
+	// verifier every Highflame service uses, so the block holds platform-wide.
+	if claims.TokenUse == TokenUseProviderFederation {
+		return nil, fmt.Errorf("%w: federation assertion is not valid for Highflame authentication", ErrInvalidToken)
+	}
+
+	return claims, nil
 }
 
 // checkAlgorithm parses the JWS header to verify the algorithm is allowed.

--- a/pkg/authjwt/verifier_test.go
+++ b/pkg/authjwt/verifier_test.go
@@ -873,3 +873,35 @@ func assertStatus(t *testing.T, rec *httptest.ResponseRecorder, want int) {
 		t.Fatalf("status = %d, want %d; body: %s", rec.Code, want, rec.Body.String())
 	}
 }
+
+// TestVerify_RejectsFederationAssertion locks the audit-round-1 replay defense
+// (ADR 0028): a provider-audienced federation assertion is a valid ZeroID
+// signature with real tenant claims, but token_use=provider_federation MUST make
+// the shared verifier refuse it for Highflame authentication — otherwise a
+// leaked / provider-logged assertion could ride Highflame's tenant-membership
+// auth gates.
+func TestVerify_RejectsFederationAssertion(t *testing.T) {
+	ks := newTestKeySet(t)
+	issuer := "https://auth.test.com"
+	v := newVerifier(t, ks, issuer)
+
+	c := baseClaims(issuer)
+	c["aud"] = []string{"https://api.anthropic.com"}
+	c["token_use"] = authjwt.TokenUseProviderFederation
+	_, err := v.Verify(context.Background(), ks.signRS256(t, c))
+	if err == nil {
+		t.Fatal("a federation assertion must be rejected for Highflame authentication")
+	}
+	if !errors.Is(err, authjwt.ErrInvalidToken) {
+		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+
+	// A normal token (no token_use) still verifies and reports empty TokenUse.
+	claims, err := v.Verify(context.Background(), ks.signRS256(t, baseClaims(issuer)))
+	if err != nil {
+		t.Fatalf("a normal token must still verify: %v", err)
+	}
+	if claims.TokenUse != "" {
+		t.Fatalf("normal token TokenUse must be empty, got %q", claims.TokenUse)
+	}
+}

--- a/pkg/authjwt/verifier_test.go
+++ b/pkg/authjwt/verifier_test.go
@@ -888,12 +888,21 @@ func TestVerify_RejectsFederationAssertion(t *testing.T) {
 	c := baseClaims(issuer)
 	c["aud"] = []string{"https://api.anthropic.com"}
 	c["token_use"] = authjwt.TokenUseProviderFederation
-	_, err := v.Verify(context.Background(), ks.signRS256(t, c))
+	assertion := ks.signRS256(t, c)
+
+	_, err := v.Verify(context.Background(), assertion)
 	if err == nil {
 		t.Fatal("a federation assertion must be rejected for Highflame authentication")
 	}
 	if !errors.Is(err, authjwt.ErrInvalidToken) {
 		t.Fatalf("want ErrInvalidToken, got %v", err)
+	}
+
+	// VerifyRealTime does local validation (Verify) BEFORE introspection, so it
+	// must reject the assertion too — guards against a future refactor that
+	// drops the local step.
+	if _, rterr := v.VerifyRealTime(context.Background(), assertion); rterr == nil {
+		t.Fatal("VerifyRealTime must also reject a federation assertion")
 	}
 
 	// A normal token (no token_use) still verifies and reports empty TokenUse.

--- a/server.go
+++ b/server.go
@@ -744,6 +744,19 @@ func (s *Server) ExternalPrincipalExchange(ctx context.Context, req GrantRequest
 	})
 }
 
+// FederatedCredentialExchange mints a short-lived, provider-audienced assertion
+// for a Workload-Identity-Federation broker (ADR 0028 / CAP-IDN-023). The
+// caller (an authenticated trusted service, e.g. the AI gateway) has already
+// authenticated the agent and resolved its tenant + WIMSE; ZeroID stamps a
+// free-form provider audience and an `act.sub` = the authenticated broker,
+// returning a token whose `sub` is the agent. Unlike ExternalPrincipalExchange
+// the audience is not a scope profile and the token carries no ZeroID scopes —
+// see service.OAuthService.FederatedCredentialExchange for the security
+// contract and its compensating controls.
+func (s *Server) FederatedCredentialExchange(ctx context.Context, req FederatedExchangeRequest) (*domain.AccessToken, error) {
+	return s.oauthSvc.FederatedCredentialExchange(ctx, req)
+}
+
 // OnClaimsIssue registers a claims enricher called during JWT issuance.
 func (s *Server) OnClaimsIssue(enricher ClaimsEnricher) {
 	s.mu.Lock()

--- a/tests/integration/federation_exchange_test.go
+++ b/tests/integration/federation_exchange_test.go
@@ -1,0 +1,90 @@
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/highflame-ai/zeroid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFederatedCredentialExchange is the mint-level contract for the WIF broker
+// path (ADR 0028 / CAP-IDN-023). Called directly on the Server (authn exposes it
+// behind an internal endpoint, not the /oauth2/token grants), it mints a token
+// whose:
+//   - sub = the acting agent's WIMSE (the principal the provider matches);
+//   - act.sub = the AUTHENTICATED broker name (delegation, not impersonation);
+//   - aud = the free-form provider audience (NOT a scope profile);
+//   - scopes = none (the assertion conveys zero ZeroID authority).
+func TestFederatedCredentialExchange(t *testing.T) {
+	const (
+		agentWIMSE = "spiffe://highflame.io/ns/proj-test-001/agent-x"
+		provider   = "https://api.anthropic.com"
+	)
+	trustedCtx := context.WithValue(context.Background(), trustedServiceCtxKey{}, "firehog")
+
+	t.Run("mints a delegated, provider-audienced, scopeless assertion", func(t *testing.T) {
+		tok, err := testZeroIDServer.FederatedCredentialExchange(trustedCtx, zeroid.FederatedExchangeRequest{
+			AccountID:    testAccountID,
+			ProjectID:    testProjectID,
+			SubjectWIMSE: agentWIMSE,
+			ExternalID:   "agent-x",
+			Audience:     provider,
+		})
+		require.NoError(t, err)
+		claims := decodeJWTPayload(t, tok.AccessToken)
+
+		assert.Equal(t, agentWIMSE, claims["sub"], "sub is the acting agent, never the broker")
+		assert.Equal(t, []string{provider}, audienceOf(t, claims), "aud is the free-form provider audience")
+
+		act, ok := claims["act"].(map[string]any)
+		require.True(t, ok, "act claim must be present (delegation)")
+		assert.Equal(t, "firehog", act["sub"], "act.sub is the AUTHENTICATED broker, not caller-supplied")
+
+		assert.Empty(t, scopesOf(t, claims), "the assertion carries NO ZeroID scopes")
+		assert.Equal(t, "agent-x", claims["external_id"], "external_id recorded for audit correlation")
+		assert.Equal(t, testIssuer, claims["iss"], "iss is the ZeroID issuer the provider trusts")
+		assert.Equal(t, testAccountID, tok.AccountID)
+		assert.Equal(t, testProjectID, tok.ProjectID)
+		assert.LessOrEqual(t, tok.ExpiresIn, 900, "short-lived (<= default 900s)")
+	})
+
+	t.Run("actor is the authenticated service, not spoofable by the request", func(t *testing.T) {
+		// A DIFFERENT trusted service name in the context must surface as act.sub;
+		// the request carries no actor field, so the broker identity can only come
+		// from the authenticated gate.
+		otherCtx := context.WithValue(context.Background(), trustedServiceCtxKey{}, "some-other-service")
+		tok, err := testZeroIDServer.FederatedCredentialExchange(otherCtx, zeroid.FederatedExchangeRequest{
+			AccountID:    testAccountID,
+			ProjectID:    testProjectID,
+			SubjectWIMSE: agentWIMSE,
+			Audience:     provider,
+		})
+		require.NoError(t, err)
+		act := decodeJWTPayload(t, tok.AccessToken)["act"].(map[string]any)
+		assert.Equal(t, "some-other-service", act["sub"])
+	})
+
+	t.Run("untrusted caller is refused (no mint)", func(t *testing.T) {
+		_, err := testZeroIDServer.FederatedCredentialExchange(context.Background(), zeroid.FederatedExchangeRequest{
+			AccountID:    testAccountID,
+			ProjectID:    testProjectID,
+			SubjectWIMSE: agentWIMSE,
+			Audience:     provider,
+		})
+		require.Error(t, err, "no trusted-service context must fail closed")
+	})
+
+	t.Run("TTL is clamped into the federation window", func(t *testing.T) {
+		tok, err := testZeroIDServer.FederatedCredentialExchange(trustedCtx, zeroid.FederatedExchangeRequest{
+			AccountID:    testAccountID,
+			ProjectID:    testProjectID,
+			SubjectWIMSE: agentWIMSE,
+			Audience:     provider,
+			TTLSeconds:   100000, // absurd -> clamped to 3600
+		})
+		require.NoError(t, err)
+		assert.LessOrEqual(t, tok.ExpiresIn, 3600, "TTL clamped to the 3600s ceiling")
+	})
+}

--- a/tests/integration/federation_exchange_test.go
+++ b/tests/integration/federation_exchange_test.go
@@ -43,6 +43,8 @@ func TestFederatedCredentialExchange(t *testing.T) {
 		assert.Equal(t, "firehog", act["sub"], "act.sub is the AUTHENTICATED broker, not caller-supplied")
 
 		assert.Empty(t, scopesOf(t, claims), "the assertion carries NO ZeroID scopes")
+		assert.Equal(t, "provider_federation", claims["token_use"],
+			"token_use marks the assertion so the shared verifier rejects it for Highflame auth (audit round 1)")
 		assert.Equal(t, "agent-x", claims["external_id"], "external_id recorded for audit correlation")
 		assert.Equal(t, testIssuer, claims["iss"], "iss is the ZeroID issuer the provider trusts")
 		assert.Equal(t, testAccountID, tok.AccountID)


### PR DESCRIPTION
Adds `Server.FederatedCredentialExchange` — the ZeroID mint for the federated credential broker ([ADR 0028](https://github.com/highflame-ai/highflame-architecture/blob/main/adrs/0028-federated-credential-broker.md) / CAP-IDN-023). A trusted internal service (the AI gateway / firehog) that has authenticated an agent asks ZeroID to mint a short-lived assertion it can present to an external provider's Workload-Identity-Federation endpoint (e.g. Anthropic WIF).

## What it mints
`sub` = the acting agent's WIMSE · `act.sub` = the **authenticated** broker (from the trusted-service gate, never a caller field) · `aud` = a **free-form** provider audience (bypassing the audience-scope profile gate) · **no ZeroID scopes** · TTL clamped to [60, 3600], default 900.

The free-form audience is the security-sensitive part; compensating controls: trusted-service gate; audience validated as an absolute https URL with a **public** host (no userinfo, no loopback/private IP); and — see below — the token can't authenticate back to Highflame.

## Two audit rounds (folded in)
- **Round 1 (security-reviewer) — CRITICAL:** the "scopeless ⇒ harmless" premise was **false**. The assertion is a valid ZeroID-signed token with tenant claims; since internal verifiers don't check `aud` and tenant-membership routes need no scopes, an assertion (handed to the provider by design) could be **replayed against authn's own routes** (revoke credentials = DoS, read/mint downstream tokens) within its TTL. **Fix:** the mint stamps `token_use=provider_federation`, and the shared `pkg/authjwt` verifier — used by every Highflame Go service — **rejects** that marker. Plus audience loopback/private-IP hardening.
- **Round 2 (adversarial):** verified every `pkg/authjwt` entry point (`Verify`, `VerifyRealTime`, `Middleware`) routes through the reject, and the marker is on the token end-to-end with no const drift. Folded: reserve `token_use` in `reservedClaims` (a trusted caller can't inject the marker via `additional_claims`); `VerifyRealTime`-rejects test. (Firehog's Rust verifier reject is a sibling firehog PR.)

## Files
- `internal/service/federation.go` (new) — `FederatedCredentialExchange` + `validateFederationAudience` + the documented trust boundary.
- `server.go` / `hooks.go` — exported wrapper + public `FederatedExchangeRequest` alias.
- `pkg/authjwt/{claims.go,verifier.go}` — `TokenUseProviderFederation` const, `Claims.TokenUse`, the verifier reject.
- `internal/service/oauth.go` — `token_use` reserved.

## Tests
Unit (trusted-service gate, shape + audience-validation table incl. loopback/private/link-local/userinfo, the validator), integration (the delegated/provider-audienced/scopeless mint against a real store; marker present; actor un-spoofable; untrusted refused; TTL clamp), and `pkg/authjwt` (federation assertion rejected by both `Verify` and `VerifyRealTime`; normal token still verifies). `GOEXPERIMENT=jsonv2 go test ./...` green; `go vet` clean.

## Residual trust boundary (documented, tracked hardenings)
The caller asserts `SubjectWIMSE` + tenant; ZeroID does not re-verify the WIMSE against the identity store (mints for a synthetic identity), bounded by the provider's federation rule. `act.sub` identifies "a holder of the internal secret," not a specific binary. Audience is validated but not allowlisted to known providers. All lower-priority now that the `token_use` marker makes a mis-audienced assertion useless against Highflame's own services.

Consumed by **highflame-authn**'s `/federation/exchange` endpoint (separate PR, pinned to this branch until this merges + tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)