### PR TITLE
fix: key rotation preserves the human in act.sub (#281)

### DIFF
--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -517,7 +518,9 @@ func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, proje
 // apiKeyGrant, ActingUserID: sk.CreatedBy). Rotation changes the secret,
 // not who is accountable, so stamping the rotation subsystem there
 // severed the human→agent audit chain for the rotated credential and
-// every identity delegated from it (#281).
+// every identity delegated from it (#281). See rotationAttribution for
+// which human the new key names, and why it is not the operator who
+// performed the rotation.
 func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID string) (*AgentRegistrationResponse, error) {
 	identity, err := s.identitySvc.GetIdentity(ctx, id, accountID, projectID)
 	if err != nil {
@@ -533,23 +536,7 @@ func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID s
 	// Revoke existing keys.
 	s.revokeKeysByIdentity(ctx, identity.ID)
 
-	// Who the rotated key attributes its tokens to, most specific first:
-	//   1. the caller who asked for the rotation (X-User-ID). Already
-	//      stripped of the reserved system: prefix by TenantContextMiddleware,
-	//      so a caller cannot forge subsystem attribution here.
-	//   2. the identity's registered owner, when the caller is unattributed
-	//      (an internal service relay that sends no X-User-ID).
-	//   3. the system principal, only when no human is known at all — an
-	//      ownerless discovered identity rotated by an unattributed caller.
-	// Case 3 is the honest answer, not a placeholder: nothing in the
-	// request or the row names a human.
-	createdBy := middleware.GetCallerName(ctx)
-	if createdBy == "" {
-		createdBy = identity.OwnerUserID
-	}
-	if createdBy == "" {
-		createdBy = middleware.SystemCallerPrefix + "key_rotation"
-	}
+	createdBy := rotationAttribution(identity, middleware.GetCallerName(ctx))
 
 	// Create new key. ExpiresAt propagates from the identity so the
 	// rotated key inherits the parent's time-bound window.
@@ -725,6 +712,78 @@ func (s *AgentService) getKeyPrefix(ctx context.Context, identityID string) stri
 		return ""
 	}
 	return sk.KeyPrefix
+}
+
+// maxAttributionLen bounds a human identifier written to service_keys.created_by,
+// which is VARCHAR(255) (migrations/006_service_keys.up.sql). RotateKey revokes
+// the outgoing keys BEFORE it creates the replacement, so an over-long value
+// would fail the INSERT and leave the identity with no usable key at all. A
+// caller-supplied header must never be able to reach that state.
+const maxAttributionLen = 255
+
+// usableHuman returns v as an attribution value, or "" when v cannot serve as
+// one. It rejects, rather than repairs, three shapes:
+//
+//   - padded or blank. A padded id matches nothing stored unpadded, so it is a
+//     silent audit break rather than a near-miss. IdentityService.OffboardOwner
+//     rejects the same shape for the same reason.
+//   - the reserved system: prefix, in any case. TenantContextMiddleware already
+//     drops this from X-User-ID, but identity.OwnerUserID and identity.CreatedBy
+//     reach us from columns that no write path filters — POST /agents/register
+//     takes created_by straight from the request body. Filtering at the point of
+//     use covers every source, not just the HTTP header.
+//   - longer than the destination column.
+//
+// Rejecting falls through to the next source in rotationAttribution, so a
+// malformed value degrades attribution instead of failing the rotation.
+func usableHuman(v string) string {
+	if v == "" || strings.TrimSpace(v) != v {
+		return ""
+	}
+	if len(v) > maxAttributionLen {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(v), middleware.SystemCallerPrefix) {
+		return ""
+	}
+	return v
+}
+
+// rotationAttribution picks the human that a rotated API key names in
+// CreatedBy, which the api_key grant copies into the token's act.sub.
+//
+// Precedence, and why the rotation operator is not first:
+//
+//  1. identity.OwnerUserID — the human accountable for what this agent does.
+//     act.sub means "the end user the principal acts on behalf of"
+//     (IssueRequest.ActingUserID), and the key mints tokens for the whole of
+//     its remaining life. An SRE who rotates a key after a leak scare is not
+//     who the agent subsequently acts for, and naming them would leave every
+//     token disagreeing with its own owner_user_id claim — a divergence that
+//     never occurs for a freshly registered agent, where RegisterAgent sets
+//     both from one value.
+//  2. identity.CreatedBy — the same fallback the identity store already uses
+//     to answer "who is the human for this identity"
+//     (COALESCE(NULLIF(owner_user_id, ”), created_by), see the created_by
+//     facet in store/postgres/identity.go). Covers rows predating the
+//     ownership invariant, and deployer-imported rows.
+//  3. callerName — a human performed this rotation and the row names nobody.
+//     Better than a subsystem, and the last human available.
+//  4. The system principal. Nothing names a human, and saying so is the
+//     honest answer.
+//
+// The operator is not lost by ranking them third: RotateKey logs created_by,
+// and identity_audit_logs records the X-User-ID caller separately from the
+// identity's owner (migrations/010_identity_audit_logs.up.sql). Who performed
+// the action and who the credential acts for are different questions, and
+// service_keys.created_by answers only the second.
+func rotationAttribution(identity *domain.Identity, callerName string) string {
+	for _, candidate := range []string{identity.OwnerUserID, identity.CreatedBy, callerName} {
+		if v := usableHuman(candidate); v != "" {
+			return v
+		}
+	}
+	return middleware.SystemCallerPrefix + "key_rotation"
 }
 
 func (s *AgentService) revokeKeysByIdentity(ctx context.Context, identityID string) {

--- a/internal/service/agent.go
+++ b/internal/service/agent.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/middleware"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
 
@@ -510,6 +511,13 @@ func (s *AgentService) DeactivateAgent(ctx context.Context, id, accountID, proje
 // identity's expires_at so a rotated key on a time-bound agent expires
 // alongside its parent — without this, rotation silently extends the
 // key's lifetime past the agent's authority window.
+//
+// The new key also inherits a human in CreatedBy, because the api_key
+// grant copies that field into the token's act.sub (see oauth.go's
+// apiKeyGrant, ActingUserID: sk.CreatedBy). Rotation changes the secret,
+// not who is accountable, so stamping the rotation subsystem there
+// severed the human→agent audit chain for the rotated credential and
+// every identity delegated from it (#281).
 func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID string) (*AgentRegistrationResponse, error) {
 	identity, err := s.identitySvc.GetIdentity(ctx, id, accountID, projectID)
 	if err != nil {
@@ -525,12 +533,30 @@ func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID s
 	// Revoke existing keys.
 	s.revokeKeysByIdentity(ctx, identity.ID)
 
+	// Who the rotated key attributes its tokens to, most specific first:
+	//   1. the caller who asked for the rotation (X-User-ID). Already
+	//      stripped of the reserved system: prefix by TenantContextMiddleware,
+	//      so a caller cannot forge subsystem attribution here.
+	//   2. the identity's registered owner, when the caller is unattributed
+	//      (an internal service relay that sends no X-User-ID).
+	//   3. the system principal, only when no human is known at all — an
+	//      ownerless discovered identity rotated by an unattributed caller.
+	// Case 3 is the honest answer, not a placeholder: nothing in the
+	// request or the row names a human.
+	createdBy := middleware.GetCallerName(ctx)
+	if createdBy == "" {
+		createdBy = identity.OwnerUserID
+	}
+	if createdBy == "" {
+		createdBy = middleware.SystemCallerPrefix + "key_rotation"
+	}
+
 	// Create new key. ExpiresAt propagates from the identity so the
 	// rotated key inherits the parent's time-bound window.
 	skResp, err := s.apiKeySvc.CreateKey(ctx, CreateAPIKeyRequest{
 		AccountID:  identity.AccountID,
 		ProjectID:  identity.ProjectID,
-		CreatedBy:  "system:key_rotation",
+		CreatedBy:  createdBy,
 		Name:       fmt.Sprintf("Agent: %s", identity.Name),
 		IdentityID: identity.ID,
 		ExpiresAt:  identity.ExpiresAt,
@@ -542,6 +568,7 @@ func (s *AgentService) RotateKey(ctx context.Context, id, accountID, projectID s
 	log.Info().
 		Str("external_id", identity.ExternalID).
 		Str("identity_id", identity.ID).
+		Str("created_by", createdBy).
 		Msg("Agent API key rotated")
 
 	return &AgentRegistrationResponse{

--- a/tests/integration/rotate_key_attribution_test.go
+++ b/tests/integration/rotate_key_attribution_test.go
@@ -1,0 +1,108 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// actSub returns the act.sub claim of a token minted from apiKey, or "" when
+// the token carries no act claim at all. act.sub is the human the credential
+// acts for — the first link in the "which human initiated this action" chain.
+func actSub(t *testing.T, apiKey string) string {
+	t.Helper()
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "api_key exchange should succeed")
+	claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+	act, ok := claims["act"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	sub, _ := act["sub"].(string)
+	return sub
+}
+
+// rotate performs POST /agents/registry/{id}/rotate-key with the given extra
+// headers merged over adminHeaders, and returns the new API key.
+func rotate(t *testing.T, agentID string, extra map[string]string) string {
+	t.Helper()
+	headers := adminHeaders()
+	for k, v := range extra {
+		headers[k] = v
+	}
+	resp := post(t, adminPath("/agents/registry/"+agentID+"/rotate-key"), nil, headers)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "rotate-key should succeed")
+	key, ok := decode(t, resp)["api_key"].(string)
+	require.True(t, ok, "rotate-key response should carry api_key")
+	require.NotEmpty(t, key)
+	return key
+}
+
+// TestRotateKeyPreservesHumanAttribution locks in the audit-chain fix for
+// #281. Rotation used to stamp CreatedBy as the literal "system:key_rotation",
+// and the api_key grant copies CreatedBy into act.sub — so every token minted
+// from a rotated key named the rotation subsystem instead of a human. The
+// human→agent link in the delegation chain was lost, silently, on a routine
+// operational action we actively encourage.
+//
+// Rotation changes the secret, not who is accountable. act.sub must keep
+// naming a human across a rotation.
+func TestRotateKeyPreservesHumanAttribution(t *testing.T) {
+	// registerAgent stamps created_by "test-user", which becomes both the
+	// identity's owner_user_id and the bootstrap key's CreatedBy.
+	reg := registerAgent(t, uid("rotate-attribution"))
+
+	before := actSub(t, reg.APIKey)
+	require.Equal(t, "test-user", before,
+		"baseline: an api_key token names the human who created the key")
+
+	// The rotation caller is the better attribution when it is known: this
+	// human performed the action, so name them rather than the registrant.
+	rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": "alice@example.com"})
+	assert.Equal(t, "alice@example.com", actSub(t, rotatedKey),
+		"act.sub should name the human who rotated the key")
+
+	// The regression itself: the subsystem literal must not appear while a
+	// human is knowable.
+	assert.NotEqual(t, "system:key_rotation", actSub(t, rotatedKey),
+		"act.sub must never be the rotation subsystem when a human is known")
+}
+
+// TestRotateKeyFallsBackToIdentityOwner covers the unattributed caller — an
+// internal service relay that rotates without sending X-User-ID. The identity's
+// registered owner is still a human, so act.sub must name them rather than
+// degrade to the subsystem literal.
+func TestRotateKeyFallsBackToIdentityOwner(t *testing.T) {
+	reg := registerAgent(t, uid("rotate-owner-fallback"))
+
+	rotatedKey := rotate(t, reg.AgentID, nil)
+	assert.Equal(t, "test-user", actSub(t, rotatedKey),
+		"with no rotation caller, act.sub should fall back to the identity owner")
+}
+
+// TestRotateKeyRejectsSpoofedSystemCaller checks that the rotation path
+// inherits the audit-spoof guard in TenantContextMiddleware. A caller that
+// submits the reserved system: prefix must not get it reflected into act.sub,
+// or an admin could forge subsystem attribution for their own rotation and
+// make a deliberate action look automated in the audit trail.
+func TestRotateKeyRejectsSpoofedSystemCaller(t *testing.T) {
+	reg := registerAgent(t, uid("rotate-spoof-guard"))
+
+	// Case-folding variants too: a downstream log query that filters with
+	// ILIKE 'system:%' would otherwise read these as worker activity.
+	for _, spoof := range []string{
+		"system:key_rotation",
+		"System:key_rotation",
+		"SYSTEM:expired_sweep",
+	} {
+		rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": spoof})
+		got := actSub(t, rotatedKey)
+		assert.Equal(t, "test-user", got,
+			"spoofed X-User-ID %q must be dropped and fall back to the owner; got %q", spoof, got)
+	}
+}

--- a/tests/integration/rotate_key_attribution_test.go
+++ b/tests/integration/rotate_key_attribution_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -9,8 +10,8 @@ import (
 )
 
 // actSub returns the act.sub claim of a token minted from apiKey, or "" when
-// the token carries no act claim at all. act.sub is the human the credential
-// acts for — the first link in the "which human initiated this action" chain.
+// the token carries no act claim. act.sub is the human the credential acts
+// for — the first link in the "which human initiated this action" chain.
 func actSub(t *testing.T, apiKey string) string {
 	t.Helper()
 	resp := post(t, "/oauth2/token", map[string]any{
@@ -27,8 +28,8 @@ func actSub(t *testing.T, apiKey string) string {
 	return sub
 }
 
-// rotate performs POST /agents/registry/{id}/rotate-key with the given extra
-// headers merged over adminHeaders, and returns the new API key.
+// rotate performs POST /agents/registry/{id}/rotate-key with extra headers
+// merged over adminHeaders, and returns the new API key.
 func rotate(t *testing.T, agentID string, extra map[string]string) string {
 	t.Helper()
 	headers := adminHeaders()
@@ -43,66 +44,180 @@ func rotate(t *testing.T, agentID string, extra map[string]string) string {
 	return key
 }
 
+// setIdentityAttribution writes owner_user_id and created_by directly. Both
+// columns are invariant-protected through the API — registration requires an
+// owner and UpdateIdentity cannot clear one — so the lower-precedence branches
+// of rotationAttribution are only reachable from a deployer-imported or
+// legacy row, which this reproduces.
+func setIdentityAttribution(t *testing.T, identityID, ownerUserID, createdBy string) {
+	t.Helper()
+	_, err := testDB.NewUpdate().
+		Table("identities").
+		Set("owner_user_id = ?", ownerUserID).
+		Set("created_by = ?", createdBy).
+		Where("id = ?", identityID).
+		Exec(context.Background())
+	require.NoError(t, err)
+}
+
 // TestRotateKeyPreservesHumanAttribution locks in the audit-chain fix for
 // #281. Rotation used to stamp CreatedBy as the literal "system:key_rotation",
 // and the api_key grant copies CreatedBy into act.sub — so every token minted
 // from a rotated key named the rotation subsystem instead of a human. The
-// human→agent link in the delegation chain was lost, silently, on a routine
-// operational action we actively encourage.
-//
-// Rotation changes the secret, not who is accountable. act.sub must keep
-// naming a human across a rotation.
+// human→agent link was lost, silently, on a routine operational action.
 func TestRotateKeyPreservesHumanAttribution(t *testing.T) {
-	// registerAgent stamps created_by "test-user", which becomes both the
-	// identity's owner_user_id and the bootstrap key's CreatedBy.
 	reg := registerAgent(t, uid("rotate-attribution"))
-
-	before := actSub(t, reg.APIKey)
-	require.Equal(t, "test-user", before,
-		"baseline: an api_key token names the human who created the key")
-
-	// The rotation caller is the better attribution when it is known: this
-	// human performed the action, so name them rather than the registrant.
-	rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": "alice@example.com"})
-	assert.Equal(t, "alice@example.com", actSub(t, rotatedKey),
-		"act.sub should name the human who rotated the key")
-
-	// The regression itself: the subsystem literal must not appear while a
-	// human is knowable.
-	assert.NotEqual(t, "system:key_rotation", actSub(t, rotatedKey),
-		"act.sub must never be the rotation subsystem when a human is known")
-}
-
-// TestRotateKeyFallsBackToIdentityOwner covers the unattributed caller — an
-// internal service relay that rotates without sending X-User-ID. The identity's
-// registered owner is still a human, so act.sub must name them rather than
-// degrade to the subsystem literal.
-func TestRotateKeyFallsBackToIdentityOwner(t *testing.T) {
-	reg := registerAgent(t, uid("rotate-owner-fallback"))
+	setIdentityAttribution(t, reg.AgentID, "owner-alice", "registrant-carol")
 
 	rotatedKey := rotate(t, reg.AgentID, nil)
-	assert.Equal(t, "test-user", actSub(t, rotatedKey),
-		"with no rotation caller, act.sub should fall back to the identity owner")
+	got := actSub(t, rotatedKey)
+
+	assert.Equal(t, "owner-alice", got,
+		"act.sub should name the identity owner after rotation")
+	assert.NotEqual(t, "system:key_rotation", got,
+		"the regression: act.sub must not be the rotation subsystem when a human is known")
 }
 
-// TestRotateKeyRejectsSpoofedSystemCaller checks that the rotation path
-// inherits the audit-spoof guard in TenantContextMiddleware. A caller that
-// submits the reserved system: prefix must not get it reflected into act.sub,
-// or an admin could forge subsystem attribution for their own rotation and
-// make a deliberate action look automated in the audit trail.
-func TestRotateKeyRejectsSpoofedSystemCaller(t *testing.T) {
-	reg := registerAgent(t, uid("rotate-spoof-guard"))
+// TestRotateKeyPrefersOwnerOverRotationOperator pins the precedence decision.
+// act.sub means "the human this credential acts for", and the rotated key mints
+// tokens for the rest of its life — so it must name the accountable owner, not
+// the on-call operator who happened to rotate the key after a leak scare.
+// Naming the operator would also leave every token disagreeing with its own
+// owner_user_id claim, which never happens for a freshly registered agent.
+//
+// The operator is not lost: RotateKey logs created_by, and identity_audit_logs
+// records the X-User-ID caller separately.
+func TestRotateKeyPrefersOwnerOverRotationOperator(t *testing.T) {
+	reg := registerAgent(t, uid("rotate-owner-wins"))
+	setIdentityAttribution(t, reg.AgentID, "owner-alice", "registrant-carol")
 
-	// Case-folding variants too: a downstream log query that filters with
+	rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": "sre-bob"})
+	assert.Equal(t, "owner-alice", actSub(t, rotatedKey),
+		"the rotation operator must not displace the accountable owner in act.sub")
+}
+
+// TestRotateKeyFallsBackToIdentityCreatedBy covers a row whose owner_user_id is
+// empty but whose created_by still names a human — a row predating the
+// ownership invariant, or one a deployer imported. The identity store already
+// answers "who is the human for this identity" as
+// COALESCE(NULLIF(owner_user_id, ”), created_by); rotation must not stamp the
+// system literal over attribution sitting one column away.
+func TestRotateKeyFallsBackToIdentityCreatedBy(t *testing.T) {
+	reg := registerAgent(t, uid("rotate-createdby-fallback"))
+	setIdentityAttribution(t, reg.AgentID, "", "registrant-carol")
+
+	rotatedKey := rotate(t, reg.AgentID, nil)
+	assert.Equal(t, "registrant-carol", actSub(t, rotatedKey),
+		"with no owner, act.sub should fall back to the identity's created_by")
+}
+
+// TestRotateKeyFallsBackToRotationCaller covers the last human available: the
+// row names nobody, but a human performed the rotation. Naming them beats
+// naming a subsystem.
+func TestRotateKeyFallsBackToRotationCaller(t *testing.T) {
+	reg := registerAgent(t, uid("rotate-caller-fallback"))
+	setIdentityAttribution(t, reg.AgentID, "", "")
+
+	rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": "sre-bob"})
+	assert.Equal(t, "sre-bob", actSub(t, rotatedKey),
+		"with no human on the row, act.sub should name the rotation caller")
+}
+
+// TestRotateKeySystemPrincipalWhenNoHumanKnown pins the exact audit literal for
+// the case where nothing names a human. Operators and log queries that filter
+// with ILIKE 'system:%' depend on the string, and it is assembled by
+// concatenation, so an assertion on the whole value is what pins it.
+func TestRotateKeySystemPrincipalWhenNoHumanKnown(t *testing.T) {
+	reg := registerAgent(t, uid("rotate-no-human"))
+	setIdentityAttribution(t, reg.AgentID, "", "")
+
+	rotatedKey := rotate(t, reg.AgentID, nil)
+	assert.Equal(t, "system:key_rotation", actSub(t, rotatedKey),
+		"with no human anywhere, act.sub should be the system principal verbatim")
+}
+
+// TestRotateKeyRejectsSpoofedSystemCaller checks the audit-spoof guard on every
+// source, not only the HTTP header. TenantContextMiddleware drops a system:
+// prefixed X-User-ID, but owner_user_id and created_by reach rotation from
+// columns no write path filters — POST /agents/register takes created_by
+// straight from the request body. A forged subsystem value from any source must
+// not become act.sub, or a deliberate human action can be made to look
+// automated.
+func TestRotateKeyRejectsSpoofedSystemCaller(t *testing.T) {
+	// Case-folding variants too: a downstream log query filtering with
 	// ILIKE 'system:%' would otherwise read these as worker activity.
-	for _, spoof := range []string{
-		"system:key_rotation",
-		"System:key_rotation",
-		"SYSTEM:expired_sweep",
+	spoofs := []string{"system:key_rotation", "System:key_rotation", "SYSTEM:expired_sweep"}
+
+	t.Run("via X-User-ID header", func(t *testing.T) {
+		reg := registerAgent(t, uid("rotate-spoof-header"))
+		setIdentityAttribution(t, reg.AgentID, "owner-alice", "")
+		for _, spoof := range spoofs {
+			rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": spoof})
+			assert.Equal(t, "owner-alice", actSub(t, rotatedKey),
+				"spoofed X-User-ID %q must not reach act.sub", spoof)
+		}
+	})
+
+	t.Run("via owner_user_id and created_by columns", func(t *testing.T) {
+		for _, spoof := range spoofs {
+			reg := registerAgent(t, uid("rotate-spoof-column"))
+			setIdentityAttribution(t, reg.AgentID, spoof, spoof)
+
+			rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": "sre-bob"})
+			assert.Equal(t, "sre-bob", actSub(t, rotatedKey),
+				"spoofed column value %q must be skipped in favour of a real human", spoof)
+		}
+	})
+}
+
+// TestRotateKeyOversizedCallerDoesNotLockOutAgent guards the foot-gun that
+// rotation revokes the outgoing keys BEFORE it creates the replacement. An
+// over-long X-User-ID would fail the INSERT against service_keys.created_by
+// (VARCHAR(255)) and leave the identity with every key revoked and no
+// replacement — a hard lockout triggered by a header. Before #281 CreatedBy was
+// a fixed 19-character constant, so no caller input could reach that state.
+//
+// The row carries no owner and no created_by, so the caller is the only
+// candidate and the oversized value is genuinely exercised rather than
+// short-circuited by a higher-precedence source.
+func TestRotateKeyOversizedCallerDoesNotLockOutAgent(t *testing.T) {
+	reg := registerAgent(t, uid("rotate-oversized-caller"))
+	setIdentityAttribution(t, reg.AgentID, "", "")
+
+	oversized := make([]byte, 300)
+	for i := range oversized {
+		oversized[i] = 'x'
+	}
+
+	// rotate() requires 200: an unbounded value reaches the INSERT, fails it,
+	// and returns 500 with every key already revoked.
+	rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": string(oversized)})
+	assert.Equal(t, "system:key_rotation", actSub(t, rotatedKey),
+		"an oversized caller must be skipped, leaving the honest system principal")
+}
+
+// TestRotateKeyRejectsMalformedColumnAttribution covers padded and blank
+// attribution on the identity row. A padded id matches nothing stored unpadded,
+// so it is a silent audit break rather than a near-miss — IdentityService.
+// OffboardOwner rejects the same shape for the same reason. These are reachable
+// because POST /agents/register takes created_by straight from the request body
+// with no normalisation.
+//
+// Not covered here: a padded X-User-ID. Go's HTTP layer trims optional
+// whitespace around a header value, so a padded caller never reaches the
+// service in the first place.
+func TestRotateKeyRejectsMalformedColumnAttribution(t *testing.T) {
+	for name, malformed := range map[string]string{
+		"padded":          "owner-alice ",
+		"whitespace only": "   ",
 	} {
-		rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": spoof})
-		got := actSub(t, rotatedKey)
-		assert.Equal(t, "test-user", got,
-			"spoofed X-User-ID %q must be dropped and fall back to the owner; got %q", spoof, got)
+		t.Run(name, func(t *testing.T) {
+			reg := registerAgent(t, uid("rotate-malformed-column"))
+			setIdentityAttribution(t, reg.AgentID, malformed, malformed)
+
+			rotatedKey := rotate(t, reg.AgentID, map[string]string{"X-User-ID": "sre-bob"})
+			assert.Equal(t, "sre-bob", actSub(t, rotatedKey),
+				"malformed column value %q must be skipped in favour of a real human", malformed)
+		})
 	}
 }


### PR DESCRIPTION
Closes #281.

## The bug

`RotateKey` stamped the replacement key's `CreatedBy` as the literal `system:key_rotation`. The api_key grant copies `CreatedBy` straight into the token's `act` claim (`ActingUserID: sk.CreatedBy`), so every token minted from a rotated key named the rotation subsystem where a user id belonged.

That severs the human→agent link in the delegation audit chain, for the rotated credential and for every agent identity delegated from it. The agent→agent links survive rotation intact; only the first one breaks.

Two things make it worse than an ordinary wrong value:

- **It is silent.** Nothing distinguishes "this key was rotated" from "no human was ever involved". An audit months later cannot tell the two apart.
- **It fires on a routine action we actively encourage.** Doing the recommended thing quietly degrades the audit trail.

Rotation changes the secret, not who is accountable.

## The fix

`rotationAttribution` resolves which human the rotated key names:

| | Source | Why here |
|---|---|---|
| 1 | `identity.OwnerUserID` | The human accountable for what the agent does. |
| 2 | `identity.CreatedBy` | The same fallback the identity store uses — `COALESCE(NULLIF(owner_user_id, ''), created_by)`. Covers rows predating the ownership invariant and deployer-imported rows. |
| 3 | The rotation caller, from `X-User-ID` | A human performed this and the row names nobody. Better than a subsystem. |
| 4 | `system:key_rotation` | Nothing names a human, and saying so is the honest answer. |

### Why the rotation operator is not first

`act.sub` means "the end user the principal acts on behalf of", and a rotated key mints tokens for the whole of its remaining life.

Agent `billing-bot` is owned by alice. On-call SRE bob rotates the key after a leak scare. Ranking bob first means that for the next 90 days every token the agent mints carries `act.sub = bob` while the same token carries `owner_user_id = alice`. An audit asking "which human initiated this agent's actions" answers bob for all of alice's agent's work, and the two human claims permanently disagree — a divergence that never occurs for a freshly registered agent, where `RegisterAgent` sets both from one value.

The operator is not lost. `RotateKey` logs `created_by`, and `identity_audit_logs` already records the `X-User-ID` caller separately from the owner. Who performed the action and who the credential acts for are different questions; `service_keys.created_by` answers only the second.

This is issue #281's option 1, which the issue marked recommended. Option 3 — emit the human as a separate claim — already exists: `credential.go:407` emits `owner_user_id`. The gap was specifically `act.sub`, the claim consumers read for the human.

### Every source is filtered, not just the header

`usableHuman` rejects three shapes at the point of use: blank or padded, the reserved `system:` prefix in any case, and longer than the destination column.

`TenantContextMiddleware` filters `system:` from `X-User-ID`, but `owner_user_id` and `created_by` arrive from columns no write path filters — `POST /agents/register` takes `created_by` straight from the request body. Registering with `created_by: "system:expired_sweep"` and then rotating would otherwise produce forged subsystem attribution. Filtering at the point of use covers every source, and holds if a future automatic-rotation worker calls `SetCallerName` with a system value, which deliberately bypasses the middleware filter.

The length bound is not cosmetic. `RotateKey` revokes the outgoing keys **before** creating the replacement, so an `X-User-ID` longer than `service_keys.created_by`'s `VARCHAR(255)` failed the INSERT and returned 500 with every key already revoked and no replacement — a hard lockout from a header. Unreachable before this change, when `CreatedBy` was a fixed 19-character constant. Rejecting rather than repairing means a malformed value degrades attribution instead of failing the rotation.

**Not changed:** the revoke-before-create ordering. Rotating after a leak wants the old key dead immediately, and any `CreateKey` failure leaving the identity keyless is a pre-existing hazard wider than this fix.

## Tests

Seven tests in `tests/integration/rotate_key_attribution_test.go`: owner named after rotation, owner beats the operator, `created_by` fallback, caller fallback, the system literal pinned verbatim, spoof rejection via header **and** via columns, the oversized-header lockout, and padded/blank column values.

Each branch gets a distinct value via `setIdentityAttribution`. The earlier tests could not distinguish the branch they claimed to cover — `registerAgent` posts `created_by: "test-user"`, which becomes `owner_user_id`, `identities.created_by` and the bootstrap key's `created_by` at once, so the assertions passed against four different implementations.

Five mutation checks, all confirmed to fail:

- rank `callerName` first → owner-beats-operator fails
- drop the `system:` filter → the column-spoof subtest fails
- drop the length bound → the lockout test fails on a 500
- drop the trim guard → both malformed-column subtests fail
- drop the `created_by` fallback → that fallback test fails

`go build`, `go vet`, `gofmt` clean. `go test ./...` green across 9 packages.

## Not addressed here

`POST /agents/register` reads `created_by` from the request **body** with no `system:` filter, unlike the header path. This PR makes rotation immune to the resulting forged values, but the column still stores them and other readers still trust it. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)