### PR TITLE
feat: RFC 8707 resource request parameter on the token endpoint (CAP-IDN-026)

### DIFF
--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -94,7 +94,23 @@ type TokenInput struct {
 		// resource(s) the minted token is bound to (CAP-IDN-026). Accepts a
 		// single URI string or an array of them; a form-encoded request may
 		// repeat the parameter. Mutually exclusive with Audience.
-		Resource resourceParam `json:"resource,omitempty" doc:"RFC 8707 resource indicator(s) to bind the token to — absolute URI(s), no fragment"`
+		//
+		// THE TOKEN REQUEST IS THE ONLY PLACE A BINDING IS ESTABLISHED.
+		// /oauth2/authorize accepts and ignores `resource` (RFC 6749 §3.1's
+		// ignore-unrecognized posture), and the binding is not carried on the
+		// authorization code — so a client that sends it only at the
+		// authorization request receives an UNBOUND token, with no error at any
+		// step. The MCP authorization profile requires `resource` on both the
+		// authorization and the token request, so a conformant MCP client is
+		// bound correctly; a client following RFC 8707 §2 alone, which permits
+		// the token request to rely on the code's binding, is not.
+		// Tracked for a follow-up that persists the authorized set on the code
+		// row and cross-checks it at redemption.
+		//
+		// Note also that a request carrying `resource` is issued NO refresh
+		// token: the binding is not carried across rotation, so a refresh would
+		// silently unbind the token.
+		Resource resourceParam `json:"resource,omitempty" doc:"RFC 8707 resource indicator(s) to bind the token to — absolute URI(s), no fragment. Must be sent on THIS request: /oauth2/authorize ignores it and the binding is not carried on the authorization code. A resource-bound request receives no refresh_token."`
 		// authorization_code grant fields:
 		Code         string `json:"code,omitempty" doc:"Authorization code JWT"`
 		CodeVerifier string `json:"code_verifier,omitempty" doc:"PKCE S256 code verifier"`

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -89,6 +90,11 @@ type TokenInput struct {
 		// external principal can self-rotate its session at /oauth2/token. Honoured
 		// only on that path AND only for a profiled Audience; ignored otherwise.
 		IssueRefreshToken bool `json:"issue_refresh_token,omitempty" doc:"Also mint a rotating refresh token (trusted external-principal exchange with a profiled audience only)"`
+		// Resource is the RFC 8707 §2 resource indicator: the protected
+		// resource(s) the minted token is bound to (CAP-IDN-026). Accepts a
+		// single URI string or an array of them; a form-encoded request may
+		// repeat the parameter. Mutually exclusive with Audience.
+		Resource resourceParam `json:"resource,omitempty" doc:"RFC 8707 resource indicator(s) to bind the token to — absolute URI(s), no fragment"`
 		// authorization_code grant fields:
 		Code         string `json:"code,omitempty" doc:"Authorization code JWT"`
 		CodeVerifier string `json:"code_verifier,omitempty" doc:"PKCE S256 code verifier"`
@@ -100,6 +106,68 @@ type TokenInput struct {
 		// RFC 6749 §3.1: the server MUST ignore unrecognized request
 		// parameters rather than rejecting the request outright.
 		_ struct{} `additionalProperties:"true"`
+	}
+}
+
+// resourceParam binds the RFC 8707 `resource` request parameter, which §2
+// defines as repeatable — "the parameter can be included multiple times to
+// indicate multiple resources". That shape has three encodings on the wire and
+// all three must land as the same []string:
+//
+//   - JSON array:  {"resource": ["https://a", "https://b"]}
+//   - JSON string: {"resource": "https://a"}          — the single-resource case
+//   - form body:   resource=https://a&resource=https://b
+//
+// The form case is normalized to a JSON array upstream by
+// oauthFormCompatMiddleware (see repeatableFormFields in server.go); a
+// single-occurrence form parameter still arrives here as a bare string, which is
+// why the string case is not merely a convenience.
+//
+// A JSON `null` binds to nil (parameter absent) rather than erroring: RFC 6749
+// §3.1 tells the server to ignore unrecognized/empty parameters, and a client
+// that serializes an unset optional field as null means "not supplied".
+type resourceParam []string
+
+// UnmarshalJSON accepts either a string or an array of strings. Anything else
+// (number, object, bool) is a client error surfaced by Huma as a 422 binding
+// failure — deliberately not coerced, since a caller sending the wrong type for
+// a security-relevant parameter should be told, not guessed at.
+func (r *resourceParam) UnmarshalJSON(b []byte) error {
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "null" {
+		*r = nil
+		return nil
+	}
+	if strings.HasPrefix(trimmed, "[") {
+		var many []string
+		if err := json.Unmarshal(b, &many); err != nil {
+			return fmt.Errorf("resource must be a URI string or an array of URI strings: %w", err)
+		}
+		*r = many
+		return nil
+	}
+	var one string
+	if err := json.Unmarshal(b, &one); err != nil {
+		return fmt.Errorf("resource must be a URI string or an array of URI strings: %w", err)
+	}
+	*r = []string{one}
+	return nil
+}
+
+// Schema advertises the union shape in the OpenAPI document so generated
+// clients and the interop testers reading our spec see that both encodings are
+// accepted. Without this, Huma would infer a plain array from the underlying
+// []string and the string form would look unsupported.
+func (resourceParam) Schema(huma.Registry) *huma.Schema {
+	uri := &huma.Schema{Type: "string", Format: "uri"}
+	return &huma.Schema{
+		Description: "RFC 8707 resource indicator(s): absolute URI(s) identifying the " +
+			"protected resource the token is bound to. A single URI or an array; " +
+			"form-encoded requests may repeat the parameter.",
+		OneOf: []*huma.Schema{
+			uri,
+			{Type: "array", Items: uri},
+		},
 	}
 }
 
@@ -562,6 +630,7 @@ func (a *API) tokenOp(ctx context.Context, input *TokenInput) (*TokenOutput, err
 		PrivilegeScope:    input.Body.PrivilegeScope,
 		Audience:          input.Body.Audience,
 		IssueRefreshToken: input.Body.IssueRefreshToken,
+		Resource:          []string(input.Body.Resource),
 		Code:              input.Body.Code,
 		CodeVerifier:      input.Body.CodeVerifier,
 		RedirectURI:       input.Body.RedirectURI,

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -175,7 +175,22 @@ func (r *resourceParam) UnmarshalJSON(b []byte) error {
 // accepted. Without this, Huma would infer a plain array from the underlying
 // []string and the string form would look unsupported.
 func (resourceParam) Schema(huma.Registry) *huma.Schema {
-	uri := &huma.Schema{Type: "string", Format: "uri"}
+	// Deliberately `type: string` with NO `format: uri`.
+	//
+	// huma validates formats at bind time, not only in the document, so a
+	// `format: uri` here would reject a malformed value with a binder 422 and a
+	// {"title":"Unprocessable Entity"} body. RFC 6749 §5.2 requires the token
+	// endpoint to answer with an error object — {"error":"invalid_target",…} —
+	// and an interop tester probing error handling reads the body, not just the
+	// status. It also made validateResourceIndicators' own parse-error branch
+	// unreachable over HTTP: two validators, one of them dead, disagreeing about
+	// the response shape.
+	//
+	// So the service is the single authority on what a resource indicator may
+	// be, and the schema documents the shape (string or array of strings)
+	// without enforcing the grammar. The RFC 8707 §2 rules — absolute URI, no
+	// fragment, no userinfo — live in one place and answer in one shape.
+	uri := &huma.Schema{Type: "string"}
 	return &huma.Schema{
 		Description: "RFC 8707 resource indicator(s): absolute URI(s) identifying the " +
 			"protected resource the token is bound to. A single URI or an array; " +

--- a/internal/handler/resource_param_test.go
+++ b/internal/handler/resource_param_test.go
@@ -1,0 +1,84 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestResourceParamUnmarshal pins the three wire encodings RFC 8707 §2 implies.
+// The single-string case is the one that matters most in practice: it is what a
+// form-encoded request with one `resource` parameter becomes, and what the MCP
+// interop harness sends.
+func TestResourceParamUnmarshal(t *testing.T) {
+	type body struct {
+		Resource resourceParam `json:"resource,omitempty"`
+	}
+
+	t.Run("bare string binds to a one-element slice", func(t *testing.T) {
+		var b body
+		if err := json.Unmarshal([]byte(`{"resource":"https://gw.example/mcp/github"}`), &b); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(b.Resource) != 1 || b.Resource[0] != "https://gw.example/mcp/github" {
+			t.Fatalf("got %#v", b.Resource)
+		}
+	})
+
+	t.Run("array binds in order", func(t *testing.T) {
+		var b body
+		if err := json.Unmarshal([]byte(`{"resource":["https://a.example","https://b.example"]}`), &b); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(b.Resource) != 2 || b.Resource[0] != "https://a.example" || b.Resource[1] != "https://b.example" {
+			t.Fatalf("got %#v", b.Resource)
+		}
+	})
+
+	t.Run("absent parameter leaves nil", func(t *testing.T) {
+		var b body
+		if err := json.Unmarshal([]byte(`{}`), &b); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if b.Resource != nil {
+			t.Fatalf("expected nil, got %#v", b.Resource)
+		}
+	})
+
+	t.Run("null binds to nil, not an error", func(t *testing.T) {
+		var b body
+		if err := json.Unmarshal([]byte(`{"resource":null}`), &b); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if b.Resource != nil {
+			t.Fatalf("expected nil, got %#v", b.Resource)
+		}
+	})
+
+	t.Run("empty array binds to an empty slice", func(t *testing.T) {
+		// Distinct from absent at this layer; the service treats both as "no
+		// binding requested", but the binder must not error.
+		var b body
+		if err := json.Unmarshal([]byte(`{"resource":[]}`), &b); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(b.Resource) != 0 {
+			t.Fatalf("expected empty, got %#v", b.Resource)
+		}
+	})
+
+	rejects := map[string]string{
+		"number":           `{"resource":42}`,
+		"object":           `{"resource":{"uri":"https://a.example"}}`,
+		"bool":             `{"resource":true}`,
+		"array of numbers": `{"resource":[1,2]}`,
+		"mixed array":      `{"resource":["https://a.example",7]}`,
+	}
+	for name, payload := range rejects {
+		t.Run("rejects "+name, func(t *testing.T) {
+			var b body
+			if err := json.Unmarshal([]byte(payload), &b); err == nil {
+				t.Fatalf("expected a binding error, got %#v", b.Resource)
+			}
+		})
+	}
+}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -697,6 +697,18 @@ func (s *OAuthService) jwtBearer(ctx context.Context, req TokenRequest) (*domain
 		return s.idJAGBearer(ctx, req)
 	}
 
+	// `resource` is honoured on the ID-JAG profile only, where it narrows the
+	// set the corporate IdP authorized. The NHI self-signed path has no such
+	// authorized set — the assertion proves possession of a registered key and
+	// says nothing about which resources the agent may reach — so there is
+	// nothing to narrow against and binding would be an unreviewed grant of
+	// exactly the kind CAP-IDN-026 avoids by only ever narrowing. Reject rather
+	// than ignore: the grant type is marked as supporting `resource`, so without
+	// this the parameter would be silently dropped here.
+	if err := rejectUnsupportedResource(req, "self-signed jwt-bearer (RFC 7523)"); err != nil {
+		return nil, err
+	}
+
 	// Reject alg=none / HS* before any further work — JWT-SVID §3.
 	if err := jwtalg.Validate(req.Assertion); err != nil {
 		return nil, oauthBadRequestCause(oautherror.InvalidGrant, "assertion JWT uses an unsupported algorithm", err)

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -518,6 +518,24 @@ type TokenRequest struct {
 	// exchange AND ONLY for a profiled Audience (the refresh grant re-stamps that
 	// `aud`/scope profile on every rotation). Ignored when Audience is empty.
 	IssueRefreshToken bool
+	// Resource carries the RFC 8707 `resource` request parameter — the protected
+	// resource(s) the minted token is being bound to (CAP-IDN-026). A single
+	// value or several; the wire accepts a bare string or an array, and a
+	// form-encoded request may repeat the parameter (RFC 8707 §2).
+	//
+	// It only ever NARROWS. The values are stamped as the token's `aud` AND as
+	// the reserved `resource` claim that Shield enforces INV-IDN-006 on, and
+	// grant no authority the grant did not already carry — which is why an
+	// arbitrary caller-supplied identifier is safe to accept without a registry
+	// of known resource servers.
+	//
+	// Mutually exclusive with Audience: that names a server-defined scope profile
+	// (it widens), this names a resource (it narrows). Both on one request is
+	// `invalid_request` — see checkResourceAudienceExclusive.
+	//
+	// Validated once in Token() before dispatch, so every grant sees a list that
+	// is already syntax-checked and de-duplicated.
+	Resource []string
 	// authorization_code grant fields:
 	Code         string // HS256 auth code JWT
 	CodeVerifier string // PKCE S256 code verifier
@@ -537,6 +555,25 @@ type TokenRequest struct {
 
 // Token handles the /oauth2/token endpoint dispatch.
 func (s *OAuthService) Token(ctx context.Context, req TokenRequest) (*domain.AccessToken, error) {
+	// RFC 8707 resource indicators (CAP-IDN-026). Resolved here, once, BEFORE
+	// grant dispatch so every grant — including custom ones registered via
+	// RegisterGrant — sees the same validated list and no grant can forget the
+	// exclusivity rule. Order matters: the audience/resource conflict is a
+	// malformed REQUEST (invalid_request) and is reported as such even when the
+	// resource values would also have failed validation, so a caller that made
+	// both mistakes is told about the structural one first.
+	if err := checkResourceAudienceExclusive(req); err != nil {
+		return nil, err
+	}
+	validatedResources, err := validateResourceIndicators(req.Resource)
+	if err != nil {
+		return nil, err
+	}
+	req.Resource = validatedResources
+	if len(req.Resource) > 0 && !grantSupportsResource(req.GrantType) {
+		return nil, rejectUnsupportedResource(req, req.GrantType)
+	}
+
 	switch req.GrantType {
 	case "client_credentials":
 		return s.clientCredentials(ctx, req)

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -663,13 +663,16 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 		return nil, oauthServerError("failed to resolve identity credential policy", err)
 	}
 
-	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+	issue := IssueRequest{
 		Identity:          identity,
 		IdentityPolicyID:  policy.ID,
 		Scopes:            scopes,
 		GrantType:         domain.GrantTypeClientCredentials,
 		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
-	})
+	}
+	bindResourceOnIssue(&issue, req.Resource)
+
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, issue)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1005,7 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 	// child that survives the parent's expiry — and once the parent row
 	// expires, the cascade-revocation walk can no longer reach the child
 	// (the traversal anchors on live ancestry).
-	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+	issue := IssueRequest{
 		Identity:            actorIdentity,
 		IdentityPolicyID:    actorPolicy.ID,
 		Scopes:              scopes,
@@ -1013,7 +1016,10 @@ func (s *OAuthService) tokenExchange(ctx context.Context, req TokenRequest) (*do
 		MissionID:           missionID,
 		DPoPKeyThumbprint:   req.DPoPKeyThumbprint,
 		CredentialExpiresAt: &subjectCred.ExpiresAt,
-	})
+	}
+	bindResourceOnIssue(&issue, req.Resource)
+
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, issue)
 	if err != nil {
 		return nil, err
 	}
@@ -1179,7 +1185,7 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 		audience = []string{req.Audience}
 	}
 
-	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+	issue := IssueRequest{
 		Identity:          identity,
 		IdentityPolicyID:  identityPolicyID,
 		GrantType:         domain.GrantTypeTokenExchange,
@@ -1193,7 +1199,16 @@ func (s *OAuthService) ExternalPrincipalExchange(ctx context.Context, req TokenR
 		TTL:               externalPrincipalAccessTokenTTL, // 15 minutes — short-lived for external principals
 		CustomClaims:      customClaims,
 		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
-	})
+	}
+	// The external-principal exchange binds too. It cannot collide with the
+	// audience profile above — `audience` and `resource` are mutually exclusive
+	// at the Token() gate, so exactly one of them is ever non-empty here. That
+	// exclusivity also means the refresh token in step 6 is unreachable for a
+	// bound request (it is gated on a profiled audience), which is why this path
+	// needs no separate refresh suppression.
+	bindResourceOnIssue(&issue, req.Resource)
+
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, issue)
 	if err != nil {
 		return nil, oauthServerError("failed to issue external principal token", err)
 	}
@@ -1446,7 +1461,7 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 		scopes = intersectScopes(scopes, identity.AllowedScopes)
 	}
 
-	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+	issue := IssueRequest{
 		Identity:           identity,
 		IdentityPolicyID:   identityPolicyID,
 		CredentialPolicyID: sk.CredentialPolicyID,
@@ -1461,7 +1476,10 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 		// must never mint a 30-day token even if the identity policy allows.
 		CredentialExpiresAt: sk.ExpiresAt,
 		DPoPKeyThumbprint:   req.DPoPKeyThumbprint,
-	})
+	}
+	bindResourceOnIssue(&issue, req.Resource)
+
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, issue)
 	if err != nil {
 		return nil, err
 	}
@@ -2050,7 +2068,7 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 		identityPolicyID = policy.ID
 	}
 
-	accessToken, cred, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+	issue := IssueRequest{
 		Identity:          identity,
 		IdentityPolicyID:  identityPolicyID,
 		GrantType:         domain.GrantTypeAuthorizationCode,
@@ -2060,7 +2078,10 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 		TTL:               ttl,
 		Scopes:            authCode.Scopes,
 		DPoPKeyThumbprint: req.DPoPKeyThumbprint,
-	})
+	}
+	bindResourceOnIssue(&issue, req.Resource)
+
+	accessToken, cred, err := s.credentialSvc.IssueCredential(ctx, issue)
 	if err != nil {
 		return nil, err
 	}
@@ -2071,8 +2092,35 @@ func (s *OAuthService) authorizationCode(ctx context.Context, req TokenRequest) 
 
 	var refreshFamilyID string
 
+	// A resource-bound access token is issued WITHOUT a refresh token, even for
+	// a client registered for the refresh_token grant (CAP-IDN-026).
+	//
+	// The refresh path re-mints from state carried on the refresh-token row —
+	// scopes, mission, the audience-profile name — and the RFC 8707 binding is
+	// not among them: it lives in CustomClaims, which rotation does not carry.
+	// So a rotated token would come back UNBOUND, silently. Bind to server X,
+	// refresh, use anywhere — no error at any step, and INV-IDN-006 enforcement
+	// goes quiet because the discriminator claim is simply gone.
+	//
+	// Suppressing is the fail-closed answer and needs no schema change. It also
+	// matches what the binding is for: an RFC 8707 binding is a narrow, short-
+	// lived grant for one resource, and long-lived continuity for a deliberately
+	// narrow credential is a smell. A client that wants a fresh bound token asks
+	// for one — that is a new authorization decision, which is the right shape.
+	//
+	// Carrying the binding on the refresh row instead (a `resource` column,
+	// mirroring migration 039's `audience`) is the alternative if long-lived
+	// resource-bound sessions ever have a real use case.
+	resourceBound := len(req.Resource) > 0
+	if resourceBound && hasRefreshGrant {
+		log.Info().
+			Str("client_id", req.ClientID).
+			Strs("resource", req.Resource).
+			Msg("resource-bound authorization_code exchange: refresh token suppressed (binding is not carried across rotation)")
+	}
+
 	// Issue refresh token when the client is registered for the refresh_token grant.
-	if hasRefreshGrant && s.refreshTokenSvc != nil {
+	if hasRefreshGrant && !resourceBound && s.refreshTokenSvc != nil {
 		rtResult, rtErr := s.refreshTokenSvc.IssueRefreshToken(ctx, &RefreshTokenParams{
 			ClientID:          req.ClientID,
 			AccountID:         authCode.AccountID,

--- a/internal/service/oauth_external_idp.go
+++ b/internal/service/oauth_external_idp.go
@@ -153,7 +153,18 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 	// deployer asked for them and (b) the upstream actually set them.
 	// We never default-fill — RFC 9068 authentication-context claims are
 	// only meaningful when they reflect the IdP's authentication event.
+	//
+	// reservedClaims is enforced here too, not just on the AdditionalClaims loop
+	// below. Config restricts propagate_claims to auth_time/acr/amr today
+	// (domain.ExternalIssuerConfig.Validate), so nothing reserved can reach this
+	// loop — but that is a guarantee held one file away, and `resource` in
+	// particular is only a trustworthy signal while bindResourceOnIssue is its
+	// sole writer. A deployer-controlled list that can name claims must not be
+	// the one place that could quietly become an exception.
 	for _, claim := range cfg.PropagateClaims {
+		if reservedClaims[claim] {
+			continue
+		}
 		if v, present := rawClaims[claim]; present {
 			customClaims[claim] = v
 		}
@@ -182,7 +193,7 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 	}
 
 	scopes := parseScopeString(req.Scope)
-	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
+	issue := IssueRequest{
 		Identity:         identity,
 		IdentityPolicyID: identityPolicyID,
 		// Govern the synthetic-carrier path (no application_id, so no identity
@@ -204,7 +215,24 @@ func (s *OAuthService) externalIDTokenExchange(ctx context.Context, req TokenReq
 		TTL:                   900, // 15 minutes — same short-lived posture as the broker path
 		CustomClaims:          customClaims,
 		DPoPKeyThumbprint:     req.DPoPKeyThumbprint,
-	})
+	}
+	// RFC 8707 resource binding (CAP-IDN-026). token-exchange forks THREE ways —
+	// this id_token federation path, the trusted external-principal exchange, and
+	// NHI delegation — and the grant type as a whole is in
+	// resourceSupportedGrants, so the Token() gate admits `resource` for all
+	// three. A fork that does not bind here does not ignore the parameter
+	// harmlessly: it returns 200 with an UNBOUND token, and Shield's
+	// checkResourceBinding then allows the request at every MCP server because
+	// the discriminator claim is absent. The caller believes it holds a token
+	// narrowed to one server and holds one honoured everywhere.
+	//
+	// Binding rather than rejecting: this is an ordinary federation grant with no
+	// upstream authorized set to narrow against, so the requested resource simply
+	// restricts the token it would have minted anyway — the same treatment
+	// client_credentials and api_key get.
+	bindResourceOnIssue(&issue, req.Resource)
+
+	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, issue)
 	if err != nil {
 		return nil, oauthServerError("failed to issue external id_token exchange token", err)
 	}

--- a/internal/service/oauth_id_jag.go
+++ b/internal/service/oauth_id_jag.go
@@ -232,6 +232,23 @@ func (s *OAuthService) idJAGBearer(ctx context.Context, req TokenRequest) (*doma
 		return nil, oauthBadRequest(oautherror.InvalidGrant, "ID-JAG missing required resource claim — cannot audience-restrict the minted token")
 	}
 
+	// RFC 8707 `resource` on the token request NARROWS the binding to a subset of
+	// what the IdP authorized (CAP-IDN-026). Where an ID-JAG names several
+	// servers, the client — which knows which one it is about to call — selects;
+	// without the parameter the claim decides for it and the token is minted good
+	// for every server in the assertion, which is wider than any single call
+	// needs. Every requested value must appear in the claim, so this can only
+	// shrink the set, never extend it: the IdP remains the sole source of
+	// authority and the client only spends less of it.
+	//
+	// Placed AFTER the missing-claim check so an assertion with no resource fails
+	// with the D4 error regardless of what the request asked for, and BEFORE the
+	// single-use jti is consumed so a bad `resource` does not burn the grant.
+	resources, err = narrowResourcesTo(resources, req.Resource)
+	if err != nil {
+		return nil, err
+	}
+
 	// Resolve the application identity if requested (IDOR-guarded, same as the
 	// id_token-exchange path); otherwise synthesize a service identity for the
 	// external principal.

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -228,6 +228,33 @@ func grantSupportsResource(grantType string) bool {
 // caller can never inject or widen one through additional_claims, which is what
 // keeps the claim's presence load-bearing.
 //
+// ── `aud` IS NOT AN AUTHORIZATION SIGNAL ─────────────────────────────────────
+//
+// Setting Audience here means that on the ordinary grants (client_credentials,
+// api_key, token-exchange, authorization_code) the CALLER chooses `aud`. That is
+// deliberate and safe only because nothing on this platform treats `aud` as an
+// authorization input:
+//
+//   - Shield, Observatory, Cerberus, Discovery and AuthN all construct
+//     authjwt.VerifierConfig with Issuer + JWKSURL and leave Audience unset.
+//   - INV-IDN-006 enforcement keys on the `resource` claim precisely because
+//     `aud` cannot carry that meaning — ZeroID stamps it on every token,
+//     defaulting to the issuer URL for JWT-SVID §3.
+//
+// The "a binding only ever NARROWS" argument — the reason ZeroID accepts an
+// arbitrary resource URI with no registry of known resource servers — applies to
+// the `resource` claim, which is presence-gated and therefore restrict-only. It
+// does NOT extend to `aud`, which is an accept/reject gate: swapping it from the
+// issuer to a caller-chosen value is not a subset operation.
+//
+// So: a relying party MUST NOT use `aud` to decide whether to accept a ZeroID
+// token. Pinning authjwt's optional Audience to your own identifier does not
+// establish that the token was minted for you — any tenant principal can request
+// that value. Authorize on `resource` (a binding ZeroID recorded), on `scopes`,
+// and on the principal. If a future need genuinely requires an unforgeable
+// audience, it needs the resource-server registry RFC 8707 §2's
+// invalid_target-for-unknown-resource exists for, not a tweak here.
+//
 // A no-op when nothing was requested, so callers can apply it unconditionally
 // and no grant's default issuance shape changes.
 func bindResourceOnIssue(issue *IssueRequest, resources []string) {

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -187,7 +187,7 @@ var resourceSupportedGrants = map[string]bool{
 	"client_credentials": true,
 	"api_key":            true,
 	"urn:ietf:params:oauth:grant-type:token-exchange": true,
-	"authorization_code": true,
+	"authorization_code":                              true,
 }
 
 func grantSupportsResource(grantType string) bool {

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -105,11 +105,17 @@ func validateResourceIndicators(resources []string) ([]string, error) {
 				fmt.Sprintf("resource %q must be an absolute URI (RFC 8707 §2)", raw))
 		}
 		// url.Parse accepts "https://" with no host and yields IsAbs()==true, so
-		// the absolute check alone is not enough to reject a hostless value for
-		// the network schemes we actually bind against.
-		if (u.Scheme == "http" || u.Scheme == "https") && u.Host == "" {
+		// the absolute check alone is not enough to reject a hostless value.
+		//
+		// Keyed on the "//" authority marker rather than an http/https allow-list:
+		// any scheme that declares an authority must actually name one, so
+		// "ftp://" and "foo://" are rejected on the same grounds as "https://".
+		// A scheme with no authority component is left alone — "urn:example:mcp"
+		// is a legitimate absolute URI with no host to require, and RFC 8707 §2
+		// says absolute URI, not http(s) URL.
+		if strings.Contains(raw, "://") && u.Host == "" {
 			return nil, oauthBadRequest(oautherror.InvalidTarget,
-				fmt.Sprintf("resource %q must include a host", raw))
+				fmt.Sprintf("resource %q declares an authority but names no host", raw))
 		}
 		// Fragment is checked via the raw string as well as the parsed struct:
 		// a trailing "#" parses to an empty Fragment but is still a fragment

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -1,0 +1,199 @@
+package service
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+)
+
+// ── RFC 8707 resource indicators ─────────────────────────────────────────────
+//
+// `resource` is a REQUEST parameter naming the protected resource(s) a token is
+// being minted for (CAP-IDN-026). It is the minting half of INV-IDN-006, whose
+// enforcement half (Shield) gates on the `resource` CLAIM this parameter
+// produces.
+//
+// The security model rests on one property: a resource binding only ever
+// NARROWS. Stamping a resource on a token strictly reduces where that token is
+// honoured and grants no authority the grant did not already carry. That is why
+// ZeroID can accept an arbitrary caller-supplied identifier without a registry
+// of known resource servers — the worst a caller can do by naming a resource
+// that does not exist is mint a token nothing will accept. Any future change
+// that makes `resource` widen anything (select a scope profile, pick a policy,
+// route to a different identity) breaks this and needs a registry first.
+
+// maxResourceIndicators bounds how many resources one request may name. RFC 8707
+// sets no limit; an unbounded list would let a caller inflate every issued JWT
+// (the values land in both `aud` and the `resource` claim) and, on the ID-JAG
+// path, force a large subset comparison. Eight is far above the realistic case —
+// a token is normally bound to exactly one MCP server — and far below anything
+// that matters for token size.
+const maxResourceIndicators = 8
+
+// validateResourceIndicators checks a `resource` request parameter against
+// RFC 8707 §2 and returns the de-duplicated list to bind.
+//
+// Per §2 each value MUST be an absolute URI and MUST NOT include a fragment.
+// The absolute-URI rule is what keeps the identifier globally meaningful: a
+// relative reference ("/mcp/github") means nothing to a resource server that
+// did not issue it, and Shield's origin comparison (sameOrigin) silently fails
+// closed on one, so a token bound to a relative value would be dead on arrival
+// in a way the client could not diagnose. The no-fragment rule matters because
+// fragments are not sent over the wire — two identifiers differing only by
+// fragment are the same resource to every party that matters, so accepting one
+// would create bindings that compare unequal for no observable reason.
+//
+// A query component IS permitted (§2 explicitly allows it when the resource
+// server uses one). Values are compared and stamped verbatim, with no
+// normalization: the identifier a client sends must be byte-identical to what
+// the resource server advertises in its RFC 9728 metadata, and silently
+// canonicalizing (lowercasing a host, stripping a default port, adding a
+// trailing slash) would produce a binding the client did not ask for.
+//
+// Duplicates are collapsed rather than rejected — repeating a resource is
+// harmless and RFC 8707 §2 explicitly permits the parameter to appear multiple
+// times, so a client that lists one twice gets what it asked for.
+//
+// Returns an *OAuthError with `invalid_target` (RFC 8707 §2 names this the
+// error for an invalid or unknown resource) on any violation.
+func validateResourceIndicators(resources []string) ([]string, error) {
+	if len(resources) == 0 {
+		return nil, nil
+	}
+	if len(resources) > maxResourceIndicators {
+		return nil, oauthBadRequest(oautherror.InvalidTarget,
+			fmt.Sprintf("too many resource indicators (max %d)", maxResourceIndicators))
+	}
+
+	out := make([]string, 0, len(resources))
+	for _, raw := range resources {
+		// A caller that sends `resource=` (empty) on a form body never reaches
+		// here — the form-compat middleware drops valueless parameters per
+		// RFC 6749 §3.2. A JSON caller can still send "", so reject explicitly
+		// rather than binding a token to the empty string.
+		if strings.TrimSpace(raw) == "" {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				"resource must not be empty")
+		}
+		// Deliberately NOT TrimSpace'd into the parse: a value with surrounding
+		// whitespace is a malformed identifier, not one to silently repair.
+		u, err := url.Parse(raw)
+		if err != nil {
+			return nil, oauthBadRequestCause(oautherror.InvalidTarget,
+				fmt.Sprintf("resource %q is not a valid URI", raw), err)
+		}
+		if !u.IsAbs() {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				fmt.Sprintf("resource %q must be an absolute URI (RFC 8707 §2)", raw))
+		}
+		// url.Parse accepts "https://" with no host and yields IsAbs()==true, so
+		// the absolute check alone is not enough to reject a hostless value for
+		// the network schemes we actually bind against.
+		if (u.Scheme == "http" || u.Scheme == "https") && u.Host == "" {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				fmt.Sprintf("resource %q must include a host", raw))
+		}
+		// Fragment is checked via the raw string as well as the parsed struct:
+		// a trailing "#" parses to an empty Fragment but is still a fragment
+		// component per RFC 3986 §3.5, and §2 forbids the component, not just a
+		// non-empty one.
+		if u.Fragment != "" || strings.Contains(raw, "#") {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				fmt.Sprintf("resource %q must not include a fragment (RFC 8707 §2)", raw))
+		}
+		if !slices.Contains(out, raw) {
+			out = append(out, raw)
+		}
+	}
+	return out, nil
+}
+
+// checkResourceAudienceExclusive rejects a request that carries BOTH the
+// audience-profile `audience` parameter and the RFC 8707 `resource` parameter.
+//
+// The two look similar and both end up influencing `aud`, but they mean
+// different things: `audience` names a server-defined SCOPE PROFILE (it widens —
+// it adds that profile's fixed scope set), while `resource` names a protected
+// resource (it only narrows). Letting them coexist would put two meanings on one
+// claim with no discriminator — which is exactly the failure that made Shield
+// deny every MCP-targeted request in prod (shield#366, INV-IDN-006). Refusing
+// the combination outright means there is no precedence rule to get wrong, and
+// no profiled-audience token ever also carries a resource binding.
+//
+// If a concrete need for "profiled AND resource-bound" ever appears, it needs a
+// separate deliberate design (likely a distinct claim), not a precedence tweak
+// here.
+func checkResourceAudienceExclusive(req TokenRequest) error {
+	if req.Audience != "" && len(req.Resource) > 0 {
+		return oauthBadRequest(oautherror.InvalidRequest,
+			"audience and resource are mutually exclusive: audience names a scope profile, "+
+				"resource names an RFC 8707 protected resource")
+	}
+	return nil
+}
+
+// narrowResourcesTo restricts an authorized resource set to the subset the
+// client requested, for grants where an upstream authority (today: an ID-JAG's
+// own `resource` claim) already decided which resources are permissible.
+//
+// Every requested value MUST appear in authorized, compared as an exact string.
+// This is the direction that makes the parameter safe here: the client SELECTS
+// from what the IdP granted, and can never add to it. Comparison is exact
+// because both sides are opaque identifiers — a prefix or origin match would let
+// "https://gw.example/mcp/github-admin" be satisfied by an authorization for
+// "https://gw.example/mcp/github".
+//
+// An empty request returns the full authorized set unchanged: omitting the
+// parameter keeps the pre-CAP-IDN-026 behaviour, where the claim decides.
+func narrowResourcesTo(authorized, requested []string) ([]string, error) {
+	if len(requested) == 0 {
+		return authorized, nil
+	}
+	for _, want := range requested {
+		if !slices.Contains(authorized, want) {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				fmt.Sprintf("resource %q is not among the resources this grant authorizes", want))
+		}
+	}
+	return requested, nil
+}
+
+// grantSupportsResource reports whether a grant honours the `resource`
+// parameter. Grants are enabled here as their binding lands; anything not
+// listed rejects the parameter outright (rejectUnsupportedResource) rather than
+// accepting and ignoring it.
+//
+// refresh_token is deliberately absent and stays that way: a refresh continues
+// an existing grant, so accepting a NEW binding there would let a client
+// re-target a token it already holds, and re-binding is a fresh authorization
+// decision that belongs at the original grant. A resource-bound request is
+// issued no refresh token at all, so the case should not arise — this is the
+// second lock on that door.
+var resourceSupportedGrants = map[string]bool{
+	// Populated as each grant's binding lands. Empty means every `resource`
+	// request is refused with invalid_target — accepted-and-ignored is the one
+	// outcome that must never happen.
+}
+
+func grantSupportsResource(grantType string) bool {
+	return resourceSupportedGrants[grantType]
+}
+
+// rejectUnsupportedResource fails a request that carries `resource` on a grant
+// that does not yet honour it.
+//
+// Fail loud, never silently ignore. A caller that asks for a resource-bound
+// token and receives an UNBOUND one has a token that works everywhere while
+// believing it works in one place — the exact confusion INV-IDN-006 exists to
+// prevent. RFC 8707 §2 specifies `invalid_target` for a resource the AS cannot
+// honour, which covers "not on this grant" as well as "not a valid URI".
+func rejectUnsupportedResource(req TokenRequest, grant string) error {
+	if len(req.Resource) == 0 {
+		return nil
+	}
+	return oauthBadRequest(oautherror.InvalidTarget,
+		fmt.Sprintf("the resource parameter is not supported on the %s grant", grant))
+}

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -33,6 +33,15 @@ import (
 // that matters for token size.
 const maxResourceIndicators = 8
 
+// maxResourceIndicatorLen bounds each individual value. The count cap alone does
+// NOT bound token size — eight megabyte-long URIs pass a count check and then
+// land in `aud`, in the `resource` claim, in the signed JWT, in the credentials
+// row, and in the error/log lines that echo them. 2 KiB is far above any real
+// RFC 9728 identifier (`<origin>/mcp/<slug>` is tens of bytes) and far below
+// anything that inflates a token. Mirrors maxObservedResourceLen, which the
+// inventory path already enforces.
+const maxResourceIndicatorLen = 2048
+
 // validateResourceIndicators checks a `resource` request parameter against
 // RFC 8707 §2 and returns the de-duplicated list to bind.
 //
@@ -77,6 +86,12 @@ func validateResourceIndicators(resources []string) ([]string, error) {
 		if strings.TrimSpace(raw) == "" {
 			return nil, oauthBadRequest(oautherror.InvalidTarget,
 				"resource must not be empty")
+		}
+		// Checked before parsing so a pathological value is rejected without
+		// url.Parse walking it, and the error never echoes the oversized input.
+		if len(raw) > maxResourceIndicatorLen {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				fmt.Sprintf("resource exceeds the maximum length of %d bytes", maxResourceIndicatorLen))
 		}
 		// Deliberately NOT TrimSpace'd into the parse: a value with surrounding
 		// whitespace is a malformed identifier, not one to silently repair.

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -179,10 +179,51 @@ var resourceSupportedGrants = map[string]bool{
 	// parameter itself — see jwtBearer — because it has no authorized set to
 	// narrow against.
 	"urn:ietf:params:oauth:grant-type:jwt-bearer": true,
+	// The ordinary grants bind directly (bindResourceOnIssue): there is no
+	// upstream authorized set to narrow against, so the requested resource
+	// simply restricts where the token they would have minted anyway is
+	// honoured. This is the case zeroid#258 exists for — a resource-bound token
+	// with no enterprise IdP in the loop.
+	"client_credentials": true,
+	"api_key":            true,
+	"urn:ietf:params:oauth:grant-type:token-exchange": true,
+	"authorization_code": true,
 }
 
 func grantSupportsResource(grantType string) bool {
 	return resourceSupportedGrants[grantType]
+}
+
+// bindResourceOnIssue stamps an RFC 8707 binding onto an issuance request.
+//
+// Two claims, deliberately, because they answer different questions:
+//
+//   - `aud` — RFC 8707 §2 conformance. A resource-indicator request produces a
+//     token audienced to the resource, which is what a spec-following resource
+//     server checks.
+//   - `resource` — the discriminator INV-IDN-006 enforcement keys on. It cannot
+//     read `aud` for this: ZeroID stamps `aud` on every token it issues,
+//     defaulting to the issuer URL to satisfy JWT-SVID §3, so a non-empty `aud`
+//     says nothing about whether a binding exists. Treating it as if it did
+//     denied every MCP-targeted request in prod (shield#366). Presence of the
+//     `resource` claim is the signal; its absence means "not bound".
+//
+// `resource` is in reservedClaims, so setting it here — the same direct-to-
+// CustomClaims route the ID-JAG path uses — is the ONLY way it can appear. A
+// caller can never inject or widen one through additional_claims, which is what
+// keeps the claim's presence load-bearing.
+//
+// A no-op when nothing was requested, so callers can apply it unconditionally
+// and no grant's default issuance shape changes.
+func bindResourceOnIssue(issue *IssueRequest, resources []string) {
+	if len(resources) == 0 {
+		return
+	}
+	issue.Audience = resources
+	if issue.CustomClaims == nil {
+		issue.CustomClaims = make(map[string]any, 1)
+	}
+	issue.CustomClaims["resource"] = resources
 }
 
 // rejectUnsupportedResource fails a request that carries `resource` on a grant

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -173,9 +173,12 @@ func narrowResourcesTo(authorized, requested []string) ([]string, error) {
 // issued no refresh token at all, so the case should not arise — this is the
 // second lock on that door.
 var resourceSupportedGrants = map[string]bool{
-	// Populated as each grant's binding lands. Empty means every `resource`
-	// request is refused with invalid_target — accepted-and-ignored is the one
-	// outcome that must never happen.
+	// jwt-bearer covers the ID-JAG profile, where `resource` SELECTS a subset of
+	// the resources the corporate IdP already authorized (narrowResourcesTo).
+	// The NHI self-signed jwt-bearer path shares this grant type and rejects the
+	// parameter itself — see jwtBearer — because it has no authorized set to
+	// narrow against.
+	"urn:ietf:params:oauth:grant-type:jwt-bearer": true,
 }
 
 func grantSupportsResource(grantType string) bool {

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -93,6 +93,22 @@ func validateResourceIndicators(resources []string) ([]string, error) {
 			return nil, oauthBadRequest(oautherror.InvalidTarget,
 				fmt.Sprintf("resource exceeds the maximum length of %d bytes", maxResourceIndicatorLen))
 		}
+		// RFC 3986 §2 confines a URI to a subset of printable ASCII: anything
+		// else — a space, a tab, a control character, a raw non-ASCII rune —
+		// must be percent-encoded. url.Parse is lenient about several of these
+		// (a space passes), so without this a value that can never match an
+		// RFC 9728 advertisement is accepted and bound, then appears verbatim
+		// in a signed token, an audit record and a log line where a space or an
+		// embedded newline makes the identifier ambiguous to read.
+		//
+		// Rejecting outright rather than percent-encoding for the caller: the
+		// identifier has to match what the resource server advertises byte for
+		// byte, and silently repairing it would produce a binding the client
+		// never asked for.
+		if i := strings.IndexFunc(raw, func(r rune) bool { return r < 0x21 || r > 0x7e }); i >= 0 {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				fmt.Sprintf("resource contains a character that RFC 3986 requires be percent-encoded (offset %d)", i))
+		}
 		// Deliberately NOT TrimSpace'd into the parse: a value with surrounding
 		// whitespace is a malformed identifier, not one to silently repair.
 		u, err := url.Parse(raw)

--- a/internal/service/oauth_resource.go
+++ b/internal/service/oauth_resource.go
@@ -117,6 +117,27 @@ func validateResourceIndicators(resources []string) ([]string, error) {
 			return nil, oauthBadRequest(oautherror.InvalidTarget,
 				fmt.Sprintf("resource %q declares an authority but names no host", raw))
 		}
+		// Userinfo is rejected, and the rejection deliberately does NOT echo the
+		// value back.
+		//
+		// A resource indicator is a public identifier that gets stamped into a
+		// SIGNED token (both `aud` and the `resource` claim), persisted on the
+		// credential row, recorded in the observed-resource inventory, and
+		// logged. A userinfo component puts a password into every one of those,
+		// and a signed JWT cannot be un-issued — so this is a durable disclosure
+		// rather than a caller-harms-only-themselves mistake, and "a binding only
+		// narrows" does not cover it.
+		//
+		// It is also confusable: in "https://a:80@b/x" a reader sees host "a"
+		// port 80, while every URL parser resolves the origin to "b" — so an
+		// auditor and the enforcement point disagree about which server a token
+		// is bound to. The same repo already rejects userinfo on the analogous
+		// redirect_uri check (redirectURIAllowed), so accepting it here was an
+		// inconsistency rather than a decision.
+		if u.User != nil {
+			return nil, oauthBadRequest(oautherror.InvalidTarget,
+				"resource must not include a userinfo component (RFC 8707 §2 identifiers are public)")
+		}
 		// Fragment is checked via the raw string as well as the parsed struct:
 		// a trailing "#" parses to an empty Fragment but is still a fragment
 		// component per RFC 3986 §3.5, and §2 forbids the component, not just a
@@ -271,7 +292,13 @@ func bindResourceOnIssue(issue *IssueRequest, resources []string) {
 	if issue.CustomClaims == nil {
 		issue.CustomClaims = make(map[string]any, 1)
 	}
-	issue.CustomClaims["resource"] = resources
+	// Cloned rather than aliased. `resources` can arrive with cap > len (the
+	// validator allocates cap for the pre-dedup count), so sharing one backing
+	// array between `aud` and the `resource` claim means a later
+	// append(issue.Audience, …) would write THROUGH into the claim Shield
+	// enforces on — silently changing a binding with no error anywhere. Nothing
+	// appends today; one word removes the whole class.
+	issue.CustomClaims["resource"] = slices.Clone(resources)
 }
 
 // rejectUnsupportedResource fails a request that carries `resource` on a grant

--- a/internal/service/oauth_resource_dispatch_test.go
+++ b/internal/service/oauth_resource_dispatch_test.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/highflame-ai/zeroid/internal/oautherror"
@@ -46,6 +48,7 @@ func TestTokenGate_SupportedGrantsPassTheGate(t *testing.T) {
 
 	for _, grant := range []string{
 		"client_credentials",
+		"api_key",
 		"urn:ietf:params:oauth:grant-type:token-exchange",
 		"authorization_code",
 	} {
@@ -54,8 +57,17 @@ func TestTokenGate_SupportedGrantsPassTheGate(t *testing.T) {
 				GrantType: grant,
 				Resource:  []string{"https://gw.example/mcp/github"},
 			})
-			// invalid_request = reached the grant's own validation.
-			wantOAuthError(t, err, oautherror.InvalidRequest)
+			// Assert the PROPERTY — the gate did not intercept — rather than each
+			// grant's internal validation order. Pinning the exact first error
+			// would break this test when an unrelated guard is added to any of
+			// these grants, which is a false signal about the resource gate.
+			if err == nil {
+				t.Fatal("expected the grant's own validation to reject an otherwise-empty request")
+			}
+			var oe *OAuthError
+			if errors.As(err, &oe) && oe.Code == oautherror.InvalidTarget {
+				t.Fatalf("resource gate intercepted a supported grant: %s", oe.Description)
+			}
 		})
 	}
 }
@@ -129,8 +141,12 @@ func TestJWTBearer_SelfSignedRejectsResource(t *testing.T) {
 		Resource:  []string{"https://gw.example/mcp/github"},
 	})
 	oe := wantOAuthError(t, err, oautherror.InvalidTarget)
-	if oe.Description == "" {
-		t.Fatal("rejection should explain which path refused the parameter")
+	// Must name the self-signed path. Asserting only the CODE would pass even if
+	// jwt-bearer were removed from resourceSupportedGrants entirely — the
+	// Token() gate returns the same invalid_target — so the whole ID-JAG
+	// narrowing capability could be deleted with this test still green.
+	if !strings.Contains(oe.Description, "self-signed") {
+		t.Fatalf("rejection must come from the NHI path, not the dispatch gate: %q", oe.Description)
 	}
 }
 

--- a/internal/service/oauth_resource_dispatch_test.go
+++ b/internal/service/oauth_resource_dispatch_test.go
@@ -16,11 +16,16 @@ func TestTokenGate_ResourceOnUnsupportedGrant(t *testing.T) {
 	svc := &OAuthService{}
 
 	for _, grant := range []string{
-		"client_credentials",
-		"api_key",
-		"urn:ietf:params:oauth:grant-type:token-exchange",
-		"authorization_code",
+		// A refresh continues an existing grant; re-targeting a token already
+		// held is a fresh authorization decision that belongs at the original
+		// grant. Permanently excluded, not pending.
 		"refresh_token",
+		// CIBA redeems through BackchannelService, which takes no resource —
+		// binding would have to be plumbed there deliberately rather than
+		// inherited.
+		"urn:openid:params:grant-type:ciba",
+		// Unknown / custom grants registered via RegisterGrant: fail closed.
+		"no_such_grant",
 	} {
 		t.Run(grant, func(t *testing.T) {
 			_, err := svc.Token(context.Background(), TokenRequest{
@@ -28,6 +33,29 @@ func TestTokenGate_ResourceOnUnsupportedGrant(t *testing.T) {
 				Resource:  []string{"https://gw.example/mcp/github"},
 			})
 			wantOAuthError(t, err, oautherror.InvalidTarget)
+		})
+	}
+}
+
+// TestTokenGate_SupportedGrantsPassTheGate proves the enabled grants are not
+// intercepted: each must fail on its OWN missing-parameter validation, not on
+// the resource gate. Without this the suite would still pass if a grant were
+// accidentally left out of resourceSupportedGrants.
+func TestTokenGate_SupportedGrantsPassTheGate(t *testing.T) {
+	svc := &OAuthService{}
+
+	for _, grant := range []string{
+		"client_credentials",
+		"urn:ietf:params:oauth:grant-type:token-exchange",
+		"authorization_code",
+	} {
+		t.Run(grant, func(t *testing.T) {
+			_, err := svc.Token(context.Background(), TokenRequest{
+				GrantType: grant,
+				Resource:  []string{"https://gw.example/mcp/github"},
+			})
+			// invalid_request = reached the grant's own validation.
+			wantOAuthError(t, err, oautherror.InvalidRequest)
 		})
 	}
 }

--- a/internal/service/oauth_resource_dispatch_test.go
+++ b/internal/service/oauth_resource_dispatch_test.go
@@ -1,0 +1,128 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+)
+
+// These exercise the Token() gate and the jwt-bearer split without a DB. Every
+// case here is rejected before any credential, store, or signature work, which
+// is the point: a malformed or unsupported `resource` must never reach issuance
+// machinery, and proving that needs no fixtures.
+
+func TestTokenGate_ResourceOnUnsupportedGrant(t *testing.T) {
+	svc := &OAuthService{}
+
+	for _, grant := range []string{
+		"client_credentials",
+		"api_key",
+		"urn:ietf:params:oauth:grant-type:token-exchange",
+		"authorization_code",
+		"refresh_token",
+	} {
+		t.Run(grant, func(t *testing.T) {
+			_, err := svc.Token(context.Background(), TokenRequest{
+				GrantType: grant,
+				Resource:  []string{"https://gw.example/mcp/github"},
+			})
+			wantOAuthError(t, err, oautherror.InvalidTarget)
+		})
+	}
+}
+
+func TestTokenGate_AudienceAndResourceRejectedBeforeAnythingElse(t *testing.T) {
+	svc := &OAuthService{}
+
+	// Both parameters AND an unsupported grant AND a malformed resource. The
+	// structural conflict is reported first, so a caller that made several
+	// mistakes is told about the one that makes the request incoherent.
+	_, err := svc.Token(context.Background(), TokenRequest{
+		GrantType: "client_credentials",
+		Audience:  "codeoid",
+		Resource:  []string{"not-a-uri"},
+	})
+	wantOAuthError(t, err, oautherror.InvalidRequest)
+}
+
+func TestTokenGate_MalformedResourceRejectedBeforeGrantDispatch(t *testing.T) {
+	svc := &OAuthService{}
+
+	// client_credentials would normally fail with invalid_request for a missing
+	// account_id/project_id. Getting invalid_target instead proves validation
+	// ran before dispatch.
+	_, err := svc.Token(context.Background(), TokenRequest{
+		GrantType: "client_credentials",
+		Resource:  []string{"https://gw.example/mcp#frag"},
+	})
+	wantOAuthError(t, err, oautherror.InvalidTarget)
+}
+
+func TestTokenGate_NoResourceLeavesGrantsUntouched(t *testing.T) {
+	svc := &OAuthService{}
+
+	// Without `resource`, client_credentials must reach its own validation and
+	// fail on the missing tenant — proving the gate is inert when the parameter
+	// is absent rather than intercepting every request.
+	_, err := svc.Token(context.Background(), TokenRequest{GrantType: "client_credentials"})
+	wantOAuthError(t, err, oautherror.InvalidRequest)
+}
+
+func TestTokenGate_UnknownGrantStillUnsupportedGrantType(t *testing.T) {
+	svc := &OAuthService{}
+
+	// No resource: the normal unsupported_grant_type path is unchanged.
+	_, err := svc.Token(context.Background(), TokenRequest{GrantType: "no_such_grant"})
+	wantOAuthError(t, err, oautherror.UnsupportedGrantType)
+
+	// With a resource: the resource gate fires first. Either error is defensible;
+	// pinning it means a future reorder is a deliberate choice, not a surprise.
+	_, err = svc.Token(context.Background(), TokenRequest{
+		GrantType: "no_such_grant",
+		Resource:  []string{"https://gw.example/mcp/github"},
+	})
+	wantOAuthError(t, err, oautherror.InvalidTarget)
+}
+
+// TestJWTBearer_SelfSignedRejectsResource pins the split inside the jwt-bearer
+// grant: the grant type is marked as supporting `resource` for the ID-JAG
+// profile, so the NHI self-signed path has to refuse it explicitly or the
+// parameter would be silently dropped — the exact accepted-and-ignored outcome
+// the design forbids.
+func TestJWTBearer_SelfSignedRejectsResource(t *testing.T) {
+	svc := &OAuthService{}
+
+	// Not an ID-JAG (no oauth-id-jag+jwt typ header), so this takes the NHI
+	// branch. The rejection lands before any algorithm or signature work.
+	_, err := svc.Token(context.Background(), TokenRequest{
+		GrantType: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		Subject:   "not.a.real.assertion",
+		Resource:  []string{"https://gw.example/mcp/github"},
+	})
+	oe := wantOAuthError(t, err, oautherror.InvalidTarget)
+	if oe.Description == "" {
+		t.Fatal("rejection should explain which path refused the parameter")
+	}
+}
+
+func TestJWTBearer_SelfSignedUnaffectedWithoutResource(t *testing.T) {
+	svc := &OAuthService{}
+
+	// Same assertion, no resource: must fail on the assertion itself
+	// (invalid_grant), not on the resource gate.
+	_, err := svc.Token(context.Background(), TokenRequest{
+		GrantType: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		Subject:   "not.a.real.assertion",
+	})
+	wantOAuthError(t, err, oautherror.InvalidGrant)
+}
+
+func TestJWTBearer_MissingSubjectStillInvalidRequest(t *testing.T) {
+	svc := &OAuthService{}
+
+	_, err := svc.Token(context.Background(), TokenRequest{
+		GrantType: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+	})
+	wantOAuthError(t, err, oautherror.InvalidRequest)
+}

--- a/internal/service/oauth_resource_dispatch_test.go
+++ b/internal/service/oauth_resource_dispatch_test.go
@@ -137,7 +137,7 @@ func TestJWTBearer_SelfSignedRejectsResource(t *testing.T) {
 	// branch. The rejection lands before any algorithm or signature work.
 	_, err := svc.Token(context.Background(), TokenRequest{
 		GrantType: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-		Subject:   "not.a.real.assertion",
+		Assertion: "not.a.real.assertion",
 		Resource:  []string{"https://gw.example/mcp/github"},
 	})
 	oe := wantOAuthError(t, err, oautherror.InvalidTarget)
@@ -157,7 +157,7 @@ func TestJWTBearer_SelfSignedUnaffectedWithoutResource(t *testing.T) {
 	// (invalid_grant), not on the resource gate.
 	_, err := svc.Token(context.Background(), TokenRequest{
 		GrantType: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-		Subject:   "not.a.real.assertion",
+		Assertion: "not.a.real.assertion",
 	})
 	wantOAuthError(t, err, oautherror.InvalidGrant)
 }

--- a/internal/service/oauth_resource_test.go
+++ b/internal/service/oauth_resource_test.go
@@ -57,6 +57,14 @@ func TestValidateResourceIndicators(t *testing.T) {
 		}
 	})
 
+	t.Run("accepts a non-http scheme that DOES name an authority", func(t *testing.T) {
+		// The authority rule is about naming a host when you claim one, not about
+		// which schemes are allowed.
+		if _, err := validateResourceIndicators([]string{"ftp://files.example.com/mcp"}); err != nil {
+			t.Fatalf("authority-bearing non-http scheme rejected: %v", err)
+		}
+	})
+
 	t.Run("de-duplicates rather than rejecting", func(t *testing.T) {
 		got, err := validateResourceIndicators([]string{
 			"https://a.example/mcp", "https://a.example/mcp", "https://b.example/mcp",
@@ -111,6 +119,10 @@ func TestValidateResourceIndicators(t *testing.T) {
 		{"bare trailing fragment marker", "https://gw.example.com/mcp#", "fragment"},
 		{"https with no host", "https://", "host"},
 		{"http with no host", "http://", "host"},
+		// Any scheme that declares an authority must name one — the rule is the
+		// "//" marker, not an http/https allow-list.
+		{"ftp with no host", "ftp://", "host"},
+		{"unknown scheme with no host", "foo://", "host"},
 	}
 	for _, tc := range rejects {
 		t.Run("rejects "+tc.name, func(t *testing.T) {

--- a/internal/service/oauth_resource_test.go
+++ b/internal/service/oauth_resource_test.go
@@ -270,3 +270,88 @@ func TestRefreshTokenNeverSupportsResource(t *testing.T) {
 		t.Fatal("refresh_token must never accept a resource parameter")
 	}
 }
+
+func TestBindResourceOnIssue(t *testing.T) {
+	resources := []string{"https://gw.example/mcp/github"}
+
+	t.Run("no resource leaves issuance untouched", func(t *testing.T) {
+		issue := IssueRequest{Scopes: []string{"mcp:connect"}}
+		bindResourceOnIssue(&issue, nil)
+		if issue.Audience != nil {
+			t.Fatalf("aud was set with no resource: %#v", issue.Audience)
+		}
+		if issue.CustomClaims != nil {
+			t.Fatalf("CustomClaims allocated with no resource: %#v", issue.CustomClaims)
+		}
+	})
+
+	t.Run("stamps both aud and the resource claim", func(t *testing.T) {
+		var issue IssueRequest
+		bindResourceOnIssue(&issue, resources)
+		if len(issue.Audience) != 1 || issue.Audience[0] != resources[0] {
+			t.Fatalf("aud not stamped: %#v", issue.Audience)
+		}
+		got, ok := issue.CustomClaims["resource"].([]string)
+		if !ok || len(got) != 1 || got[0] != resources[0] {
+			t.Fatalf("resource claim not stamped: %#v", issue.CustomClaims["resource"])
+		}
+	})
+
+	t.Run("preserves existing custom claims", func(t *testing.T) {
+		issue := IssueRequest{CustomClaims: map[string]any{"role": "admin"}}
+		bindResourceOnIssue(&issue, resources)
+		if issue.CustomClaims["role"] != "admin" {
+			t.Fatal("an existing custom claim was dropped")
+		}
+		if issue.CustomClaims["resource"] == nil {
+			t.Fatal("resource claim missing")
+		}
+	})
+
+	t.Run("resource claim wins over a pre-set one", func(t *testing.T) {
+		// Defence in depth. `resource` is in reservedClaims so additional_claims
+		// can never reach here, but if some future path pre-populates it, the
+		// value validated for THIS request must be the one that lands — a
+		// binding must never be widened by a leftover.
+		issue := IssueRequest{CustomClaims: map[string]any{
+			"resource": []string{"https://gw.example/mcp/everything"},
+		}}
+		bindResourceOnIssue(&issue, resources)
+		got := issue.CustomClaims["resource"].([]string)
+		if len(got) != 1 || got[0] != resources[0] {
+			t.Fatalf("pre-set resource was not overwritten: %#v", got)
+		}
+	})
+
+	t.Run("aud is replaced, not appended", func(t *testing.T) {
+		// A binding narrows; leaving a prior audience alongside it would widen
+		// where the token is accepted.
+		issue := IssueRequest{Audience: []string{"https://auth.highflame.ai"}}
+		bindResourceOnIssue(&issue, resources)
+		if len(issue.Audience) != 1 || issue.Audience[0] != resources[0] {
+			t.Fatalf("aud was widened rather than replaced: %#v", issue.Audience)
+		}
+	})
+
+	t.Run("binds every requested resource", func(t *testing.T) {
+		multi := []string{"https://gw.example/mcp/a", "https://gw.example/mcp/b"}
+		var issue IssueRequest
+		bindResourceOnIssue(&issue, multi)
+		if len(issue.Audience) != 2 {
+			t.Fatalf("aud dropped a resource: %#v", issue.Audience)
+		}
+		if len(issue.CustomClaims["resource"].([]string)) != 2 {
+			t.Fatalf("claim dropped a resource: %#v", issue.CustomClaims["resource"])
+		}
+	})
+}
+
+// TestResourceIsReserved is a tripwire: bindResourceOnIssue is only the sole
+// writer of the `resource` claim for as long as additional_claims cannot reach
+// it. If reservedClaims ever loses the entry, the claim stops being proof that
+// ZeroID recorded a binding and INV-IDN-006 enforcement becomes forgeable.
+func TestResourceIsReserved(t *testing.T) {
+	if !reservedClaims["resource"] {
+		t.Fatal("resource must stay in reservedClaims — the claim's presence is the security signal")
+	}
+}

--- a/internal/service/oauth_resource_test.go
+++ b/internal/service/oauth_resource_test.go
@@ -70,7 +70,13 @@ func TestValidateResourceIndicators(t *testing.T) {
 	})
 
 	t.Run("preserves order of first appearance", func(t *testing.T) {
-		got, _ := validateResourceIndicators([]string{"https://b.example", "https://a.example", "https://b.example"})
+		got, err := validateResourceIndicators([]string{"https://b.example", "https://a.example", "https://b.example"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("expected 2 values after de-duplication, got %#v", got)
+		}
 		if got[0] != "https://b.example" || got[1] != "https://a.example" {
 			t.Fatalf("order not preserved: %#v", got)
 		}
@@ -104,6 +110,7 @@ func TestValidateResourceIndicators(t *testing.T) {
 		{"non-empty fragment", "https://gw.example.com/mcp#frag", "fragment"},
 		{"bare trailing fragment marker", "https://gw.example.com/mcp#", "fragment"},
 		{"https with no host", "https://", "host"},
+		{"http with no host", "http://", "host"},
 	}
 	for _, tc := range rejects {
 		t.Run("rejects "+tc.name, func(t *testing.T) {
@@ -115,6 +122,47 @@ func TestValidateResourceIndicators(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("rejects a value url.Parse itself cannot handle", func(t *testing.T) {
+		// Distinct from the !IsAbs path: "not-a-uri" parses fine and is caught by
+		// the absolute check. This exercises the parse-error branch, which was
+		// otherwise the only unreached statement in the function.
+		_, err := validateResourceIndicators([]string{"https://[::1"})
+		oe := wantOAuthError(t, err, oautherror.InvalidTarget)
+		if !strings.Contains(oe.Description, "not a valid URI") {
+			t.Fatalf("expected the parse-error message, got %q", oe.Description)
+		}
+		if !errors.Is(err, err) || oe.Unwrap() == nil {
+			t.Fatal("the parse error must be wrapped as the cause")
+		}
+	})
+
+	t.Run("rejects a value over the per-value length cap", func(t *testing.T) {
+		// The COUNT cap does not bound token size; without this, eight huge URIs
+		// pass validation and land in aud, the resource claim, the signed JWT,
+		// the credentials row, and the logs.
+		long := "https://gw.example.com/mcp/" + strings.Repeat("a", maxResourceIndicatorLen)
+		_, err := validateResourceIndicators([]string{long})
+		oe := wantOAuthError(t, err, oautherror.InvalidTarget)
+		if !strings.Contains(oe.Description, "maximum length") {
+			t.Fatalf("expected a length rejection, got %q", oe.Description)
+		}
+		if strings.Contains(oe.Description, "aaaa") {
+			t.Fatal("the error must not echo the oversized value back")
+		}
+	})
+
+	t.Run("a value exactly at the cap is accepted", func(t *testing.T) {
+		// Pins the boundary as inclusive, so a later off-by-one is a deliberate
+		// change rather than an accident.
+		exact := "https://gw.example.com/" + strings.Repeat("a", maxResourceIndicatorLen-23)
+		if len(exact) != maxResourceIndicatorLen {
+			t.Fatalf("test fixture is %d bytes, expected %d", len(exact), maxResourceIndicatorLen)
+		}
+		if _, err := validateResourceIndicators([]string{exact}); err != nil {
+			t.Fatalf("a value exactly at the cap must be accepted: %v", err)
+		}
+	})
 
 	t.Run("rejects more than the cap", func(t *testing.T) {
 		many := make([]string, 0, maxResourceIndicators+1)
@@ -280,8 +328,8 @@ func TestBindResourceOnIssue(t *testing.T) {
 		if issue.Audience != nil {
 			t.Fatalf("aud was set with no resource: %#v", issue.Audience)
 		}
-		if issue.CustomClaims != nil {
-			t.Fatalf("CustomClaims allocated with no resource: %#v", issue.CustomClaims)
+		if issue.CustomClaims["resource"] != nil {
+			t.Fatalf("a resource claim appeared with no resource requested: %#v", issue.CustomClaims)
 		}
 	})
 

--- a/internal/service/oauth_resource_test.go
+++ b/internal/service/oauth_resource_test.go
@@ -1,0 +1,272 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+)
+
+// wantOAuthError asserts the error is an *OAuthError carrying the given code.
+func wantOAuthError(t *testing.T, err error, code string) *OAuthError {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %s, got nil error", code)
+	}
+	var oe *OAuthError
+	if !errors.As(err, &oe) {
+		t.Fatalf("expected *OAuthError(%s), got %T: %v", code, err, err)
+	}
+	if oe.Code != code {
+		t.Fatalf("expected code %s, got %s (%s)", code, oe.Code, oe.Description)
+	}
+	return oe
+}
+
+func TestValidateResourceIndicators(t *testing.T) {
+	t.Run("absent parameter is not an error", func(t *testing.T) {
+		got, err := validateResourceIndicators(nil)
+		if err != nil || got != nil {
+			t.Fatalf("want (nil, nil), got (%v, %v)", got, err)
+		}
+	})
+
+	t.Run("accepts an absolute https URI", func(t *testing.T) {
+		got, err := validateResourceIndicators([]string{"https://gw.example.com/mcp/github"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0] != "https://gw.example.com/mcp/github" {
+			t.Fatalf("value was not preserved verbatim: %#v", got)
+		}
+	})
+
+	t.Run("accepts a query component", func(t *testing.T) {
+		// RFC 8707 §2 permits a query; only the fragment is forbidden.
+		if _, err := validateResourceIndicators([]string{"https://gw.example.com/mcp?tenant=acme"}); err != nil {
+			t.Fatalf("query component rejected: %v", err)
+		}
+	})
+
+	t.Run("accepts a non-http scheme", func(t *testing.T) {
+		// The spec says "absolute URI", not "http(s) URL". A resource server
+		// identified by urn: or a custom scheme is legitimate.
+		if _, err := validateResourceIndicators([]string{"urn:example:mcp:github"}); err != nil {
+			t.Fatalf("urn rejected: %v", err)
+		}
+	})
+
+	t.Run("de-duplicates rather than rejecting", func(t *testing.T) {
+		got, err := validateResourceIndicators([]string{
+			"https://a.example/mcp", "https://a.example/mcp", "https://b.example/mcp",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("duplicates not collapsed: %#v", got)
+		}
+	})
+
+	t.Run("preserves order of first appearance", func(t *testing.T) {
+		got, _ := validateResourceIndicators([]string{"https://b.example", "https://a.example", "https://b.example"})
+		if got[0] != "https://b.example" || got[1] != "https://a.example" {
+			t.Fatalf("order not preserved: %#v", got)
+		}
+	})
+
+	t.Run("does not normalize", func(t *testing.T) {
+		// Two values that a normalizing implementation would collapse must stay
+		// distinct: the client's identifier has to match what the resource
+		// server advertises, byte for byte.
+		got, err := validateResourceIndicators([]string{
+			"https://GW.example.com/mcp", "https://gw.example.com/mcp",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("host case was normalized away: %#v", got)
+		}
+	})
+
+	rejects := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"relative reference", "/mcp/github", "absolute"},
+		{"scheme-relative", "//gw.example.com/mcp", "absolute"},
+		{"bare host", "gw.example.com/mcp", "absolute"},
+		{"empty string", "", "empty"},
+		{"whitespace only", "   ", "empty"},
+		{"non-empty fragment", "https://gw.example.com/mcp#frag", "fragment"},
+		{"bare trailing fragment marker", "https://gw.example.com/mcp#", "fragment"},
+		{"https with no host", "https://", "host"},
+	}
+	for _, tc := range rejects {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			_, err := validateResourceIndicators([]string{tc.value})
+			oe := wantOAuthError(t, err, oautherror.InvalidTarget)
+			if !strings.Contains(oe.Description, tc.want) {
+				t.Fatalf("description %q does not explain the failure (want mention of %q)",
+					oe.Description, tc.want)
+			}
+		})
+	}
+
+	t.Run("rejects more than the cap", func(t *testing.T) {
+		many := make([]string, 0, maxResourceIndicators+1)
+		for i := 0; i <= maxResourceIndicators; i++ {
+			many = append(many, "https://gw.example.com/mcp/"+string(rune('a'+i)))
+		}
+		_, err := validateResourceIndicators(many)
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+
+	t.Run("cap counts values before de-duplication", func(t *testing.T) {
+		// A caller cannot smuggle past the cap with repeats; the guard runs on
+		// the raw list. Documents the choice rather than leaving it incidental.
+		many := make([]string, maxResourceIndicators+1)
+		for i := range many {
+			many[i] = "https://gw.example.com/mcp/same"
+		}
+		if _, err := validateResourceIndicators(many); err == nil {
+			t.Fatal("repeats of one value slipped past the cap")
+		}
+	})
+
+	t.Run("one bad value rejects the whole request", func(t *testing.T) {
+		// Fail closed: never mint bound to the good subset while dropping the
+		// bad one, which would silently narrow differently than asked.
+		_, err := validateResourceIndicators([]string{"https://good.example/mcp", "not-a-uri"})
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+}
+
+func TestCheckResourceAudienceExclusive(t *testing.T) {
+	t.Run("audience alone is fine", func(t *testing.T) {
+		if err := checkResourceAudienceExclusive(TokenRequest{Audience: "codeoid"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("resource alone is fine", func(t *testing.T) {
+		if err := checkResourceAudienceExclusive(TokenRequest{Resource: []string{"https://a.example"}}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("neither is fine", func(t *testing.T) {
+		if err := checkResourceAudienceExclusive(TokenRequest{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("both is invalid_request", func(t *testing.T) {
+		err := checkResourceAudienceExclusive(TokenRequest{
+			Audience: "codeoid",
+			Resource: []string{"https://a.example"},
+		})
+		oe := wantOAuthError(t, err, oautherror.InvalidRequest)
+		if !strings.Contains(oe.Description, "mutually exclusive") {
+			t.Fatalf("description does not name the rule: %q", oe.Description)
+		}
+	})
+}
+
+func TestNarrowResourcesTo(t *testing.T) {
+	authorized := []string{"https://gw.example/mcp/github", "https://gw.example/mcp/slack"}
+
+	t.Run("no request keeps the full authorized set", func(t *testing.T) {
+		got, err := narrowResourcesTo(authorized, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("authorized set was altered: %#v", got)
+		}
+	})
+
+	t.Run("narrows to the requested subset", func(t *testing.T) {
+		got, err := narrowResourcesTo(authorized, []string{"https://gw.example/mcp/slack"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 || got[0] != "https://gw.example/mcp/slack" {
+			t.Fatalf("did not narrow to the request: %#v", got)
+		}
+	})
+
+	t.Run("requesting everything is a no-op", func(t *testing.T) {
+		got, err := narrowResourcesTo(authorized, authorized)
+		if err != nil || len(got) != 2 {
+			t.Fatalf("want the full set back, got (%#v, %v)", got, err)
+		}
+	})
+
+	t.Run("cannot add a resource the grant did not authorize", func(t *testing.T) {
+		_, err := narrowResourcesTo(authorized, []string{"https://gw.example/mcp/payroll"})
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+
+	t.Run("cannot smuggle an extra alongside a valid one", func(t *testing.T) {
+		_, err := narrowResourcesTo(authorized, []string{
+			"https://gw.example/mcp/github", "https://gw.example/mcp/payroll",
+		})
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+
+	t.Run("match is exact, not prefix", func(t *testing.T) {
+		// "github-admin" must not be satisfied by an authorization for "github".
+		_, err := narrowResourcesTo(
+			[]string{"https://gw.example/mcp/github"},
+			[]string{"https://gw.example/mcp/github-admin"},
+		)
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+
+	t.Run("match is exact, not origin", func(t *testing.T) {
+		// Same origin, different server — an origin-level match would authorize
+		// every MCP server behind one gateway.
+		_, err := narrowResourcesTo(
+			[]string{"https://gw.example/mcp/github"},
+			[]string{"https://gw.example/mcp/slack"},
+		)
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+
+	t.Run("empty authorized set authorizes nothing", func(t *testing.T) {
+		_, err := narrowResourcesTo(nil, []string{"https://gw.example/mcp/github"})
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+}
+
+func TestRejectUnsupportedResource(t *testing.T) {
+	t.Run("no resource is a no-op", func(t *testing.T) {
+		if err := rejectUnsupportedResource(TokenRequest{}, "client_credentials"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("resource on an unsupported grant is invalid_target", func(t *testing.T) {
+		err := rejectUnsupportedResource(
+			TokenRequest{Resource: []string{"https://a.example"}}, "client_credentials")
+		oe := wantOAuthError(t, err, oautherror.InvalidTarget)
+		if !strings.Contains(oe.Description, "client_credentials") {
+			t.Fatalf("description does not name the grant: %q", oe.Description)
+		}
+	})
+}
+
+// TestRefreshTokenNeverSupportsResource pins the rule that a refresh can never
+// take a NEW resource binding. It is a separate test from the table above
+// because it is a durable security property, not a slice-by-slice rollout
+// state: enabling it later would let a client re-target a token it already
+// holds without a fresh authorization decision.
+func TestRefreshTokenNeverSupportsResource(t *testing.T) {
+	if grantSupportsResource("refresh_token") {
+		t.Fatal("refresh_token must never accept a resource parameter")
+	}
+}

--- a/internal/service/oauth_resource_test.go
+++ b/internal/service/oauth_resource_test.go
@@ -149,6 +149,33 @@ func TestValidateResourceIndicators(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects a userinfo component without echoing it", func(t *testing.T) {
+		// A resource indicator lands in a SIGNED token, the credential row, the
+		// observed-resource inventory and the logs. A userinfo component puts a
+		// secret in all four, and a signed JWT cannot be un-issued — so this is a
+		// durable disclosure, not a caller-harms-only-themselves mistake.
+		secret := "s3cr3t"
+		at := string(rune(64))
+		_, err := validateResourceIndicators([]string{
+			"https://user:" + secret + at + "gw.example.com/mcp/github"})
+		oe := wantOAuthError(t, err, oautherror.InvalidTarget)
+		if !strings.Contains(oe.Description, "userinfo") {
+			t.Fatalf("expected a userinfo rejection, got %q", oe.Description)
+		}
+		if strings.Contains(oe.Description, secret) {
+			t.Fatal("the rejection must not echo the credential back to the caller")
+		}
+	})
+
+	t.Run("rejects userinfo that reads like a host:port", func(t *testing.T) {
+		// "https://a:80@b/x" reads to a human as host a, port 80; every URL parser
+		// resolves the origin to b. An auditor and the enforcement point would
+		// disagree about which server the token is bound to.
+		at := string(rune(64))
+		_, err := validateResourceIndicators([]string{"https://a:80" + at + "b/mcp/github"})
+		wantOAuthError(t, err, oautherror.InvalidTarget)
+	})
+
 	t.Run("rejects a value over the per-value length cap", func(t *testing.T) {
 		// The COUNT cap does not bound token size; without this, eight huge URIs
 		// pass validation and land in aud, the resource claim, the signed JWT,

--- a/internal/service/oauth_resource_test.go
+++ b/internal/service/oauth_resource_test.go
@@ -149,6 +149,37 @@ func TestValidateResourceIndicators(t *testing.T) {
 		}
 	})
 
+	t.Run("rejects characters RFC 3986 requires be percent-encoded", func(t *testing.T) {
+		// url.Parse is lenient about several of these — a space passes — so
+		// without an explicit rule a value that can never match an RFC 9728
+		// advertisement is bound, and then appears verbatim in a signed token and
+		// an audit record where whitespace makes it ambiguous to read.
+		for name, bad := range map[string]string{
+			"space":     "https://gw.example.com/mcp/a b",
+			"tab":       "https://gw.example.com/mcp/a\tb",
+			"newline":   "https://gw.example.com/mcp/a\nb",
+			"del":       "https://gw.example.com/mcp/a\x7f",
+			"non-ascii": "https://gw.example.com/mcp/caf\u00e9",
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, err := validateResourceIndicators([]string{bad})
+				oe := wantOAuthError(t, err, oautherror.InvalidTarget)
+				if !strings.Contains(oe.Description, "percent-encoded") {
+					t.Fatalf("expected the character-set rejection, got %q", oe.Description)
+				}
+			})
+		}
+	})
+
+	t.Run("a percent-encoded equivalent is accepted", func(t *testing.T) {
+		// The rule rejects the RAW character, not the encoding of it — otherwise
+		// a legitimately encoded path would be unbindable.
+		if _, err := validateResourceIndicators([]string{
+			"https://gw.example.com/mcp/a%20b"}); err != nil {
+			t.Fatalf("a percent-encoded value was rejected: %v", err)
+		}
+	})
+
 	t.Run("rejects a userinfo component without echoing it", func(t *testing.T) {
 		// A resource indicator lands in a SIGNED token, the credential row, the
 		// observed-resource inventory and the logs. A userinfo component puts a

--- a/oauth_form_resource_test.go
+++ b/oauth_form_resource_test.go
@@ -1,0 +1,121 @@
+package zeroid
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Tests for the RFC 8707 §2 repeatable-`resource` carve-out in
+// oauthFormCompatMiddleware (CAP-IDN-026).
+//
+// RFC 6749 §3.1 says a request parameter MUST NOT appear more than once, and
+// the middleware enforces that. RFC 8707 §2 overrides it for `resource`
+// specifically — "the parameter can be included multiple times to indicate
+// multiple resources". Without the carve-out a conformant multi-resource
+// request is rejected with `duplicate OAuth parameter: resource`, which reads
+// to an interop tester as "resource unsupported".
+
+// postForm runs a form-encoded body through the middleware and returns the
+// rewritten JSON body the downstream handler would see, plus the response
+// recorder (non-200 means the middleware rejected it).
+func postForm(t *testing.T, body string) (map[string]any, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	var seen []byte
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading rewritten body: %v", err)
+		}
+		seen = b
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	oauthFormCompatMiddleware(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK || len(seen) == 0 {
+		return nil, rec
+	}
+	var out map[string]any
+	if err := json.Unmarshal(seen, &out); err != nil {
+		t.Fatalf("middleware emitted invalid JSON %q: %v", seen, err)
+	}
+	return out, rec
+}
+
+func TestFormCompat_RepeatedResourceBecomesArray(t *testing.T) {
+	got, rec := postForm(t,
+		"grant_type=client_credentials&resource=https%3A%2F%2Fa.example%2Fmcp&resource=https%3A%2F%2Fb.example%2Fmcp")
+	if got == nil {
+		t.Fatalf("middleware rejected a conformant RFC 8707 request: %d %s", rec.Code, rec.Body.String())
+	}
+
+	arr, ok := got["resource"].([]any)
+	if !ok {
+		t.Fatalf("resource did not become an array: %#v", got["resource"])
+	}
+	if len(arr) != 2 || arr[0] != "https://a.example/mcp" || arr[1] != "https://b.example/mcp" {
+		t.Fatalf("values or order wrong: %#v", arr)
+	}
+}
+
+func TestFormCompat_SingleResourceStaysAString(t *testing.T) {
+	// One occurrence must keep the plain-string shape — this is the common case
+	// and the handler's resourceParam binder accepts both.
+	got, rec := postForm(t, "grant_type=client_credentials&resource=https%3A%2F%2Fa.example%2Fmcp")
+	if got == nil {
+		t.Fatalf("rejected: %d %s", rec.Code, rec.Body.String())
+	}
+	if s, ok := got["resource"].(string); !ok || s != "https://a.example/mcp" {
+		t.Fatalf("single resource did not stay a string: %#v", got["resource"])
+	}
+}
+
+func TestFormCompat_OtherDuplicatesStillRejected(t *testing.T) {
+	// The carve-out must be surgical: RFC 6749 §3.1 still applies to every
+	// other parameter. A repeated client_id is an attack shape (parameter
+	// smuggling), not a spec feature.
+	_, rec := postForm(t, "grant_type=client_credentials&client_id=a&client_id=b")
+	if rec.Code == http.StatusOK {
+		t.Fatal("duplicate client_id was accepted — the carve-out is too broad")
+	}
+	if !strings.Contains(rec.Body.String(), "duplicate OAuth parameter") {
+		t.Fatalf("unexpected rejection reason: %s", rec.Body.String())
+	}
+}
+
+func TestFormCompat_ValuelessRepeatsDropped(t *testing.T) {
+	// RFC 6749 §3.2: a parameter sent without a value is treated as omitted.
+	// That rule has to survive the repeat path too, or `resource=https://a&resource=`
+	// would bind a token to the empty string alongside the real resource.
+	got, rec := postForm(t,
+		"grant_type=client_credentials&resource=https%3A%2F%2Fa.example%2Fmcp&resource=")
+	if got == nil {
+		t.Fatalf("rejected: %d %s", rec.Code, rec.Body.String())
+	}
+	arr, ok := got["resource"].([]any)
+	if !ok {
+		t.Fatalf("expected an array, got %#v", got["resource"])
+	}
+	if len(arr) != 1 || arr[0] != "https://a.example/mcp" {
+		t.Fatalf("valueless occurrence was not dropped: %#v", arr)
+	}
+}
+
+func TestFormCompat_AllValuelessResourceOmitted(t *testing.T) {
+	// Every occurrence valueless ⇒ the parameter is absent entirely, not an
+	// empty array (which the service would otherwise have to special-case).
+	got, rec := postForm(t, "grant_type=client_credentials&resource=&resource=")
+	if got == nil {
+		t.Fatalf("rejected: %d %s", rec.Code, rec.Body.String())
+	}
+	if _, present := got["resource"]; present {
+		t.Fatalf("expected resource to be omitted, got %#v", got["resource"])
+	}
+}

--- a/oauth_form_resource_test.go
+++ b/oauth_form_resource_test.go
@@ -119,3 +119,40 @@ func TestFormCompat_AllValuelessResourceOmitted(t *testing.T) {
 		t.Fatalf("expected resource to be omitted, got %#v", got["resource"])
 	}
 }
+
+// TestFormCompat_RepeatsAreBounded pins the middleware-side repeat bound.
+// The token endpoint is unauthenticated; without this a 10 MiB body of
+// repeated `resource=` is fully collected, re-marshalled and URI-validated per
+// element before the service's stricter cap rejects the count.
+func TestFormCompat_RepeatsAreBounded(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("grant_type=client_credentials")
+	for i := 0; i < 65; i++ {
+		b.WriteString("&resource=https://gw.example.com/mcp/s")
+	}
+
+	got, rec := postForm(t, b.String())
+	if rec.Code == http.StatusOK {
+		t.Fatalf("an unbounded repeat count was accepted: %#v", got)
+	}
+	if !strings.Contains(rec.Body.String(), "too many repeated values") {
+		t.Fatalf("expected the repeat-bound rejection, got %q", rec.Body.String())
+	}
+}
+
+// A repeat count within the bound still binds — the guard must not shadow the
+// service's own (stricter, differently-worded) limit, which stays the single
+// authority on how many resources a request may name.
+func TestFormCompat_RepeatsWithinBoundStillReachTheService(t *testing.T) {
+	got, rec := postForm(t,
+		"grant_type=client_credentials"+
+			"&resource=https://a.example.com/mcp/x"+
+			"&resource=https://b.example.com/mcp/y")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("a legal repeat was rejected by the middleware: %q", rec.Body.String())
+	}
+	arr, ok := got["resource"].([]any)
+	if !ok || len(arr) != 2 {
+		t.Fatalf("expected both resources forwarded, got %#v", got["resource"])
+	}
+}

--- a/pkg/authjwt/verifier.go
+++ b/pkg/authjwt/verifier.go
@@ -56,7 +56,21 @@ type VerifierConfig struct {
 	Issuer string
 
 	// Audience is the expected "aud" claim value. If set, tokens without this
-	// audience are rejected. Use your service identifier (e.g., "my-mcp-server").
+	// audience are rejected.
+	//
+	// NOT an authorization signal, and not proof a token was minted for you.
+	// ZeroID stamps `aud` on every token it issues (defaulting to the issuer URL
+	// to satisfy JWT-SVID §3), and since CAP-IDN-026 a caller may set it to any
+	// absolute URI by passing the RFC 8707 `resource` parameter at the token
+	// endpoint. So pinning this to your own identifier does not establish that
+	// the authorization server intended the token for your service — any tenant
+	// principal can request that value.
+	//
+	// Use it as a routing/hygiene filter if you like. Authorize on the claims
+	// that carry authority: `scopes`, the principal (`sub` / identity_type /
+	// trust_level), and — for a resource binding ZeroID actually recorded — the
+	// `resource` claim (Claims.Resource), which callers cannot forge because it
+	// is server-reserved.
 	Audience string
 
 	// IntrospectURL is the URL of the token introspection endpoint (RFC 7662).

--- a/server.go
+++ b/server.go
@@ -1609,6 +1609,22 @@ var jsonShapedFormFields = map[string]struct{}{
 	"authorization_details": {},
 }
 
+// repeatableFormFields are OAuth form parameters that a spec explicitly permits
+// to appear MORE THAN ONCE, overriding RFC 6749 §3.1's blanket "MUST NOT be
+// included more than once".
+//
+// Today only RFC 8707 `resource` qualifies: §2 states "the parameter can be
+// included multiple times to indicate multiple resources". Without this set the
+// duplicate-key guard below would reject a conformant multi-resource request
+// with `duplicate OAuth parameter: resource` — a spec violation that would look
+// to an interop tester like we do not support the parameter at all.
+//
+// Repeats are collapsed into a JSON array so the downstream binder
+// (handler.resourceParam) sees the same shape a JSON caller would send.
+var repeatableFormFields = map[string]struct{}{
+	"resource": {},
+}
+
 // mediaTypeEquals parses a Content-Type header and reports whether the media
 // type portion matches want (case-insensitive per RFC 7231 §3.1.1.1).
 // Parameters like charset are ignored for the comparison.
@@ -1664,10 +1680,28 @@ func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 		for k, vs := range r.PostForm {
 			// RFC 6749 §3.1: request parameters MUST NOT be included more
 			// than once. Duplicate keys are rejected rather than silently
-			// collapsed to vs[0].
+			// collapsed to vs[0] — EXCEPT where a later spec explicitly makes
+			// the parameter repeatable (repeatableFormFields), in which case
+			// every occurrence is preserved as a JSON array.
 			if len(vs) > 1 {
-				writeValidationError(w, r, "duplicate OAuth parameter: "+k)
-				return
+				if _, repeatable := repeatableFormFields[k]; !repeatable {
+					writeValidationError(w, r, "duplicate OAuth parameter: "+k)
+					return
+				}
+				// Drop valueless occurrences per RFC 6749 §3.2 before binding,
+				// so `resource=https://a&resource=` yields one resource rather
+				// than one resource plus an empty string.
+				kept := make([]string, 0, len(vs))
+				for _, v := range vs {
+					if v != "" {
+						kept = append(kept, v)
+					}
+				}
+				if len(kept) == 0 {
+					continue
+				}
+				flat[k] = kept
+				continue
 			}
 			if len(vs) == 0 {
 				continue

--- a/server.go
+++ b/server.go
@@ -1621,8 +1621,27 @@ var jsonShapedFormFields = map[string]struct{}{
 //
 // Repeats are collapsed into a JSON array so the downstream binder
 // (handler.resourceParam) sees the same shape a JSON caller would send.
-var repeatableFormFields = map[string]struct{}{
-	"resource": {},
+//
+// Scoped to /oauth2/token, the only endpoint that binds `resource`. Applying it
+// across every OAuthFormEndpoint would make a repeated `resource` on
+// /oauth2/bc-authorize parse cleanly and then be discarded by a body struct
+// that has no such field — advertising support for a parameter that does
+// nothing. Narrow the carve-out to where the parameter is real.
+var repeatableFormFields = map[string]map[string]struct{}{
+	"/oauth2/token": {
+		"resource": {},
+	},
+}
+
+// formFieldRepeatable reports whether parameter k may legally appear more than
+// once on the given endpoint.
+func formFieldRepeatable(path, k string) bool {
+	fields, ok := repeatableFormFields[path]
+	if !ok {
+		return false
+	}
+	_, repeatable := fields[k]
+	return repeatable
 }
 
 // mediaTypeEquals parses a Content-Type header and reports whether the media
@@ -1684,7 +1703,7 @@ func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 			// the parameter repeatable (repeatableFormFields), in which case
 			// every occurrence is preserved as a JSON array.
 			if len(vs) > 1 {
-				if _, repeatable := repeatableFormFields[k]; !repeatable {
+				if !formFieldRepeatable(r.URL.Path, k) {
 					writeValidationError(w, r, "duplicate OAuth parameter: "+k)
 					return
 				}

--- a/server.go
+++ b/server.go
@@ -1707,6 +1707,23 @@ func oauthFormCompatMiddleware(next http.Handler) http.Handler {
 					writeValidationError(w, r, "duplicate OAuth parameter: "+k)
 					return
 				}
+				// Bound the repeat count HERE, not only at the service's
+				// stricter cap. The token endpoint is unauthenticated, and
+				// without this a 10 MiB body of repeated `resource=` produces
+				// ~800k values that are collected, re-marshalled to JSON, and
+				// URI-validated per element by the request binder before the
+				// service rejects the count. That work is linear rather than
+				// amplifying, so it is not a denial-of-service on its own — but
+				// it is unbounded work admitted on the caller's say-so, and one
+				// comparison removes it. Deliberately looser than the service's
+				// own limit so THAT stays the single authority on how many
+				// resources a request may name, with its own error message.
+				const maxFormRepeats = 64
+				if len(vs) > maxFormRepeats {
+					writeValidationError(w, r,
+						"too many repeated values for OAuth parameter: "+k)
+					return
+				}
 				// Drop valueless occurrences per RFC 6749 §3.2 before binding,
 				// so `resource=https://a&resource=` yields one resource rather
 				// than one resource plus an empty string.

--- a/tests/integration/external_idp_test.go
+++ b/tests/integration/external_idp_test.go
@@ -66,6 +66,71 @@ func TestExternalIDTokenFederation_EndToEnd(t *testing.T) {
 	defer fedHTTPSrv.Close()
 	defer func() { _ = fedSrv.Shutdown(context.Background()) }()
 
+	// RFC 8707 resource binding on the id_token federation fork (CAP-IDN-026).
+	//
+	// token-exchange forks three ways and the grant type as a whole is in
+	// resourceSupportedGrants, so the Token() gate admits `resource` for ALL of
+	// them. This fork originally did not bind, which meant a 200 with an
+	// UNBOUND token: Shield's checkResourceBinding allows at every MCP server
+	// when the discriminator claim is absent, so the caller held a token good
+	// everywhere while believing it was narrowed to one server. Caught in
+	// review; these pin it.
+	t.Run("resource binds the federated token", func(t *testing.T) {
+		const mcpResource = "https://gw.example.com/mcp/github"
+		now := time.Now()
+		idToken := upstream.SignToken(t, map[string]any{
+			"iss": upstreamIss,
+			"aud": federationAud,
+			"sub": "00uRESOURCEBIND",
+			"iat": now.Unix(),
+			"exp": now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+			"subject_token":      idToken,
+			"subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+			"account_id":         fedCfg.AccountID,
+			"project_id":         fedCfg.ProjectID,
+			"resource":           mcpResource,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		require.ElementsMatch(t, []any{mcpResource}, claims["aud"],
+			"aud must be the requested resource")
+		require.ElementsMatch(t, []any{mcpResource}, claims["resource"],
+			"the resource claim is what INV-IDN-006 enforcement keys on; without "+
+				"it the token is silently unbound")
+	})
+
+	t.Run("without resource the federated token stays unbound", func(t *testing.T) {
+		// Baseline: absence of the claim is what tells Shield the token is
+		// unbound, so an empty-but-present claim would be a silent enforcement
+		// change for every existing federation caller.
+		now := time.Now()
+		idToken := upstream.SignToken(t, map[string]any{
+			"iss": upstreamIss,
+			"aud": federationAud,
+			"sub": "00uRESOURCEUNBOUND",
+			"iat": now.Unix(),
+			"exp": now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, map[string]any{
+			"grant_type":         "urn:ietf:params:oauth:grant-type:token-exchange",
+			"subject_token":      idToken,
+			"subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+			"account_id":         fedCfg.AccountID,
+			"project_id":         fedCfg.ProjectID,
+		})
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		require.Nil(t, claims["resource"],
+			"an unbound token must carry no resource claim at all")
+	})
+
 	t.Run("federation happy path emits user_id_iss", func(t *testing.T) {
 		// Mint an Okta-shaped ID token. Okta uses `sub` as a stable string
 		// identifier and emits `auth_time`/`amr` from the authentication event.

--- a/tests/integration/id_jag_test.go
+++ b/tests/integration/id_jag_test.go
@@ -157,6 +157,122 @@ func TestIDJAG_EndToEnd(t *testing.T) {
 			"minted aud must contain every resource in the ID-JAG resource array")
 	})
 
+	// ── RFC 8707 `resource` request parameter (CAP-IDN-026) ──────────────────
+	//
+	// Where an ID-JAG authorizes several servers, the CLIENT — which knows which
+	// one it is about to call — selects at redemption time. Without the
+	// parameter the claim decides and the token is minted good for every server
+	// the assertion names, which is wider than any single call needs.
+	//
+	// These pin the wiring, not just the helper: narrowResourcesTo is unit-
+	// tested in isolation, but nothing proved idJAGBearer actually calls it,
+	// with the right arguments, at the right point in the sequence.
+
+	t.Run("resource request parameter narrows aud to the selected server", func(t *testing.T) {
+		now := time.Now()
+		const mcpResource2 = "https://mcp-server-2.idjag.test"
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uNARROW01",
+			"resource": []any{mcpResource, mcpResource2},
+			"scope":    "tools:read",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		body := idJAGBody(idjag)
+		body["resource"] = mcpResource2
+
+		resp := postFederation(t, fedHTTPSrv.URL, body)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		// Both claims, not just aud: `aud` is RFC 8707 conformance, but the
+		// `resource` claim is what Shield enforces INV-IDN-006 on. A narrowing
+		// that reached only one of them would leave enforcement disagreeing with
+		// the audience.
+		require.ElementsMatch(t, []any{mcpResource2}, claims["aud"],
+			"aud must be EXACTLY the requested resource, not the full authorized set")
+		require.ElementsMatch(t, []any{mcpResource2}, claims["resource"],
+			"the resource claim must be narrowed alongside aud")
+	})
+
+	t.Run("cannot select a resource the ID-JAG does not authorize", func(t *testing.T) {
+		now := time.Now()
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uNARROW02",
+			"resource": mcpResource,
+			"scope":    "tools:read",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		body := idJAGBody(idjag)
+		body["resource"] = "https://mcp-server-unauthorized.idjag.test"
+
+		resp := postFederation(t, fedHTTPSrv.URL, body)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "body=%s", resp.RawBody)
+		require.Equal(t, "invalid_target", resp.Error, "body=%s", resp.RawBody)
+		// The message distinguishes narrowing-rejected from gate-rejected. Without
+		// this the test would still pass if the narrowing were deleted and the
+		// Token() gate happened to reject for an unrelated reason.
+		require.Contains(t, resp.RawBody, "not among the resources this grant authorizes",
+			"rejection must come from narrowing, not from the dispatch gate")
+		require.Empty(t, resp.AccessToken)
+	})
+
+	t.Run("a rejected resource does not burn the single-use jti", func(t *testing.T) {
+		// The ordering claim from oauth_id_jag.go: narrowing runs BEFORE the jti
+		// is consumed. If it ran after, an attacker could destroy a victim's
+		// one-shot grant by replaying it with a deliberately bad `resource` —
+		// and nothing would error at the time.
+		now := time.Now()
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uNARROW03",
+			"resource": mcpResource,
+			"scope":    "tools:read",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		bad := idJAGBody(idjag)
+		bad["resource"] = "https://mcp-server-unauthorized.idjag.test"
+		rejected := postFederation(t, fedHTTPSrv.URL, bad)
+		require.Equal(t, http.StatusBadRequest, rejected.StatusCode, "body=%s", rejected.RawBody)
+
+		// SAME assertion, same jti — must still be redeemable.
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"the jti was consumed by a request that failed the resource check; body=%s", resp.RawBody)
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		require.ElementsMatch(t, []any{mcpResource}, claims["aud"])
+	})
+
+	t.Run("omitting the parameter still binds to the whole authorized set", func(t *testing.T) {
+		// The pre-CAP-IDN-026 behaviour every existing ID-JAG caller depends on.
+		now := time.Now()
+		const mcpResource2 = "https://mcp-server-2.idjag.test"
+		idjag := signIDJAG(t, map[string]any{
+			"iss":      upstreamIss,
+			"aud":      federationAud,
+			"sub":      "00uNARROW04",
+			"resource": []any{mcpResource, mcpResource2},
+			"scope":    "tools:read",
+			"iat":      now.Unix(),
+			"exp":      now.Add(5 * time.Minute).Unix(),
+		})
+
+		resp := postFederation(t, fedHTTPSrv.URL, idJAGBody(idjag))
+		require.Equal(t, http.StatusOK, resp.StatusCode, "body=%s", resp.RawBody)
+		claims := decodeIssuedTokenClaims(t, resp.AccessToken)
+		require.ElementsMatch(t, []any{mcpResource, mcpResource2}, claims["aud"])
+	})
+
 	t.Run("missing resource fails closed (invalid_grant)", func(t *testing.T) {
 		now := time.Now()
 		idjag := signIDJAG(t, map[string]any{

--- a/tests/integration/oauth_form_compat_test.go
+++ b/tests/integration/oauth_form_compat_test.go
@@ -194,3 +194,57 @@ func TestOAuthFormCompatOpenAPIAdvertisesFormContentType(t *testing.T) {
 			"%s must advertise form encoding per RFC 6749/7662/7009", p)
 	}
 }
+
+// TestOpenAPIAdvertisesResourceUnionShape pins the RFC 8707 `resource` parameter's
+// documented wire shape (CAP-IDN-026).
+//
+// resourceParam implements huma.SchemaProvider specifically so the OpenAPI
+// document shows `oneOf: [string, array<string>]` — without it Huma infers an
+// array-only schema from the underlying []string and the single-string form,
+// which is what form-encoded clients and the MCP interop harness actually send,
+// looks unsupported. The Schema() method reads 0% in coverage because Huma calls
+// it during registry construction, so nothing else would notice if the union
+// silently regressed to an array.
+func TestOpenAPIAdvertisesResourceUnionShape(t *testing.T) {
+	resp, err := http.Get(testServer.URL + "/openapi.json")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var spec map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&spec))
+
+	components, _ := spec["components"].(map[string]any)
+	require.NotNil(t, components, "openapi.json has no components section")
+	schemas, _ := components["schemas"].(map[string]any)
+	require.NotNil(t, schemas)
+
+	body, _ := schemas["TokenInputBody"].(map[string]any)
+	require.NotNil(t, body, "TokenInputBody schema missing from openapi.json")
+	props, _ := body["properties"].(map[string]any)
+	require.NotNil(t, props)
+
+	resource, _ := props["resource"].(map[string]any)
+	require.NotNil(t, resource, "the resource parameter is not documented on /oauth2/token")
+
+	oneOf, ok := resource["oneOf"].([]any)
+	require.True(t, ok,
+		"resource must be documented as a union; got %#v — an array-only schema "+
+			"tells clients the single-string form is unsupported", resource)
+	require.Len(t, oneOf, 2, "expected exactly the string and array variants")
+
+	var sawString, sawArray bool
+	for _, variant := range oneOf {
+		v, _ := variant.(map[string]any)
+		switch v["type"] {
+		case "string":
+			sawString = true
+		case "array":
+			items, _ := v["items"].(map[string]any)
+			require.Equal(t, "string", items["type"], "the array variant must hold strings")
+			sawArray = true
+		}
+	}
+	require.True(t, sawString, "the single-URI string form must be advertised")
+	require.True(t, sawArray, "the multi-resource array form must be advertised")
+}

--- a/tests/integration/resource_indicator_test.go
+++ b/tests/integration/resource_indicator_test.go
@@ -1,8 +1,13 @@
 package integration_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,7 +96,11 @@ func TestResourceIndicator_BindsClientCredentialsToken(t *testing.T) {
 
 		assert.Nil(t, resourceClaimOf(t, claims),
 			"an unbound token must carry no resource claim at all")
-		assert.NotEqual(t, []string{mcpGithub}, audienceOf(t, claims))
+		// Assert what aud IS, not what it is not: NotEqual passes for any token
+		// not bound to that exact URL, and nothing could make an unrequested
+		// resource appear there.
+		assert.Equal(t, []string{testIssuer}, audienceOf(t, claims),
+			"an unbound token's aud must stay the issuer default")
 	})
 
 	t.Run("array form binds every value", func(t *testing.T) {
@@ -144,7 +153,7 @@ func TestResourceIndicator_Rejections(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			b := clientCredsBody(t, "res-reject")
+			b := clientCredsBody(t, "res-reject-"+strings.ReplaceAll(tc.name, " ", "-"))
 			b["resource"] = tc.resource
 
 			resp := post(t, "/oauth2/token", b, nil)
@@ -345,9 +354,14 @@ func TestResourceIndicator_FormEncoded(t *testing.T) {
 		f["client_id"] = []string{f.Get("client_id"), "someone-else"}
 
 		resp := postForm(t, "/oauth2/token", f)
-		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		assert.NotEqual(t, http.StatusOK, resp.StatusCode,
 			"duplicate client_id must not be accepted")
+		// Assert WHY. Without this the case passes if the request failed for any
+		// unrelated reason, which would hide the carve-out becoming too broad.
+		assert.Contains(t, string(body), "duplicate OAuth parameter",
+			"must be rejected by the duplicate-parameter guard specifically")
 	})
 
 	t.Run("valueless resource is treated as omitted", func(t *testing.T) {
@@ -362,5 +376,131 @@ func TestResourceIndicator_FormEncoded(t *testing.T) {
 
 		assert.Nil(t, resourceClaimOf(t, claims),
 			"an empty resource parameter must leave the token unbound, not bound to \"\"")
+	})
+}
+
+// ── One test per ISSUANCE SITE, not per grant-type string ────────────────────
+//
+// `resourceSupportedGrants` is keyed by grant type, but several grants fork
+// internally to different IssueCredential call sites, and each fork must bind
+// independently. Covering "the grant" is not the same as covering "the site":
+// a fork that misses bindResourceOnIssue returns 200 with an UNBOUND token, and
+// Shield then allows it at every MCP server because the discriminator claim is
+// absent. Each test below is mutation-checked to fail if its call is removed.
+
+func TestResourceIndicator_BindsAPIKeyGrant(t *testing.T) {
+	agent := registerAgent(t, uid("res-apikey"))
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    agent.APIKey,
+		"resource":   mcpGithub,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+	_ = resp.Body.Close()
+
+	assert.Equal(t, []string{mcpGithub}, audienceOf(t, claims),
+		"api_key grant must bind aud to the requested resource")
+	assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims),
+		"api_key grant must stamp the resource claim")
+}
+
+func TestResourceIndicator_BindsNHIDelegationExchange(t *testing.T) {
+	// token-exchange fork 1 of 3: NHI delegation (actor_token present).
+	scopes := []string{"data:read"}
+	_, _, parent := issueRootCredential(t, "", "res-deleg-root", scopes)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	extID := uid("res-deleg-child")
+	registerIdentityWithPolicy(t, extID, "", ecPublicKeyPEM(t, key), scopes, adminHeaders())
+	wimse := fetchIdentityWIMSEByExternalID(t, extID)
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": parent,
+		"actor_token":   buildAssertion(t, key, wimse),
+		"scope":         "data:read",
+		"resource":      mcpGithub,
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+	_ = resp.Body.Close()
+
+	assert.Equal(t, []string{mcpGithub}, audienceOf(t, claims),
+		"a delegated token must carry the requested binding")
+	assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims))
+}
+
+func TestResourceIndicator_BindsExternalPrincipalExchange(t *testing.T) {
+	// token-exchange fork 2 of 3: trusted external-principal (no actor_token,
+	// no audience profile).
+	trusted := map[string]string{testTrustedServiceHeader: "trusted-service"}
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": "external-principal-assertion",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"user_id":       uid("res-extprin"),
+		"resource":      mcpGithub,
+	}, trusted)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+	_ = resp.Body.Close()
+
+	assert.Equal(t, []string{mcpGithub}, audienceOf(t, claims))
+	assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims))
+}
+
+// TestResourceIndicator_ExternalPrincipalBoundGetsNoRefreshToken pins the
+// invariant the code only ASSERTS in a comment: the external-principal refresh
+// token is gated on a profiled audience, and audience/resource are mutually
+// exclusive, so a bound request can never reach it.
+//
+// The reasoning is correct today, but it is one refactor from being wrong —
+// changing that gate from `len(audience) > 0` to `len(issue.Audience) > 0`
+// (which bindResourceOnIssue populates) would mint a refresh token for a bound
+// request, and the rotated token would come back unbound with nothing failing.
+func TestResourceIndicator_ExternalPrincipalBoundGetsNoRefreshToken(t *testing.T) {
+	trusted := map[string]string{testTrustedServiceHeader: "trusted-service"}
+	base := func(userID string) map[string]any {
+		return map[string]any{
+			"grant_type":          "urn:ietf:params:oauth:grant-type:token-exchange",
+			"subject_token":       "external-principal-assertion",
+			"account_id":          testAccountID,
+			"project_id":          testProjectID,
+			"user_id":             userID,
+			"issue_refresh_token": true,
+		}
+	}
+
+	t.Run("baseline: a profiled audience DOES get a refresh token", func(t *testing.T) {
+		// Guards the assertion below from passing for the wrong reason.
+		b := base(uid("res-ep-base"))
+		b["audience"] = "codeoid"
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		token := decode(t, resp)
+		_ = resp.Body.Close()
+		assert.NotEmpty(t, token["refresh_token"])
+	})
+
+	t.Run("resource-bound gets none even with issue_refresh_token", func(t *testing.T) {
+		b := base(uid("res-ep-bound"))
+		b["resource"] = mcpGithub
+
+		resp := post(t, "/oauth2/token", b, trusted)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		token := decode(t, resp)
+		_ = resp.Body.Close()
+
+		assert.Empty(t, token["refresh_token"],
+			"a resource-bound token must never come with a refresh token — the "+
+				"binding is not carried across rotation")
+		claims := decodeJWTPayload(t, token["access_token"].(string))
+		assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims))
 	})
 }

--- a/tests/integration/resource_indicator_test.go
+++ b/tests/integration/resource_indicator_test.go
@@ -1,0 +1,366 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end contract for the RFC 8707 `resource` request parameter
+// (CAP-IDN-026, zeroid#258). These drive the real HTTP endpoint against a real
+// database, so they cover the wiring the service-level unit tests cannot: JSON
+// binding of the string-or-array shape, the Token() gate ordering, and what
+// actually lands in the signed JWT.
+
+const (
+	mcpGithub = "https://gw.example.com/mcp/github"
+	mcpSlack  = "https://gw.example.com/mcp/slack"
+)
+
+// resourceClaimOf normalizes the `resource` claim, which — like `aud` — may
+// serialize as a bare string or an array. Returns nil when the claim is absent,
+// which is the meaningful "not resource-bound" case.
+func resourceClaimOf(t *testing.T, claims map[string]any) []string {
+	t.Helper()
+	switch v := claims["resource"].(type) {
+	case nil:
+		return nil
+	case string:
+		return []string{v}
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, e := range v {
+			s, ok := e.(string)
+			require.True(t, ok, "resource array element must be a string")
+			out = append(out, s)
+		}
+		return out
+	default:
+		t.Fatalf("unexpected resource claim type %T", v)
+		return nil
+	}
+}
+
+// clientCredsBody registers an identity + confidential client and returns a
+// ready client_credentials token request.
+func clientCredsBody(t *testing.T, prefix string) map[string]any {
+	t.Helper()
+	agentID := uid(prefix)
+	registerIdentity(t, agentID, []string{"data:read"})
+	client := registerOAuthClient(t, agentID, []string{"data:read"})
+	return map[string]any{
+		"grant_type":    "client_credentials",
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"scope":         "data:read",
+	}
+}
+
+func TestResourceIndicator_BindsClientCredentialsToken(t *testing.T) {
+	t.Run("stamps aud and the resource claim", func(t *testing.T) {
+		b := clientCredsBody(t, "res-cc-bind")
+		b["resource"] = mcpGithub
+
+		resp := post(t, "/oauth2/token", b, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Equal(t, []string{mcpGithub}, audienceOf(t, claims),
+			"aud must be the requested resource, not the issuer default")
+		assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims),
+			"the resource claim is what INV-IDN-006 enforcement keys on")
+	})
+
+	t.Run("without the parameter nothing changes", func(t *testing.T) {
+		// The baseline every existing caller depends on: aud stays the issuer
+		// default and NO resource claim appears. Absence of the claim is what
+		// tells Shield the token is unbound, so an accidental empty-but-present
+		// claim would be a silent enforcement change.
+		b := clientCredsBody(t, "res-cc-none")
+
+		resp := post(t, "/oauth2/token", b, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Nil(t, resourceClaimOf(t, claims),
+			"an unbound token must carry no resource claim at all")
+		assert.NotEqual(t, []string{mcpGithub}, audienceOf(t, claims))
+	})
+
+	t.Run("array form binds every value", func(t *testing.T) {
+		b := clientCredsBody(t, "res-cc-array")
+		b["resource"] = []string{mcpGithub, mcpSlack}
+
+		resp := post(t, "/oauth2/token", b, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.ElementsMatch(t, []string{mcpGithub, mcpSlack}, audienceOf(t, claims))
+		assert.ElementsMatch(t, []string{mcpGithub, mcpSlack}, resourceClaimOf(t, claims))
+	})
+
+	t.Run("string and single-element array agree", func(t *testing.T) {
+		// The two encodings are the same request; a client should not get a
+		// different token for choosing one.
+		b1 := clientCredsBody(t, "res-cc-str")
+		b1["resource"] = mcpGithub
+		r1 := post(t, "/oauth2/token", b1, nil)
+		require.Equal(t, http.StatusOK, r1.StatusCode)
+		c1 := decodeJWTPayload(t, decode(t, r1)["access_token"].(string))
+		_ = r1.Body.Close()
+
+		b2 := clientCredsBody(t, "res-cc-arr1")
+		b2["resource"] = []string{mcpGithub}
+		r2 := post(t, "/oauth2/token", b2, nil)
+		require.Equal(t, http.StatusOK, r2.StatusCode)
+		c2 := decodeJWTPayload(t, decode(t, r2)["access_token"].(string))
+		_ = r2.Body.Close()
+
+		assert.Equal(t, audienceOf(t, c1), audienceOf(t, c2))
+		assert.Equal(t, resourceClaimOf(t, c1), resourceClaimOf(t, c2))
+	})
+}
+
+func TestResourceIndicator_Rejections(t *testing.T) {
+	cases := []struct {
+		name     string
+		resource any
+		wantErr  string
+	}{
+		{"fragment", mcpGithub + "#frag", "invalid_target"},
+		{"relative reference", "/mcp/github", "invalid_target"},
+		{"bare host", "gw.example.com/mcp", "invalid_target"},
+		{"empty string", "", "invalid_target"},
+		{"one bad value among good ones", []string{mcpGithub, "not-a-uri"}, "invalid_target"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := clientCredsBody(t, "res-reject")
+			b["resource"] = tc.resource
+
+			resp := post(t, "/oauth2/token", b, nil)
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			body := decode(t, resp)
+			_ = resp.Body.Close()
+			assert.Equal(t, tc.wantErr, body["error"])
+		})
+	}
+}
+
+// TestResourceIndicator_MutuallyExclusiveWithAudience pins the precedence rule.
+// Two meanings on one claim with no discriminator is the shape of the bug that
+// denied every MCP-targeted request in prod (shield#366); refusing the
+// combination means there is no precedence to get wrong.
+func TestResourceIndicator_MutuallyExclusiveWithAudience(t *testing.T) {
+	body := map[string]any{
+		"grant_type":    "urn:ietf:params:oauth:grant-type:token-exchange",
+		"subject_token": "external-principal-assertion",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"user_id":       uid("res-excl-user"),
+		"audience":      "codeoid",
+		"resource":      mcpGithub,
+	}
+	trusted := map[string]string{testTrustedServiceHeader: "trusted-service"}
+
+	resp := post(t, "/oauth2/token", body, trusted)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	got := decode(t, resp)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, "invalid_request", got["error"],
+		"the conflict is a malformed request, not an unknown target")
+	assert.Contains(t, got["error_description"], "mutually exclusive")
+}
+
+// TestResourceIndicator_CannotBeInjectedViaAdditionalClaims is the tripwire that
+// keeps the claim's presence load-bearing. If a caller could set `resource`
+// through the ungated additional_claims map, it could make an unbound token look
+// bound — or widen a real binding — and Shield's enforcement would be reading a
+// caller-controlled value.
+func TestResourceIndicator_CannotBeInjectedViaAdditionalClaims(t *testing.T) {
+	b := clientCredsBody(t, "res-inject")
+	b["additional_claims"] = map[string]any{"resource": []string{mcpSlack}}
+
+	resp := post(t, "/oauth2/token", b, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "reserved claims are dropped, not fatal")
+	claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+	_ = resp.Body.Close()
+
+	assert.Nil(t, resourceClaimOf(t, claims),
+		"additional_claims must never be able to forge a resource binding")
+}
+
+func TestResourceIndicator_WideningAttemptViaAdditionalClaims(t *testing.T) {
+	// Bound to github, additional_claims tries to add slack. The real binding
+	// must survive untouched.
+	b := clientCredsBody(t, "res-widen")
+	b["resource"] = mcpGithub
+	b["additional_claims"] = map[string]any{"resource": []string{mcpGithub, mcpSlack}}
+
+	resp := post(t, "/oauth2/token", b, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+	_ = resp.Body.Close()
+
+	assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims),
+		"a real binding must not be widenable through additional_claims")
+	assert.Equal(t, []string{mcpGithub}, audienceOf(t, claims))
+}
+
+// TestResourceIndicator_RefreshGrantRefusesResource pins the permanent
+// exclusion: a refresh continues an existing grant, so re-targeting a token
+// already held would skip a fresh authorization decision.
+func TestResourceIndicator_RefreshGrantRefusesResource(t *testing.T) {
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "refresh_token",
+		"refresh_token": "zid_rt_whatever",
+		"resource":      mcpGithub,
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	got := decode(t, resp)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, "invalid_target", got["error"],
+		"rejected on the resource gate, before the refresh token is even looked up")
+}
+
+// TestResourceIndicator_AuthCodeSuppressesRefreshToken proves the refresh
+// decision end-to-end. testMCPClientID is registered for the refresh_token
+// grant and normally receives one (TestAuthorizationCodeMCPFlow asserts it), so
+// the difference here is attributable to `resource` alone.
+//
+// This is the failure being prevented: the refresh path re-mints from state on
+// the refresh-token row, and the RFC 8707 binding is not on it — it lives in
+// CustomClaims, which rotation does not carry. A rotated token would come back
+// unbound with no error anywhere, so "bind to X, refresh, use anywhere" would
+// work silently and INV-IDN-006 enforcement would go quiet.
+func TestResourceIndicator_AuthCodeSuppressesRefreshToken(t *testing.T) {
+	authCodeExchange := func(t *testing.T, userID string, resource any) map[string]any {
+		t.Helper()
+		verifier, challenge := buildPKCEPair(t)
+		code := buildAuthCode(t, testMCPClientID, userID, testRedirectURI, challenge, []string{"data:read"})
+		body := map[string]any{
+			"grant_type":    "authorization_code",
+			"client_id":     testMCPClientID,
+			"code":          code,
+			"code_verifier": verifier,
+			"redirect_uri":  testRedirectURI,
+		}
+		if resource != nil {
+			body["resource"] = resource
+		}
+		resp := post(t, "/oauth2/token", body, nil)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		out := decode(t, resp)
+		_ = resp.Body.Close()
+		return out
+	}
+
+	t.Run("baseline: the same client does get a refresh token", func(t *testing.T) {
+		// Guards the test itself. Without this, a change that stopped issuing
+		// refresh tokens entirely would make the assertion below pass for the
+		// wrong reason.
+		token := authCodeExchange(t, uid("res-ac-base"), nil)
+		assert.NotEmpty(t, token["refresh_token"],
+			"an unbound authorization_code exchange must still receive a refresh token")
+	})
+
+	t.Run("resource-bound exchange receives no refresh token", func(t *testing.T) {
+		token := authCodeExchange(t, uid("res-ac-bound"), mcpGithub)
+
+		assert.NotEmpty(t, token["access_token"], "the access token is still issued")
+		assert.Empty(t, token["refresh_token"],
+			"a resource-bound token must not come with a refresh token — the binding "+
+				"is not carried across rotation, so refreshing would silently unbind it")
+
+		claims := decodeJWTPayload(t, token["access_token"].(string))
+		assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims),
+			"the access token itself is still bound")
+		assert.Equal(t, []string{mcpGithub}, audienceOf(t, claims))
+	})
+}
+
+// Form-encoded requests reuse postForm from oauth_form_compat_test.go.
+
+// TestResourceIndicator_FormEncoded covers the RFC 8707 §2 wire shape that
+// RFC 6749 §3.1 would otherwise forbid: "the parameter can be included multiple
+// times to indicate multiple resources". Before the repeatableFormFields
+// carve-out this returned `duplicate OAuth parameter: resource`, which reads to
+// an interop tester as "resource unsupported" rather than "we disagree about
+// §3.1".
+func TestResourceIndicator_FormEncoded(t *testing.T) {
+	newForm := func(t *testing.T, prefix string) url.Values {
+		t.Helper()
+		b := clientCredsBody(t, prefix)
+		return url.Values{
+			"grant_type":    {b["grant_type"].(string)},
+			"client_id":     {b["client_id"].(string)},
+			"client_secret": {b["client_secret"].(string)},
+			"account_id":    {b["account_id"].(string)},
+			"project_id":    {b["project_id"].(string)},
+			"scope":         {b["scope"].(string)},
+		}
+	}
+
+	t.Run("single occurrence binds", func(t *testing.T) {
+		f := newForm(t, "res-form-one")
+		f.Set("resource", mcpGithub)
+
+		resp := postForm(t, "/oauth2/token", f)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Equal(t, []string{mcpGithub}, resourceClaimOf(t, claims))
+	})
+
+	t.Run("repeated occurrences bind every value", func(t *testing.T) {
+		f := newForm(t, "res-form-many")
+		f["resource"] = []string{mcpGithub, mcpSlack}
+
+		resp := postForm(t, "/oauth2/token", f)
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"a conformant RFC 8707 multi-resource form request must be accepted")
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.ElementsMatch(t, []string{mcpGithub, mcpSlack}, resourceClaimOf(t, claims))
+		assert.ElementsMatch(t, []string{mcpGithub, mcpSlack}, audienceOf(t, claims))
+	})
+
+	t.Run("other duplicated parameters are still rejected", func(t *testing.T) {
+		// The carve-out must stay surgical: a repeated client_id is parameter
+		// smuggling, not a spec feature.
+		f := newForm(t, "res-form-dup")
+		f["client_id"] = []string{f.Get("client_id"), "someone-else"}
+
+		resp := postForm(t, "/oauth2/token", f)
+		defer func() { _ = resp.Body.Close() }()
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode,
+			"duplicate client_id must not be accepted")
+	})
+
+	t.Run("valueless resource is treated as omitted", func(t *testing.T) {
+		// RFC 6749 §3.2. An empty value must not bind the token to "".
+		f := newForm(t, "res-form-empty")
+		f.Set("resource", "")
+
+		resp := postForm(t, "/oauth2/token", f)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		claims := decodeJWTPayload(t, decode(t, resp)["access_token"].(string))
+		_ = resp.Body.Close()
+
+		assert.Nil(t, resourceClaimOf(t, claims),
+			"an empty resource parameter must leave the token unbound, not bound to \"\"")
+	})
+}

--- a/tests/integration/resource_indicator_test.go
+++ b/tests/integration/resource_indicator_test.go
@@ -149,6 +149,12 @@ func TestResourceIndicator_Rejections(t *testing.T) {
 		{"bare host", "gw.example.com/mcp", "invalid_target"},
 		{"empty string", "", "invalid_target"},
 		{"one bad value among good ones", []string{mcpGithub, "not-a-uri"}, "invalid_target"},
+		// Values that huma's `format: uri` would itself reject. These MUST still
+		// come back as an RFC 6749 §5.2 error object, not a binder 422 — the
+		// token endpoint's error shape is part of its contract, and an interop
+		// tester probing error handling reads the body, not just the status.
+		{"embedded space", "https://gw.example.com/mcp/a b", "invalid_target"},
+		{"control character", "https://gw.example.com/mcp/a\x7f", "invalid_target"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Closes #258. Implements `CAP-IDN-026`.

## Why

`INV-IDN-006` enforces a binding that almost nothing produces. The ID-JAG grant was the only path that stamped `resource`, and ID-JAG is not configured in prod — so the invariant was **correct and dormant**. This is the minting half: RFC 8707 §2 `resource` as a **request parameter** on `POST /oauth2/token`, available to ordinary grants with no enterprise IdP in the loop.

## What it does

| Grant | Behaviour |
|---|---|
| `jwt-bearer` (ID-JAG) | **SELECTS** — each requested value must appear in the assertion's own `resource` claim, else `invalid_target`. The client picks which MCP server; today the claim picked for it. |
| `client_credentials`, `api_key`, `token-exchange` (all 3 forks), `authorization_code` | **BINDS** — no upstream authorized set to narrow against, so the request restricts the token that would have been minted anyway. |
| `refresh_token`, CIBA, unknown/custom grants | **REFUSED** with `invalid_target`. Accepted-and-ignored is the one outcome that must never happen. |

Two claims are stamped, because they answer different questions: `aud` for RFC 8707 §2 conformance, and `resource` — the discriminator Shield's `INV-IDN-006` enforcement keys on. It cannot read `aud` for that: ZeroID stamps `aud` on every token it issues, defaulting to the issuer URL for JWT-SVID §3, so a non-empty `aud` says nothing about whether a binding exists. Reading it as if it did denied every MCP-targeted request in prod (highflame-shield#366).

## Three decisions worth reviewing explicitly

**A resource-bound request receives no refresh token.** `authorization_code` is the only bindable grant that mints one, and the refresh path re-mints from state on the refresh-token row — where the binding is not, because it lives in `CustomClaims`, which rotation does not carry. A rotated token would come back **unbound, silently**: bind to server X, refresh, use anywhere, no error at any step, and enforcement goes quiet because the discriminator claim is simply gone. Suppressing fails closed and needs no migration. Carrying it on the row (a `resource` column, mirroring migration `039`'s `audience`) is the alternative if long-lived resource-bound sessions ever have a real use case.

**`audience` and `resource` are mutually exclusive** — both on one request is `invalid_request`. `audience` names a server-defined scope profile (it widens); `resource` names a resource (it narrows). Two meanings sharing one channel with no discriminator is precisely the bug `INV-IDN-006` was narrowed to fix; this refuses to re-create it one parameter over.

**`aud` is not an authorization signal.** The parameter also sets `aud`, so on the ordinary grants the **caller chooses** that claim. "Only narrows" holds for the presence-gated `resource` claim; it does not extend to `aud`, which is an accept/reject gate. Safe because nothing on the platform authorizes on `aud` — verified across Shield, Observatory, Cerberus, Discovery and AuthN, all of which build their verifier with issuer + JWKS and leave the audience check unset. Recorded in highflame-ai/highflame-architecture#330, and `pkg/authjwt`'s `VerifierConfig.Audience` godoc is corrected here — it previously said *"Use your service identifier (e.g. `my-mcp-server`)"*, which reads as proof of intended recipient and is not.

## A spec conflict this had to resolve

RFC 8707 §2 makes `resource` **repeatable**; `oauthFormCompatMiddleware` enforced RFC 6749 §3.1's blanket "MUST NOT be included more than once". A conformant multi-resource form request was rejected with `duplicate OAuth parameter: resource` — which reads to an interop tester as "resource unsupported", not "we disagree about §3.1". Added a carve-out scoped to `/oauth2/token` and to that one field; a duplicated `client_id` is still rejected, and that is tested.

## Review found a real hole, and it is fixed here

`token-exchange` forks three ways and the grant type as a whole passes the gate. Only two forks bound. `externalIDTokenExchange` returned **200 with an unbound token** — the caller believes it is narrowed to one MCP server, Shield honours it at all of them. Structurally identical to the `jwt-bearer` ID-JAG/NHI split that *was* guarded; I saw that split and missed this one (`fdab65f`).

The bigger finding was a **test gap**: deleting the ID-JAG narrowing call left the entire suite green. Coverage is now per **issuance site** rather than per grant-type string — that is the unit that can independently forget to bind — and all six are mutation-checked. Before the fix, 2 of 5 were killed.

Adversarial review then found two more: a **userinfo component** was accepted into a resource indicator, putting a credential verbatim into a signed JWT, the credential row, the observed-resource inventory and the logs (`a231a02`); and malformed values were answered with a huma **422** rather than the RFC 6749 §5.2 error object, which had also made the service's own parse-error branch unreachable over HTTP (`70d45f2`).

## Verification

- **Exercised against a running service**, not just harnesses: an isolated ZeroID (own binary, own Postgres) — 21/21 on the ordinary grants, and 13/13 on ID-JAG narrowing against a real ES256 stub OP registered as an external issuer, including that a rejected `resource` does **not** burn the single-use `jti`.
- **Cross-repo shape check**: the exact identifier this mints, fed to Shield's `resourceAuthorizesServer` — authorizes the bound server, denies a different server behind the same gateway, denies a prefix lookalike (`github-admin` vs `github`), denies same-slug-different-origin.
- Both CI gates green after a rebase onto current `main`: 8 unit packages under `-race`, integration at ~52s.

## Lands in lockstep with the regression PR

`highflame-regression` carries `test_row_resource_as_request_parameter` as an **`xfail(strict=True)`**. The moment a build with this change reaches that environment the test XPASSes, and `strict` turns that into a suite failure. The companion PR removes the marker and adds `@pytest.mark.capability("CAP-IDN-026")`, which is what flips the catalog entry from `planned` to `implemented`.

## Known gaps, filed rather than hidden

- **#327** — `/oauth2/authorize` ignores `resource`. A client that sends it *only* there gets an unbound token. Safe today because the MCP profile requires it at both endpoints; a client following RFC 8707 §2 alone is not. The real fix persists the authorized set on the auth-code row and cross-checks at redemption — a migration, out of #258's scope. Documented on the field's OpenAPI description in the meantime.
- **highflame-firehog#628** — `oauth.expected_audience` is a single global `Option<String>` that would reject every resource-bound token if set, and can never be correct against per-slug RFC 9728 identifiers. Unset everywhere today.
- Shield's `sameOrigin` clause vs Firehog's relay path (`server_url` is the upstream URL, not the gateway origin), and Firehog's global PRM advertising a pathless `<origin>` that `resourceSlug` cannot match. Both follow-ups.
- **Issue #258 item 3** (who actually requests bound tokens) is unanswered by design — the parameter is a prerequisite either way. Item 2 (Firehog per-server RFC 9728 metadata) was **already shipped**; no Firehog work was needed.

## Not claimed

`make test` cannot pass and could not before this change — it runs `./...` at `-timeout=120s` against an integration suite that takes ~420s under `-race`. Verified against the two commands `pr-check.yml` actually runs instead. The Makefile target is stale and unrelated; left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
