### PR TITLE
fix: quickstart hand-rolls the actor assertion the SDK now builds

### DIFF
--- a/examples/zeroid_quickstart.ipynb
+++ b/examples/zeroid_quickstart.ipynb
@@ -622,7 +622,7 @@
    "metadata": {},
    "execution_count": null,
    "outputs": [],
-   "source": "from highflame.zeroid import build_actor_assertion\n\n# Equivalent to the pyjwt.encode cell above: ES256, iss == sub == the WIMSE\n# URI, aud == the issuer. It also adds a `jti` nonce, which the manual version\n# above omits.\nassertion = build_actor_assertion(\n    wimse_uri=tool_agent.wimse_uri,\n    private_key_pem=tool_agent_private_key,\n    audience=issuer_url,\n)\n\n# Or skip both steps. delegate_to() signs the assertion and exchanges it,\n# resolving `aud` from the client's own issuer.\none_call = client.tokens.delegate_to(\n    wimse_uri=tool_agent.wimse_uri,\n    private_key_pem=tool_agent_private_key,\n    scope=\"data:read\",\n    subject_token=orchestrator_token,\n)\n\nprint(f\"assertion built:   {assertion[:40]}...\")\nprint(f\"delegated in one call, scope: {one_call.scope}\")"
+   "source": "from highflame.zeroid import build_actor_assertion\n\n# Equivalent to the pyjwt.encode cell above: ES256, iss == sub == the WIMSE\n# URI, aud == the issuer. It also adds a `jti` nonce, which the manual version\n# above omits.\nassertion = build_actor_assertion(\n    wimse_uri=tool_agent.wimse_uri,\n    private_key_pem=tool_agent_private_key,\n    audience=issuer_url,\n)\n\n# Or skip both steps. delegate_to() signs the assertion and exchanges it,\n# resolving `aud` from the client's own issuer.\none_call = client.tokens.delegate_to(\n    wimse_uri=tool_agent.wimse_uri,\n    private_key_pem=tool_agent_private_key,\n    scope=\"data:read\",\n    subject_token=orchestrator_token,\n    # This client is unauthenticated, so delegate_to cannot read the\n    # issuer off its own token. Pass it — it is the `aud` the assertion\n    # needs, and the discovery cell above already resolved it.\n    audience=issuer_url,\n)\n\nprint(f\"assertion built:   {assertion[:40]}...\")\nprint(f\"delegated in one call, scope: {one_call.scope}\")"
   },
   {
    "cell_type": "markdown",
@@ -715,7 +715,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.tokens.revoke(delegated_token)\n",
+    "# RFC 7009 authenticates the *client*, not the token, so revocation needs\n# the OAuth client credentials from section 3. Without them ZeroID answers\n# invalid_client. To revoke an agent without an OAuth client, use\n# agents.deactivate(), which collapses every token delegated from it.\nclient.tokens.revoke(\n    delegated_token,\n    client_id=oauth_client.client_id,\n    client_secret=client_secret,\n)\n",
     "print(\"Token revocation request sent (RFC 7009 — always returns 200).\")"
    ]
   },

--- a/examples/zeroid_quickstart.ipynb
+++ b/examples/zeroid_quickstart.ipynb
@@ -612,6 +612,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "61cca6a6",
+   "metadata": {},
+   "source": "### The same thing in one call\n\nThe two cells above are what delegation *is* — a self-signed assertion, then an\nRFC 8693 exchange — and they are written out here because this is ZeroID's own\nrepo and the mechanics are the point.\n\nIn your own code you do not need to hand-roll either. `build_actor_assertion()`\nbuilds the assertion, and `delegate_to()` builds it *and* performs the exchange.\n\nThe claim set is exacting — `iss` must be the WIMSE URI exactly, `aud` must be\nthe ZeroID issuer — and the server reports any mistake as an undifferentiated\n`invalid_grant`, so the helpers are worth using."
+  },
+  {
+   "cell_type": "code",
+   "id": "de37091f",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "from highflame.zeroid import build_actor_assertion\n\n# Equivalent to the pyjwt.encode cell above: ES256, iss == sub == the WIMSE\n# URI, aud == the issuer. It also adds a `jti` nonce, which the manual version\n# above omits.\nassertion = build_actor_assertion(\n    wimse_uri=tool_agent.wimse_uri,\n    private_key_pem=tool_agent_private_key,\n    audience=issuer_url,\n)\n\n# Or skip both steps. delegate_to() signs the assertion and exchanges it,\n# resolving `aud` from the client's own issuer.\none_call = client.tokens.delegate_to(\n    wimse_uri=tool_agent.wimse_uri,\n    private_key_pem=tool_agent_private_key,\n    scope=\"data:read\",\n    subject_token=orchestrator_token,\n)\n\nprint(f\"assertion built:   {assertion[:40]}...\")\nprint(f\"delegated in one call, scope: {one_call.scope}\")"
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-s4-claims-md",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## What is stale

Section 4 hand-rolls the RFC 7523 actor assertion with `pyjwt.encode`, then exchanges it with `issue_token_exchange`. Both have had SDK helpers since highflame-sdk#32:

- `build_actor_assertion()` — builds the assertion
- `delegate_to()` — builds it **and** performs the exchange, resolving `aud` from the client's own issuer

## What changed

**The manual cells stay.** This is ZeroID's own repo and section 4 is titled "Agent-to-Agent Delegation (RFC 8693)" — walking through the mechanics is the point there, and replacing them would remove the explanation. This adds the one-call equivalent immediately after, so a reader knows they do not have to hand-roll either in their own code.

Two cells, purely additive.

## Verified the helper is a drop-in

Compared `build_actor_assertion()` output against what the notebook writes by hand, decoding both:

```
alg           build_actor_assertion=ES256    manual=ES256
iss == sub    both the agent's WIMSE URI
aud           issuer as a string; manual uses a list — server accepts both
ttl           120s default (configurable)    manual 300s
extra         adds a `jti` nonce the manual version omits
```

So it is equivalent and slightly better — the nonce guards replay, which the hand-rolled version does not.

The claim set is exacting (`iss` must be the WIMSE URI exactly, `aud` must be the issuer) and the server reports any mistake as an undifferentiated `invalid_grant`. That is what makes hand-rolling it expensive, and worth saying in the notebook.

## Deliberately left alone

`localhost:8899` and the separate `ZeroIDClient` are **correct here**, and I want to be explicit because they look like staleness at a glance:

- This notebook is a walkthrough of a **locally-run ZeroID** — its own prerequisites say "Start ZeroID locally". Pointing it at SaaS would break its premise.
- Using the unified `Highflame` client in the ZeroID service's own repo would be odd; `ZeroIDClient` is the right surface for a notebook about ZeroID.

highflame-sdk#124's audit flagged these patterns, but it was auditing `highflame-sdk/examples/zeroid_quickstart.ipynb` — a different, shorter notebook that was separately rewritten in `332ca15a`. This one covers considerably more (OAuth2 client credentials, introspection and revocation, credential policies, CAE signals) and serves a different purpose.

## Not fixed here, worth flagging

`identities.create` appears twice and works against a local instance in dev mode, but returns `[403] management token not permitted on this route` against SaaS — verified today. Harmless for this notebook's local premise, but a reader who moves to SaaS will hit it. Happy to add a note if you want; left out to keep this change tight. Related: highflame-sdk#138.

## Testing

Not executed — it needs a locally-built ZeroID, which I do not have running. The added cells use the same variables the surrounding cells already define (`tool_agent`, `tool_agent_private_key`, `issuer_url`, `orchestrator_token`), and the helper behaviour is verified above against SaaS. Worth a run by someone with a local instance before merge.

Refs highflame-sdk#124.
