### PR TITLE
fix: heal stored default credential policies that predate the CIBA grant

### DIFF
--- a/migrations/044_default_policy_add_ciba_grant.down.sql
+++ b/migrations/044_default_policy_add_ciba_grant.down.sql
@@ -1,0 +1,10 @@
+-- 044_default_policy_add_ciba_grant.down.sql
+-- Remove the CIBA grant from default policies again. Restores the pre-044
+-- shape for every default row (including fresh rows that were created with
+-- the grant by the Go defaults), which is what a downgrade to a pre-#304
+-- binary expects.
+UPDATE credential_policies
+SET allowed_grant_types = array_remove(allowed_grant_types, 'urn:openid:params:grant-type:ciba'),
+    updated_at = NOW()
+WHERE name = 'default'
+  AND 'urn:openid:params:grant-type:ciba' = ANY(allowed_grant_types);

--- a/migrations/044_default_policy_add_ciba_grant.up.sql
+++ b/migrations/044_default_policy_add_ciba_grant.up.sql
@@ -1,0 +1,20 @@
+-- 044_default_policy_add_ciba_grant.up.sql
+-- Migration 009 backfilled each tenant's `default` credential policy with an
+-- allowed_grant_types list that "must mirror domain.DefaultAllowedGrantTypes()".
+-- PR #304 then added the CIBA grant (urn:openid:params:grant-type:ciba) to
+-- those Go defaults so bound OAuth clients can redeem a human-approved
+-- backchannel request under the default policy — but stored default rows never
+-- self-heal (CredentialPolicyService.EnsureDefaultPolicy returns the existing
+-- row untouched), so every deployment that upgraded across #304 kept a default
+-- policy without the grant and saw bound-client CIBA redemption refused with
+-- access_denied. Only fresh databases got the new default.
+--
+-- Append the grant to every default policy that lacks it. Scoped to
+-- name = 'default' (domain.DefaultPolicyName): tenant-authored policies are
+-- deliberate allow-lists and are left alone. Idempotent — re-running is a
+-- no-op once the grant is present.
+UPDATE credential_policies
+SET allowed_grant_types = array_append(allowed_grant_types, 'urn:openid:params:grant-type:ciba'),
+    updated_at = NOW()
+WHERE name = 'default'
+  AND NOT ('urn:openid:params:grant-type:ciba' = ANY(allowed_grant_types));


### PR DESCRIPTION
## Summary

Data migration for an upgrade gap surfaced while reviewing #317: tenant **default** credential policies are created once (migration 009 backfill, or `EnsureDefaultPolicy` on first use) and never self-heal. PR #304 added the CIBA grant to `domain.DefaultAllowedGrantTypes()`, so fresh databases got it — but every deployment that upgraded across #304 kept a default policy without it, and bound-client CIBA redemption fails with `access_denied`. Until now the only documented remedy was `docker compose down -v` in an examples README.

**Migration 044** appends `urn:openid:params:grant-type:ciba` to every `name = 'default'` policy that lacks it. Tenant-authored policies are deliberate allow-lists and are left alone. Idempotent; the down migration removes the grant again.

## Verification

Against a live Postgres with two tenants' default rows, after stripping the grant to simulate a pre-#304 volume:

```
UP           → UPDATE 2   (grant appended)
UP again     → UPDATE 0   (idempotent)
DOWN         → UPDATE 2   (grant removed)
UP (restore) → UPDATE 2
custom rows touched: 0
```

Full integration suite (680 tests, `-race`) passes with the migration embedded.

## Related

#317's `examples/odis/README.md` now points here instead of prescribing volume destruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)