### PR TITLE
feat: chains carry their root identity, and can be filtered by it

### DIFF
--- a/internal/handler/delegation.go
+++ b/internal/handler/delegation.go
@@ -40,7 +40,16 @@ type DelegationChainsInput struct {
 	// Filtering server-side is the only way to answer "does this agent have
 	// tokens in this range". A client filtering the returned page can say
 	// "not among these N" and nothing more, however large N is.
-	RootIdentityID string `query:"root_identity_id" doc:"Only chains whose ROOT credential was issued to this identity. Applied before the limit, so an empty result means the agent has no chains in the window."`
+	//
+	// The pattern admits a UUID in either case, or nothing at all. Empty is
+	// the "no filter" sentinel and has to stay valid, so it is an explicit
+	// alternative rather than an accident of a lax pattern.
+	//
+	// Validating here is not tidiness: on THIS endpoint a malformed id would
+	// otherwise match no rows and return an empty list, and an empty list
+	// here means "this agent holds no tokens in this window". A typo would
+	// read as a clean bill of health. 400 is the only honest answer.
+	RootIdentityID string `query:"root_identity_id" pattern:"^$|^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" doc:"Only chains whose ROOT credential was issued to this identity (UUID). Applied before the limit, so an empty result means the agent has no chains in the window."`
 }
 
 type DelegationChainsOutput struct {

--- a/internal/handler/delegation.go
+++ b/internal/handler/delegation.go
@@ -37,6 +37,10 @@ type DelegationChainsInput struct {
 	Since time.Time `query:"since" doc:"Lower bound on issued_at (RFC3339); defaults to until-30d"`
 	Until time.Time `query:"until" doc:"Upper bound on issued_at (RFC3339); defaults to now"`
 	Limit int       `query:"limit" default:"50" minimum:"1" maximum:"500" doc:"Maximum number of chains to return"`
+	// Filtering server-side is the only way to answer "does this agent have
+	// tokens in this range". A client filtering the returned page can say
+	// "not among these N" and nothing more, however large N is.
+	RootIdentityID string `query:"root_identity_id" doc:"Only chains whose ROOT credential was issued to this identity. Applied before the limit, so an empty result means the agent has no chains in the window."`
 }
 
 type DelegationChainsOutput struct {
@@ -71,7 +75,7 @@ func (a *API) registerDelegationRoutes(api huma.API) {
 		Method:      http.MethodGet,
 		Path:        "/delegations/chains",
 		Summary:     "List delegation chain summaries in a time window",
-		Description: "Returns one summary row per delegation tree (grouped by mission_id, falling back to root JTI for legacy credentials), ordered by last activity DESC. Defaults to the last 30 days.",
+		Description: "Returns one summary row per delegation tree (grouped by mission_id, falling back to root JTI for legacy credentials), ordered by last activity DESC. Defaults to the last 30 days. Each row carries the root credential's identity, so callers do not need a per-row /by-jti lookup. Pass root_identity_id to filter server-side, before the limit is applied.",
 		Tags:        []string{"Delegations"},
 	}, a.delegationChainsOp)
 }
@@ -120,7 +124,7 @@ func (a *API) delegationChainsOp(ctx context.Context, input *DelegationChainsInp
 		return nil, huma.Error401Unauthorized("missing tenant context")
 	}
 
-	chains, err := a.delegationSvc.ListChains(ctx, input.Since, input.Until, input.Limit, tenant.AccountID, tenant.ProjectID)
+	chains, err := a.delegationSvc.ListChains(ctx, input.Since, input.Until, input.Limit, tenant.AccountID, tenant.ProjectID, input.RootIdentityID)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to list delegation chains")
 		return nil, huma.Error500InternalServerError("failed to list delegation chains")

--- a/internal/service/delegation.go
+++ b/internal/service/delegation.go
@@ -318,7 +318,7 @@ func (s *DelegationService) WalkByJTI(ctx context.Context, jti, accountID, proje
 //
 // until defaults to now() when zero; since defaults to until - 30 days
 // when zero. Limit is clamped to [1, 500].
-func (s *DelegationService) ListChains(ctx context.Context, since, until time.Time, limit int, accountID, projectID string) ([]*postgres.ChainSummary, error) {
+func (s *DelegationService) ListChains(ctx context.Context, since, until time.Time, limit int, accountID, projectID, rootIdentityID string) ([]*postgres.ChainSummary, error) {
 	if until.IsZero() {
 		until = time.Now()
 	}
@@ -331,7 +331,7 @@ func (s *DelegationService) ListChains(ctx context.Context, since, until time.Ti
 	if limit > 500 {
 		limit = 500
 	}
-	return s.delegRepo.ListChains(ctx, accountID, projectID, since, until, limit)
+	return s.delegRepo.ListChains(ctx, accountID, projectID, since, until, limit, rootIdentityID)
 }
 
 // IdentityDepths returns the maximum delegation depth per identity for the

--- a/internal/store/postgres/delegation.go
+++ b/internal/store/postgres/delegation.go
@@ -266,12 +266,20 @@ func (r *DelegationRepository) ListChains(ctx context.Context, accountID, projec
 			AND root.project_id = ?
 		LEFT JOIN identities i
 			ON i.id = root.identity_id
-		WHERE (? = '' OR root.identity_id::text = ?)
+		WHERE (NULLIF(?, '') IS NULL OR root.identity_id = NULLIF(?, '')::uuid)
 		ORDER BY c.last_activity_at DESC
 		LIMIT ?`
 	// The filter is applied BEFORE the limit, which is the whole point: a
 	// client filtering a capped page can only ever say "not among these N",
 	// never "this agent has none".
+	//
+	// Compared as uuid, not as text. `identity_id::text = ?` would have cast
+	// away the column's type on every row — defeating the index on
+	// identity_id — and would have compared canonical lowercase output
+	// against whatever case the caller sent, so an upper-case UUID silently
+	// matched nothing. NULLIF turns the empty sentinel into NULL before the
+	// cast, so "no filter" never reaches ::uuid; the handler's pattern
+	// guarantees anything that does reach it parses.
 	if err := db.NewRaw(q, accountID, projectID, since, until,
 		accountID, projectID, rootIdentityID, rootIdentityID, limit).Scan(ctx, &rows); err != nil {
 		return nil, fmt.Errorf("list delegation chains: %w", err)

--- a/internal/store/postgres/delegation.go
+++ b/internal/store/postgres/delegation.go
@@ -51,6 +51,20 @@ type ChainSummary struct {
 	LastActivityAt  time.Time `bun:"last_activity_at"  json:"last_activity_at"`
 	CredentialCount int       `bun:"credential_count"  json:"credential_count"`
 	MaxDepth        int       `bun:"max_depth"         json:"max_depth"`
+
+	// The identity the chain was issued TO — the root credential's subject.
+	//
+	// Carried on the summary so a caller does not have to walk /by-jti once
+	// per row to find out who a chain belongs to. Studio did exactly that,
+	// turning one list request into N+1 against this service, and it is also
+	// what forced the agent filter to run client-side over a capped page:
+	// without an identity on the row, the server had nothing to filter on.
+	//
+	// Empty when the root credential predates the identity link or its
+	// identity row was deleted (identity_id is ON DELETE SET NULL).
+	RootIdentityID   string `bun:"root_identity_id"    json:"root_identity_id,omitempty"`
+	RootIdentityName string `bun:"root_identity_name"  json:"root_identity_name,omitempty"`
+	RootWimseURI     string `bun:"root_wimse_uri"      json:"root_wimse_uri,omitempty"`
 }
 
 // WalkUp returns the credential identified by startJTI plus its ancestors
@@ -205,28 +219,61 @@ func (r *DelegationRepository) WalkDownMulti(ctx context.Context, startJTIs []st
 // post-denormalization majority. The COALESCE prevents the partial
 // index from being used directly in EXPLAIN plans, but tenant-scope
 // filtering still narrows the scan to the active tenant's rows.
-func (r *DelegationRepository) ListChains(ctx context.Context, accountID, projectID string, since, until time.Time, limit int) ([]*ChainSummary, error) {
+func (r *DelegationRepository) ListChains(ctx context.Context, accountID, projectID string, since, until time.Time, limit int, rootIdentityID string) ([]*ChainSummary, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	var rows []*ChainSummary
 	db := dbOrTx(ctx, r.db)
+	// The root credential is found by jti, NOT by picking the lowest
+	// delegation_depth inside the window. chain_id is COALESCE(mission_id,
+	// jti) and mission_id IS the root jti, so this join reaches the true
+	// root even when the root credential was issued before `since` — which
+	// is the behaviour the per-row /by-jti walk had, and losing it would
+	// silently relabel long-running chains whenever the window moved.
+	//
+	// The identity join is LEFT: identity_id is ON DELETE SET NULL, and a
+	// chain whose identity has been deleted must still be listed. Dropping
+	// it would hide exactly the tokens an offboarding review is looking for.
 	const q = `
+		WITH chains AS (
+			SELECT
+				COALESCE(mission_id, jti) AS chain_id,
+				MIN(issued_at)            AS started_at,
+				MAX(issued_at)            AS last_activity_at,
+				COUNT(*)::int             AS credential_count,
+				MAX(delegation_depth)::int AS max_depth
+			FROM issued_credentials
+			WHERE account_id = ?
+			  AND project_id = ?
+			  AND issued_at >= ?
+			  AND issued_at <  ?
+			GROUP BY COALESCE(mission_id, jti)
+		)
 		SELECT
-			COALESCE(mission_id, jti) AS chain_id,
-			MIN(issued_at)            AS started_at,
-			MAX(issued_at)            AS last_activity_at,
-			COUNT(*)::int             AS credential_count,
-			MAX(delegation_depth)::int AS max_depth
-		FROM issued_credentials
-		WHERE account_id = ?
-		  AND project_id = ?
-		  AND issued_at >= ?
-		  AND issued_at <  ?
-		GROUP BY COALESCE(mission_id, jti)
-		ORDER BY MAX(issued_at) DESC
+			c.chain_id,
+			c.started_at,
+			c.last_activity_at,
+			c.credential_count,
+			c.max_depth,
+			COALESCE(root.identity_id::text, '') AS root_identity_id,
+			COALESCE(i.name, '')                 AS root_identity_name,
+			COALESCE(i.wimse_uri, '')            AS root_wimse_uri
+		FROM chains c
+		LEFT JOIN issued_credentials root
+			ON root.jti = c.chain_id
+			AND root.account_id = ?
+			AND root.project_id = ?
+		LEFT JOIN identities i
+			ON i.id = root.identity_id
+		WHERE (? = '' OR root.identity_id::text = ?)
+		ORDER BY c.last_activity_at DESC
 		LIMIT ?`
-	if err := db.NewRaw(q, accountID, projectID, since, until, limit).Scan(ctx, &rows); err != nil {
+	// The filter is applied BEFORE the limit, which is the whole point: a
+	// client filtering a capped page can only ever say "not among these N",
+	// never "this agent has none".
+	if err := db.NewRaw(q, accountID, projectID, since, until,
+		accountID, projectID, rootIdentityID, rootIdentityID, limit).Scan(ctx, &rows); err != nil {
 		return nil, fmt.Errorf("list delegation chains: %w", err)
 	}
 	return rows, nil

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -681,6 +681,97 @@ func issueRootInTenant(t *testing.T, headers map[string]string, namePrefix strin
 // TestDelegationChains_TenantIsolation pins the tenant filter on
 // /chains. A fresh tenant must see only its own chains — never another
 // tenant's, even within an overlapping time window.
+// TestDelegationChains_CarriesRootIdentity pins the field that removes the
+// N+1: each summary names the identity its root credential was issued to.
+//
+// Studio used to discover this by calling /delegations/by-jti once per row,
+// so listing 200 chains cost 201 requests against this service. If these
+// fields ever stop being populated, that loop comes back rather than the
+// screen breaking visibly — which is why it is pinned here and not left to
+// the consumer.
+func TestDelegationChains_CarriesRootIdentity(t *testing.T) {
+	headers := tenantHeaders(
+		"acct-chains-root-"+uid(""),
+		"proj-chains-root-"+uid(""),
+	)
+	identityID, jti := issueRootInTenantWithIdentity(t, headers, "chains-root")
+
+	body := decode(t, get(t, adminPath("/delegations/chains?limit=100"), headers))
+	chains, _ := body["chains"].([]any)
+	require.Len(t, chains, 1)
+
+	first := chains[0].(map[string]any)
+	require.Equal(t, jti, first["chain_id"])
+	assert.Equal(t, identityID, first["root_identity_id"],
+		"the summary must name the identity the root credential was issued to")
+	assert.NotEmpty(t, first["root_wimse_uri"], "the root identity join must resolve")
+}
+
+// TestDelegationChains_FilterByRootIdentity pins the filter, and pins that it
+// runs BEFORE the limit.
+//
+// That ordering is the whole value: a client filtering the returned page can
+// only ever conclude "not among these N", while an empty response to this
+// filter means the agent genuinely has no chains in the window. A filter
+// applied after LIMIT would look identical in a small fixture and be wrong in
+// production, so the limit here is deliberately set to 1 and the wanted chain
+// is issued FIRST — making it the older one, which limit=1 alone would drop.
+func TestDelegationChains_FilterByRootIdentity(t *testing.T) {
+	headers := tenantHeaders(
+		"acct-chains-filter-"+uid(""),
+		"proj-chains-filter-"+uid(""),
+	)
+	wantedID, wantedJTI := issueRootInTenantWithIdentity(t, headers, "chains-wanted")
+	issueRootInTenantWithIdentity(t, headers, "chains-other")
+
+	body := decode(t, get(t,
+		adminPath("/delegations/chains?limit=1&root_identity_id="+url.QueryEscape(wantedID)),
+		headers))
+	chains, _ := body["chains"].([]any)
+	require.Len(t, chains, 1, "the filter must reach the query, not the returned page")
+	assert.Equal(t, wantedJTI, chains[0].(map[string]any)["chain_id"],
+		"limit=1 returned the newest chain, so the filter was applied after the limit")
+
+	// An identity with no chains answers empty, which is a FINDING rather
+	// than "not on this page".
+	none := decode(t, get(t,
+		adminPath("/delegations/chains?limit=100&root_identity_id="+uuid.NewString()),
+		headers))
+	noneChains, _ := none["chains"].([]any)
+	assert.Empty(t, noneChains)
+}
+
+// issueRootInTenantWithIdentity is issueRootInTenant plus the identity id,
+// which the root-identity tests assert on.
+func issueRootInTenantWithIdentity(t *testing.T, headers map[string]string, namePrefix string) (identityID, jti string) {
+	t.Helper()
+	extID := uid(namePrefix)
+	body := map[string]any{
+		"external_id":    extID,
+		"trust_level":    "unverified",
+		"owner_user_id":  "user-test-owner",
+		"allowed_scopes": []string{"data:read"},
+	}
+	idResp := post(t, adminPath("/identities"), body, headers)
+	require.Equal(t, http.StatusCreated, idResp.StatusCode)
+	identityID = decode(t, idResp)["id"].(string)
+
+	client := registerOAuthClient(t, extID, []string{"data:read"})
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    headers["X-Account-ID"],
+		"project_id":    headers["X-Project-ID"],
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return identityID, decodeJWTUnsafe(t, decode(t, resp)["access_token"].(string))["jti"].(string)
+}
+
+// TestDelegationChains_TenantIsolation pins the tenant filter on
+// /chains. A fresh tenant must see only its own chains — never another
+// tenant's, even within an overlapping time window.
 func TestDelegationChains_TenantIsolation(t *testing.T) {
 	tenantA := tenantHeaders(
 		"acct-chains-iso-a-"+uid(""),

--- a/tests/integration/delegation_test.go
+++ b/tests/integration/delegation_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -739,6 +740,17 @@ func TestDelegationChains_FilterByRootIdentity(t *testing.T) {
 		headers))
 	noneChains, _ := none["chains"].([]any)
 	assert.Empty(t, noneChains)
+
+	// UUIDs are case-insensitive, and the comparison must be too. This
+	// passed only once the filter stopped comparing identity_id::text —
+	// Postgres renders a uuid lowercase, so an upper-case id matched nothing
+	// and produced the very false negative this filter exists to remove.
+	upper := decode(t, get(t,
+		adminPath("/delegations/chains?limit=100&root_identity_id="+url.QueryEscape(strings.ToUpper(wantedID))),
+		headers))
+	upperChains, _ := upper["chains"].([]any)
+	require.Len(t, upperChains, 1, "an upper-case UUID must match the same chain")
+	assert.Equal(t, wantedJTI, upperChains[0].(map[string]any)["chain_id"])
 }
 
 // issueRootInTenantWithIdentity is issueRootInTenant plus the identity id,
@@ -912,6 +924,31 @@ func TestDelegationChains_InvalidParams_Rejected(t *testing.T) {
 		assert.Less(t, resp.StatusCode, 500,
 			"param %s must NOT 500", bad)
 	}
+
+	// A malformed root_identity_id must be REJECTED, not treated as a filter
+	// that matches nothing. An empty chain list on this endpoint means "this
+	// agent holds no tokens in this window", so a typo answering 200 with []
+	// reads as a clean bill of health.
+	for _, bad := range []string{
+		"not-a-uuid",
+		"12345",
+		"0000-0000",
+		strings.Repeat("a", 40),
+	} {
+		resp := get(t, adminPath("/delegations/chains?root_identity_id="+url.QueryEscape(bad)), adminHeaders())
+		_ = resp.Body.Close()
+		assert.GreaterOrEqual(t, resp.StatusCode, 400,
+			"root_identity_id=%s must be rejected with 4xx, never answered with an empty list", bad)
+		assert.Less(t, resp.StatusCode, 500,
+			"root_identity_id=%s must NOT 500", bad)
+	}
+
+	// Empty stays valid: it is the "no filter" sentinel, and a client that
+	// clears its agent picker sends exactly this.
+	resp := get(t, adminPath("/delegations/chains?root_identity_id="), adminHeaders())
+	_ = resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"an empty root_identity_id means no filter and must not be rejected")
 }
 
 // TestDelegationGraph_SiblingsVisibleInFullTree verifies that the


### PR DESCRIPTION
Two defects in Studio's Issued Tokens screen ([highflame-studio#1587 audit](https://github.com/highflame-ai/highflame-studio/pull/1587)) trace back to one gap here: `ChainSummary` names no identity.

**1. N+1 against this service.** With no identity on the row, Studio walks `/delegations/by-jti` once per chain to find out who each belongs to. Listing 200 chains costs 201 requests, so Studio has had to cap the list at 100 to stay responsive — a cap operators can see.

**2. A filter that cannot answer its own question.** With nothing to filter on server-side, "show me this agent's tokens" runs client-side over the capped page. An empty result means "not among these N", but the screen renders it as *"no tokens issued to this agent"* — a false negative on a forensics screen.

## What changed

`ChainSummary` gains `root_identity_id`, `root_identity_name`, `root_wimse_uri`, and `ListChains` accepts `root_identity_id` as a filter.

The root is resolved **through jti** — joining on `COALESCE(mission_id, jti)`, since `mission_id` *is* the root jti — rather than by picking the shallowest credential inside the window. That distinction matters: the root credential of a long-running chain is often issued before `since`, and picking within the window would silently relabel chains as the range moved. It also matches what the per-row `/by-jti` walk returns today, so consumers see no behaviour change beyond the new fields.

The identity join is `LEFT`: `identity_id` is `ON DELETE SET NULL`, and a chain whose identity was deleted must still list — those are exactly the tokens an offboarding review is looking for.

**The filter runs before `LIMIT`.** That ordering is the entire value: an empty response becomes a finding rather than a statement about one page.

## Tests

Two integration tests. The filter test issues the wanted chain **first** (making it the older one) and asks for `limit=1`, so a filter applied after the limit fails rather than passing on a small fixture.

## Downstream

Once released, Studio drops the enrichment loop in its chains route, passes the agent filter to the server, and can raise its row cap again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)