### PR TITLE
feat: release a deleted connector's discovered identities so another can adopt

### DIFF
--- a/internal/handler/identity.go
+++ b/internal/handler/identity.go
@@ -283,6 +283,15 @@ func (a *API) registerIdentityRoutes(api huma.API) {
 		Description: "Scoped to one (origin, source_id): deactivates only still-`discovered` rows last seen before `not_seen_since`. Never touches adopted/active identities, and never another connector's rows. The offboarding half of a connector reconcile.",
 		Tags:        []string{"Identities"},
 	}, a.pruneStaleDiscoveredOp)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "release-discovered-source",
+		Method:      http.MethodPost,
+		Path:        "/identities/discovered/release-source",
+		Summary:     "Unclaim a deleted connector's discovered identities so another can adopt them",
+		Description: "Scoped to one (origin, source_id): clears source_id on still-`discovered` rows so a future connector's reconcile can claim them. Called when a connector is DELETED — otherwise its rows stay bound to a source that never syncs again, and prune (which is source-scoped) can never reach them. Does NOT deactivate: adopt/dismiss remains a human decision. Adopted and dismissed rows keep their source_id as provenance.",
+		Tags:        []string{"Identities"},
+	}, a.releaseDiscoveredSourceOp)
 }
 
 type IdentitySchemaOutput struct {
@@ -873,5 +882,38 @@ func (a *API) pruneStaleDiscoveredOp(ctx context.Context, input *PruneDiscovered
 
 	out := &PruneDiscoveredOutput{}
 	out.Body.Deactivated = n
+	return out, nil
+}
+
+type ReleaseDiscoveredSourceInput struct {
+	Body struct {
+		Origin   string `json:"origin" required:"true" minLength:"1" doc:"External ecosystem the deleted connector enumerated (e.g. okta)"`
+		SourceID string `json:"source_id" required:"true" minLength:"1" doc:"The deleted connector's id — scopes the release to one source"`
+	}
+}
+
+type ReleaseDiscoveredSourceOutput struct {
+	Body struct {
+		Released int `json:"released"`
+	}
+}
+
+func (a *API) releaseDiscoveredSourceOp(ctx context.Context, input *ReleaseDiscoveredSourceInput) (*ReleaseDiscoveredSourceOutput, error) {
+	tenant, err := internalMiddleware.GetTenant(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("missing tenant context")
+	}
+
+	n, err := a.identitySvc.ReleaseDiscoveredSource(ctx, tenant.AccountID, tenant.ProjectID, domain.Origin(input.Body.Origin), input.Body.SourceID)
+	if err != nil {
+		if errors.Is(err, service.ErrInvalidIdentityField) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		log.Error().Err(err).Msg("failed to release discovered source")
+		return nil, huma.Error500InternalServerError("failed to release discovered source")
+	}
+
+	out := &ReleaseDiscoveredSourceOutput{}
+	out.Body.Released = n
 	return out, nil
 }

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -575,6 +575,14 @@ func (s *IdentityService) ReleaseDiscoveredSource(ctx context.Context, accountID
 	if !origin.IsExternal() {
 		return 0, fmt.Errorf("%w: release requires an external origin (got %q)", ErrInvalidIdentityField, origin)
 	}
+	// Shape-check too: IsExternal only rejects "" and "native", so a malformed
+	// value like "Okta" would reach the WHERE clause, match nothing, and return
+	// released=0 — indistinguishable from "there was nothing to release". Reject
+	// it instead, so a caller with a typo'd origin learns that rather than
+	// believing the release succeeded.
+	if !domain.ValidOrigin(string(origin)) {
+		return 0, fmt.Errorf("%w: invalid origin %q: must be a lowercase ecosystem identifier (e.g. okta, entra)", ErrInvalidIdentityField, origin)
+	}
 	if sourceID == "" {
 		return 0, fmt.Errorf("%w: release requires a source_id (a release is always scoped to one discovery source)", ErrInvalidIdentityField)
 	}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -551,6 +551,45 @@ func (s *IdentityService) PruneStaleDiscovered(ctx context.Context, accountID, p
 	return n, nil
 }
 
+// ReleaseDiscoveredSource unclaims every still-`discovered` identity belonging
+// to one discovery source, so a future connector can adopt them. Returns the
+// number released.
+//
+// Called when a connector is DELETED. Reconcile only ever adopts a source_id
+// onto a row that has none (so a live connector can't claim another live
+// connector's rows), which means a deleted connector's rows stay bound to it
+// forever — it never syncs again, and prune is scoped to a single source_id, so
+// no sweep can reach them. They would sit as `discovered` indefinitely, reading
+// as live inventory. Releasing the claim restores them to the adoptable state
+// they had before that connector first saw them.
+//
+// Deliberately NOT a deactivation: these rows are a human's pending
+// adopt/dismiss queue, and a connector being replaced is not a decision about
+// the agents it found. Rows whose agent is genuinely gone from the source stay
+// `discovered` with no owner until dismissed by hand — the same as any other
+// discovered row nobody acts on.
+//
+// Scoped like prune: origin and sourceID are both required, so a release can
+// never unclaim a whole tenant's inventory.
+func (s *IdentityService) ReleaseDiscoveredSource(ctx context.Context, accountID, projectID string, origin domain.Origin, sourceID string) (int, error) {
+	if !origin.IsExternal() {
+		return 0, fmt.Errorf("%w: release requires an external origin (got %q)", ErrInvalidIdentityField, origin)
+	}
+	if sourceID == "" {
+		return 0, fmt.Errorf("%w: release requires a source_id (a release is always scoped to one discovery source)", ErrInvalidIdentityField)
+	}
+	ctx = middleware.SetCallerName(ctx, middleware.SystemCallerPrefix+"discovery_release_source")
+	n, err := s.repo.ReleaseDiscoveredSource(ctx, accountID, projectID, string(origin), sourceID)
+	if err != nil {
+		return 0, fmt.Errorf("release discovered source: %w", err)
+	}
+	if n > 0 {
+		log.Info().Int("count", n).Str("origin", string(origin)).Str("source_id", sourceID).
+			Msg("discovery release: unclaimed discovered identities from a deleted source")
+	}
+	return n, nil
+}
+
 // GetIdentity retrieves an identity by ID.
 func (s *IdentityService) GetIdentity(ctx context.Context, id, accountID, projectID string) (*domain.Identity, error) {
 	return s.repo.GetByID(ctx, id, accountID, projectID)

--- a/internal/store/postgres/identity.go
+++ b/internal/store/postgres/identity.go
@@ -569,6 +569,47 @@ func (r *IdentityRepository) DeactivateStaleDiscovered(ctx context.Context, acco
 	return int(n), nil
 }
 
+// ReleaseDiscoveredSource clears source_id on every still-`discovered` identity
+// belonging to (origin, source_id), returning the number of rows released.
+//
+// Called when a discovery connector is deleted. Reconcile adopts a source_id
+// only onto a row that has none — it never overwrites one, so that a live
+// connector cannot claim another live connector's rows. That guard is right,
+// but it leaves a deleted connector's rows pointing at it forever: the
+// connector never syncs again, and prune is scoped `WHERE source_id = ?`, so
+// nothing can sweep them. Releasing the claim at delete time lets the existing
+// adopt-when-empty branch hand those rows to whichever connector rediscovers
+// them next.
+//
+// Only `discovered` rows are touched. An adopted or dismissed identity keeps
+// its source_id as provenance — it is outside prune scope anyway, so a stale
+// pointer there is a historical record, not a leak.
+func (r *IdentityRepository) ReleaseDiscoveredSource(ctx context.Context, accountID, projectID, origin, sourceID string) (int, error) {
+	db := dbOrTx(ctx, r.db)
+	q := db.NewUpdate().
+		TableExpr("identities").
+		Set("source_id = ?", "").
+		Set("updated_at = ?", time.Now())
+	if callerID := middleware.GetCallerName(ctx); callerID != "" {
+		q = q.Set("modified_by = ?", callerID)
+	}
+	res, err := q.
+		Where("account_id = ?", accountID).
+		Where("project_id = ?", projectID).
+		Where("origin = ?", origin).
+		Where("source_id = ?", sourceID).
+		Where("status = ?", string(domain.IdentityStatusDiscovered)).
+		Exec(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("release discovered source: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("release discovered source rows: %w", err)
+	}
+	return int(n), nil
+}
+
 // ListExpiredActive returns identities whose expires_at has passed while
 // their status is still 'active'. Used by the cleanup worker's identity
 // sweep. The partial index on (expires_at) WHERE status='active' makes

--- a/tests/integration/discovery_lifecycle_test.go
+++ b/tests/integration/discovery_lifecycle_test.go
@@ -710,3 +710,140 @@ func TestDiscovered_PruneRejectsBadTimestamp(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	_ = resp.Body.Close()
 }
+
+// ── Source release on connector delete ──────────────────────────────────────
+
+// releaseDiscoveredSource POSTs /identities/discovered/release-source and
+// returns the decoded body ({released}).
+func releaseDiscoveredSource(t *testing.T, origin, sourceID string) map[string]any {
+	t.Helper()
+	resp := post(t, adminPath("/identities/discovered/release-source"), map[string]any{
+		"origin": origin, "source_id": sourceID,
+	}, adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode, "release source: expected 200")
+	return decode(t, resp)
+}
+
+// TestDiscovered_ReleaseSourceLetsAReplacementConnectorAdopt is the whole point
+// of the endpoint.
+//
+// Reconcile adopts a source_id only onto a row that has none, so that one live
+// connector cannot claim another's rows. The consequence: a DELETED connector's
+// rows stay bound to it forever — it never syncs again, and prune is scoped
+// `WHERE source_id = ?`, so nothing can sweep them. They sit as `discovered`
+// indefinitely, reading as live inventory. Releasing at delete time restores
+// them to adoptable.
+func TestDiscovered_ReleaseSourceLetsAReplacementConnectorAdopt(t *testing.T) {
+	var (
+		ext     = uid("okta-agent")
+		oldConn = uid("connector-old")
+		newConn = uid("connector-new")
+		notSeen = time.Now().Add(time.Hour) // deliberately future-ish for the later assert
+	)
+	_ = notSeen
+
+	// The original connector discovers the agent and claims the row.
+	first := ingestDiscovered(t, map[string]any{
+		"external_id": ext, "origin": "okta", "name": "agent", "source_id": oldConn,
+	})
+	id := first["identity"].(map[string]any)["id"].(string)
+	require.Equal(t, oldConn, first["identity"].(map[string]any)["source_id"])
+
+	// A replacement connector rediscovers the same agent. WITHOUT a release it
+	// cannot take ownership — this is the guard that strands the row.
+	stillOld := ingestDiscovered(t, map[string]any{
+		"external_id": ext, "origin": "okta", "name": "agent", "source_id": newConn,
+	})
+	require.Equal(t, id, stillOld["identity"].(map[string]any)["id"], "must reconcile to the same row")
+	assert.Equal(t, oldConn, stillOld["identity"].(map[string]any)["source_id"],
+		"reconcile must NOT overwrite a live source_id — that guard is what this endpoint works around")
+
+	// Delete-time release unclaims it.
+	out := releaseDiscoveredSource(t, "okta", oldConn)
+	assert.Equal(t, float64(1), out["released"], "the stranded row must be released")
+
+	// Now the replacement's next sync claims it, and the row is back in prune scope.
+	adopted := ingestDiscovered(t, map[string]any{
+		"external_id": ext, "origin": "okta", "name": "agent", "source_id": newConn,
+	})
+	require.Equal(t, id, adopted["identity"].(map[string]any)["id"], "still the same row — no duplicate")
+	assert.Equal(t, newConn, adopted["identity"].(map[string]any)["source_id"],
+		"after release, the replacement connector must be able to adopt the row")
+}
+
+// TestDiscovered_ReleaseSourceIsScopedToItsSource guards the blast radius: a
+// release must never unclaim another connector's rows, or a whole tenant's.
+func TestDiscovered_ReleaseSourceIsScopedToItsSource(t *testing.T) {
+	var (
+		mine     = uid("connector-mine")
+		theirs   = uid("connector-theirs")
+		extMine  = uid("okta-mine")
+		extOther = uid("okta-theirs")
+	)
+
+	ingestDiscovered(t, map[string]any{
+		"external_id": extMine, "origin": "okta", "name": "mine", "source_id": mine,
+	})
+	other := ingestDiscovered(t, map[string]any{
+		"external_id": extOther, "origin": "okta", "name": "theirs", "source_id": theirs,
+	})
+	otherID := other["identity"].(map[string]any)["id"].(string)
+
+	out := releaseDiscoveredSource(t, "okta", mine)
+	assert.Equal(t, float64(1), out["released"], "only this source's row may be released")
+
+	// The other connector's row is untouched — still claimed, still prunable by it.
+	resp := get(t, adminPath("/identities/"+otherID), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	got := decode(t, resp)
+	assert.Equal(t, theirs, got["source_id"],
+		"a release must never unclaim another connector's rows")
+}
+
+// TestDiscovered_ReleaseSourceLeavesAdoptedProvenance: an adopted identity is
+// outside prune scope, so its source_id is history, not a claim. Clearing it
+// would destroy the record of where the identity came from.
+func TestDiscovered_ReleaseSourceLeavesAdoptedProvenance(t *testing.T) {
+	var (
+		ext  = uid("okta-adopted")
+		conn = uid("connector-adopted")
+	)
+
+	created := ingestDiscovered(t, map[string]any{
+		"external_id": ext, "origin": "okta", "name": "adopted agent", "source_id": conn,
+	})
+	id := created["identity"].(map[string]any)["id"].(string)
+
+	adoptResp, err := doRaw(t, http.MethodPost, adminPath("/identities/"+id+"/adopt"), map[string]any{
+		"owner_user_id": "user-adopter",
+	}, adminHeaders())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, adoptResp.StatusCode)
+
+	out := releaseDiscoveredSource(t, "okta", conn)
+	assert.Equal(t, float64(0), out["released"], "an adopted row is not a pending claim and must not be released")
+
+	resp := get(t, adminPath("/identities/"+id), adminHeaders())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	got := decode(t, resp)
+	assert.Equal(t, conn, got["source_id"], "adopted identities keep source_id as provenance")
+}
+
+// TestDiscovered_ReleaseSourceValidation: scoping is mandatory, so a release can
+// never sweep a tenant.
+func TestDiscovered_ReleaseSourceValidation(t *testing.T) {
+	t.Run("native origin rejected", func(t *testing.T) {
+		resp := post(t, adminPath("/identities/discovered/release-source"), map[string]any{
+			"origin": "native", "source_id": uid("c"),
+		}, adminHeaders())
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("missing source_id rejected", func(t *testing.T) {
+		resp := post(t, adminPath("/identities/discovered/release-source"), map[string]any{
+			"origin": "okta",
+		}, adminHeaders())
+		assert.GreaterOrEqual(t, resp.StatusCode, http.StatusBadRequest,
+			"source_id is required — an unscoped release could unclaim a whole tenant")
+	})
+}

--- a/tests/integration/discovery_lifecycle_test.go
+++ b/tests/integration/discovery_lifecycle_test.go
@@ -846,4 +846,17 @@ func TestDiscovered_ReleaseSourceValidation(t *testing.T) {
 		assert.GreaterOrEqual(t, resp.StatusCode, http.StatusBadRequest,
 			"source_id is required — an unscoped release could unclaim a whole tenant")
 	})
+
+	// IsExternal only rejects "" and "native", so a malformed origin would
+	// otherwise reach the WHERE clause, match nothing, and report released=0 —
+	// indistinguishable from "nothing to release". A typo must not read as success.
+	for _, bad := range []string{"Okta", "okta-prod", "OKTA"} {
+		t.Run("malformed origin rejected: "+bad, func(t *testing.T) {
+			resp := post(t, adminPath("/identities/discovered/release-source"), map[string]any{
+				"origin": bad, "source_id": uid("c"),
+			}, adminHeaders())
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+				"a malformed origin must be rejected, not silently released as 0")
+		})
+	}
 }


### PR DESCRIPTION
## The gap

`reconcileDiscovered` adopts a `source_id` only onto a row that has none:

```go
// Never overwrite a non-empty source_id, so one connector can't claim another's row.
if identity.SourceID == "" && req.SourceID != "" { identity.SourceID = req.SourceID }
```

That guard is correct — but it has **no counterpart for a connector that goes away.**

When a discovery connector is deleted, its discovered rows keep pointing at it forever. The connector never syncs again, and `DeactivateStaleDiscovered` is scoped `WHERE source_id = ?`, so **no prune can reach them**. A replacement connector rediscovering the same agents reconciles onto the same rows (dedup is on `external_id`, so no duplicates) but **cannot take ownership**.

Result: the rows sit as `discovered` indefinitely — presenting as live inventory long after the agent is gone from the source, and un-prunable by anything.

## The change

`POST /identities/discovered/release-source` clears `source_id` on the still-`discovered` rows of one `(origin, source_id)`, so the **existing** adopt-when-empty branch hands them to whichever connector rediscovers them next. No change to reconcile itself.

### Deliberate choices

- **A release, not a deactivation.** Those rows are a human's pending adopt/dismiss queue, and replacing a connector isn't a decision about the agents it found. Rows whose agent is genuinely gone stay `discovered` until dismissed by hand — same as any other discovered row nobody acts on.
- **Adopted and dismissed rows are untouched.** They're outside prune scope, so their `source_id` is *provenance*, not a claim; clearing it would destroy the record of where the identity came from.
- **Scoped like prune.** `origin` and `source_id` are both required, so a release can never unclaim a whole tenant's inventory.
- **The live-connector guard is preserved.** Two live connectors still can't steal each other's rows — only an explicit delete-time release unclaims anything.

## Known residual

Release helps rows the replacement **rediscovers**. An agent that vanished from the IdP *before* the connector was replaced ends up with an empty `source_id` and still isn't reachable by a source-scoped prune — it stays `discovered` until dismissed by hand.

That's not a regression (those rows are un-prunable today too, just bound to a ghost connector instead of unbound), and it's strictly better: an unowned row is honestly unowned, and re-adoptable. Fully closing it would mean either sweeping `source_id = ''` rows — which would also catch manually-ingested identities — or deactivating at delete time, which overrides the human's queue. Neither seemed worth it; happy to be argued out of that.

## Tests

Four integration tests against real Postgres:

- **the whole scenario** — original connector claims a row; a replacement reconciles onto it but *cannot* take ownership (asserting the guard that causes the problem); release; the replacement then adopts it, same row, no duplicate
- **scoping** — a release never unclaims another connector's rows
- **provenance** — an adopted identity is not released and keeps its `source_id`
- **validation** — native origin rejected, missing `source_id` rejected

```
gofmt -l .                                # clean
go vet ./...                              # clean
golangci-lint run ./...                   # 0 issues
go test ./... -race                       # green
go test -tags=integration ./tests/...     # green (43s)
```

## Context

Surfaced by an adversarial review of **highflame-ai/highflame-discovery#50**, which makes delete-then-recreate-under-the-same-name a frictionless flow and so makes this reachable in ordinary operation. It predates that PR — it applies to delete-then-recreate under *any* name — but was previously behind enough friction that nobody hit it.

**The discovery-side call at connector delete is a follow-up in that repo**; this PR only adds the capability. Nothing calls the endpoint yet, so merging it changes no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)