### PR TITLE
fix: skill example documented the deprecated `subject` parameter

### DIFF
--- a/examples/claude-skill/SKILL.md
+++ b/examples/claude-skill/SKILL.md
@@ -92,7 +92,9 @@ Request body fields:
    - `scope` -- requested scopes
 
 3. **`urn:ietf:params:oauth:grant-type:jwt-bearer`** -- agent presents a signed JWT assertion
-   - `subject` -- the signed JWT assertion
+   - `assertion` -- the signed JWT assertion (RFC 7523 §2.1)
+   - `subject` -- DEPRECATED alias for `assertion`; still accepted, but new
+     callers should send `assertion`
    - `scope` -- requested scopes
 
 4. **`urn:ietf:params:oauth:grant-type:token-exchange`** -- RFC 8693 delegation (see Delegate section below)


### PR DESCRIPTION
## Why this is worth a look before the release

#323 made ZeroID accept the RFC 7523 §2.1 `assertion` parameter, but `examples/claude-skill/SKILL.md:95` still tells readers the jwt-bearer grant takes the assertion in `subject`.

This doc **ships inside the library**. Released as-is, it goes out teaching new integrators the exact non-conformant spelling #323 exists to move them off — the same failure mode as the service-layer error message that Oracle caught mid-review.

Found by sweeping ZeroID's own docs for stale references after #323 merged. It's the only hit; the rest of `docs/` and `README.md` are clean.

## What changed

```diff
 3. **`urn:ietf:params:oauth:grant-type:jwt-bearer`** -- agent presents a signed JWT assertion
-   - `subject` -- the signed JWT assertion
+   - `assertion` -- the signed JWT assertion (RFC 7523 §2.1)
+   - `subject` -- DEPRECATED alias for `assertion`; still accepted, but new
+     callers should send `assertion`
    - `scope` -- requested scopes
```

Documents both, because both work — consistent with the OpenAPI schema (`subject` carries `deprecated: true`) and with the required-parameter error, which names `assertion` only.

Docs-only; no code, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)