### PR TITLE
fix: POST /api-keys rejects a request with no identity link (400, not 500)

### DIFF
--- a/internal/handler/apikey.go
+++ b/internal/handler/apikey.go
@@ -20,9 +20,9 @@ type CreateAPIKeyInput struct {
 	Body struct {
 		Name               string          `json:"name" required:"true" minLength:"1" doc:"Human-readable key name"`
 		Description        string          `json:"description,omitempty" doc:"Key description"`
-		IdentityID         string          `json:"identity_id,omitempty" doc:"Optional identity link"`
+		IdentityID         string          `json:"identity_id,omitempty" doc:"Identity to link this key to. Required unless product is supplied"`
 		CredentialPolicyID string          `json:"credential_policy_id,omitempty" doc:"Credential policy to enforce on this key (default: tenant default policy)"`
-		Product            string          `json:"product,omitempty" doc:"Product namespace for key scoping"`
+		Product            string          `json:"product,omitempty" doc:"Product namespace for key scoping. Required unless identity_id is supplied — a service identity is provisioned for the product"`
 		Scopes             []string        `json:"scopes,omitempty" doc:"Allowed scopes"`
 		Environment        string          `json:"environment,omitempty" enum:"live,test" doc:"Environment (default: live)"`
 		ExpiresInDays      *int            `json:"expires_in_days,omitempty" doc:"Expiry in days (nil = never)"`
@@ -133,6 +133,12 @@ func (a *API) createAPIKeyOp(ctx context.Context, input *CreateAPIKeyInput) (*Cr
 		Metadata:           input.Body.Metadata,
 	})
 	if err != nil {
+		// Neither identity_id nor product supplied — the key has no identity to
+		// link. A caller-side omission, so return 400 naming both fields
+		// instead of a 500 from the failed UUID cast at insert time.
+		if errors.Is(err, service.ErrIdentityLinkRequired) {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
 		// Caller-supplied credential_policy_id that doesn't exist in this tenant
 		// is a client error, not a server error — return 400 so the caller can
 		// correct the request.

--- a/internal/service/apikey.go
+++ b/internal/service/apikey.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,6 +17,14 @@ import (
 	"github.com/highflame-ai/zeroid/domain"
 	"github.com/highflame-ai/zeroid/internal/store/postgres"
 )
+
+// ErrIdentityLinkRequired is returned by CreateKey when the caller supplies
+// neither IdentityID nor Product. Every API key links an identity: the caller
+// names one directly, or names a product and EnsureServiceIdentity provisions
+// a service identity for it. With neither there is nothing to link, and the
+// unlinked key would skip credential-policy resolution at grant time. The
+// omission is caller-fixable, so handlers map this to 400.
+var ErrIdentityLinkRequired = errors.New("identity_id or product is required")
 
 // APIKeyService handles CRUD operations for API keys (zid_sk_* keys).
 type APIKeyService struct {
@@ -72,11 +81,20 @@ type CreateAPIKeyResponse struct {
 // Every key is linked to an identity and assigned a credential policy.
 // If IdentityID is empty and Product is set, a service identity is auto-provisioned
 // (or reused if one already exists for this account+project+product).
+// If both are empty the request is rejected with ErrIdentityLinkRequired.
 // If CredentialPolicyID is empty, the tenant's default policy is auto-created and assigned.
 func (s *APIKeyService) CreateKey(ctx context.Context, req CreateAPIKeyRequest) (*CreateAPIKeyResponse, error) {
-	// Ensure every key has an identity link.
-	// When no identity is provided, auto-provision a service identity for the product.
-	if req.IdentityID == "" && req.Product != "" {
+	// Every key has an identity link, and the caller supplies one of the two
+	// ways to establish it. Reject the empty case here rather than letting an
+	// unlinked key reach the insert, where the empty IdentityID fails the
+	// UUID cast and surfaces a caller mistake as a server fault.
+	if req.IdentityID == "" && req.Product == "" {
+		return nil, ErrIdentityLinkRequired
+	}
+
+	// The caller named a product rather than an identity — provision (or
+	// reuse) the service identity that stands for that product.
+	if req.IdentityID == "" {
 		identity, err := s.identitySvc.EnsureServiceIdentity(ctx, req.AccountID, req.ProjectID, req.Product, req.CreatedBy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to ensure service identity for product %s: %w", req.Product, err)

--- a/tests/integration/apikey_test.go
+++ b/tests/integration/apikey_test.go
@@ -143,3 +143,61 @@ func TestCreateAPIKey_CrossTenantCredentialPolicyRejected(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
 		"cross-tenant credential_policy_id must be rejected with 400, not stored on the key")
 }
+
+// TestCreateAPIKey_NoIdentityLinkRejected verifies that POST /api-keys rejects
+// a request that supplies neither identity_id nor product.
+//
+// CreateKey links an identity in one of two ways: the caller names one, or the
+// caller names a product and EnsureServiceIdentity provisions one. With
+// neither, the key has no identity to link. Before the fix bun wrote the empty
+// IdentityID into a UUID column and Postgres raised
+// `invalid input syntax for type uuid: ""`, which the handler surfaced as a
+// 500. The omission is a client error, so the endpoint must answer 400 and
+// name the two fields the caller can supply.
+func TestCreateAPIKey_NoIdentityLinkRejected(t *testing.T) {
+	headers := adminHeaders()
+	headers["X-User-ID"] = "test-user"
+
+	resp := post(t, adminPath("/api-keys"), map[string]any{
+		"name": "no-identity-no-product",
+	}, headers)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"a key with no identity link must be rejected with 400, not 500")
+
+	body := decode(t, resp)
+	detail, _ := body["detail"].(string)
+	assert.Contains(t, detail, "identity_id",
+		"the error must name identity_id so the caller can correct the request")
+	assert.Contains(t, detail, "product",
+		"the error must name product as the other way to link an identity")
+}
+
+// TestCreateAPIKey_IdentityIDOnlyAccepted verifies that the guard above does
+// not over-reject: an explicit identity_id with no product is a complete
+// request and must still create a key.
+func TestCreateAPIKey_IdentityIDOnlyAccepted(t *testing.T) {
+	headers := adminHeaders()
+	headers["X-User-ID"] = "test-user"
+
+	identityResp := post(t, adminPath("/identities"), map[string]any{
+		"external_id":   uid("identity-only-key"),
+		"trust_level":   "unverified",
+		"owner_user_id": "user-test-owner",
+	}, headers)
+	require.Equal(t, http.StatusCreated, identityResp.StatusCode)
+	identityID := decode(t, identityResp)["id"].(string)
+	require.NotEmpty(t, identityID)
+
+	resp := post(t, adminPath("/api-keys"), map[string]any{
+		"name":        "identity-only-key",
+		"identity_id": identityID,
+	}, headers)
+	require.Equal(t, http.StatusCreated, resp.StatusCode,
+		"identity_id alone is a complete request and must create a key")
+
+	keyID := decode(t, resp)["id"].(string)
+	fetched := get(t, adminPath("/api-keys/"+keyID), headers)
+	require.Equal(t, http.StatusOK, fetched.StatusCode)
+	assert.Equal(t, identityID, decode(t, fetched)["identity_id"],
+		"the created key must stay linked to the identity the caller named")
+}


### PR DESCRIPTION
Closes #306

## Summary

- `APIKeyService.CreateKey` now rejects a request that supplies neither `identity_id` nor `product` with a new `ErrIdentityLinkRequired`; the handler maps it to **400** naming both fields.
- Dropped the `"Optional identity link"` wording from the request schema — it no longer describes the contract.
- Added two integration tests: the reproducer from the issue, and a guard that `identity_id` alone still creates a key.

## Root cause

`CreateKey`'s doc comment claims "Every key is linked to an identity", but the code only linked one when `product` was set. With neither field, the empty `IdentityID` reached the insert, bun wrote `''` into the nullable `identity_id UUID` column (the field carries `type:uuid` without `nullzero`), and Postgres raised `invalid input syntax for type uuid: ""`. The handler surfaced a caller-side omission as a 500 and fired 5xx alerting.

## Which option this takes

The issue asks for a product decision. This is **option 2** — unlinked keys are not supported:

- It enforces the invariant `CreateKey` already documents.
- It is the answer consistent with #299, which proposes requiring an identity on every key. Option 1 (`nullzero`) would make the synthetic-identity branch in `resolveAPIKeyContext` reachable again — the branch #299 wants to remove.
- No migration is needed. dev1 and prod hold zero `service_keys` rows with `identity_id IS NULL`.

## Blast radius

| Caller | Effect |
|---|---|
| `RegisterAgent`, key rotation (`internal/service/agent.go`) | None — both set `IdentityID`. |
| highflame-studio, 5 `ServiceKeyTable` / `CreateKeyDialog` call sites | None — each supplies `product` or `identityId`. |
| zeroid `tests/sdk` smoke suite | None — it uses the agent-registration path, not `POST /api-keys`. |
| highflame-sdk `api_keys.create()` (Python and JavaScript) | Pre-existing gap, not a regression. Neither client exposes `product`, and the Python class docstring example `create(name="my-key")` is the exact failing request. It returned 500 before and returns 400 now. Follow-up: add `product` to both clients and fix the docstring. |

## Not in this PR

The broader "every API key links an identity" invariant — including whether it earns a `capabilities.yaml` entry, and the `identity_id NOT NULL` migration — belongs to #299. CAP-IDN-006 already describes service keys as bound to a named product, so this change needs no spec edit.

## Test plan

- [x] `TestCreateAPIKey_NoIdentityLinkRejected` — fails with 500 on `main`, passes with 400 after the fix.
- [x] `TestCreateAPIKey_IdentityIDOnlyAccepted` — guards against over-rejecting.
- [x] `go test ./... -count=1` green, including the full `tests/integration` suite.
- [x] `gofmt` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)