### PR TITLE
fix: refuse an unauthorized explicit scope request instead of narrowing it to nothing

### DIFF
--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -452,6 +452,7 @@ func (a *API) authorizeHandler(w http.ResponseWriter, r *http.Request) {
 		UserID:              principal.UserID,
 		OrgID:               principal.OrgID,
 		Scopes:              scopes,
+		RequestedScope:      req.Scope,
 		Resources:           resourceCeiling,
 		Client:              oauthClient,
 	})

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -655,6 +655,9 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 
 	// Parse and intersect requested scopes with the client's allowed scopes.
 	scopes := intersectScopes(parseScopeString(req.Scope), client.Scopes)
+	if err := requireGrantableScope(req.Scope, scopes); err != nil {
+		return nil, err
+	}
 
 	// Resolve the identity for this client (external_id == client_id within the tenant).
 	// Tenant comes from the token request — client registration is global.
@@ -804,6 +807,9 @@ func (s *OAuthService) jwtBearer(ctx context.Context, req TokenRequest) (*domain
 		return nil, oauthServerError("failed to resolve identity credential policy", err)
 	}
 	scopes := intersectScopes(parseScopeString(req.Scope), effectiveAllowedScopes(policy, identity))
+	if err := requireGrantableScope(req.Scope, scopes); err != nil {
+		return nil, err
+	}
 
 	accessToken, _, err := s.credentialSvc.IssueCredential(ctx, IssueRequest{
 		Identity:          identity,
@@ -1474,6 +1480,9 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 	scopes = intersectScopes(scopes, identityPolicyScopes)
 	if len(identityPolicyScopes) == 0 && identity != nil {
 		scopes = intersectScopes(scopes, identity.AllowedScopes)
+	}
+	if err := requireGrantableScope(req.Scope, scopes); err != nil {
+		return nil, err
 	}
 
 	issue := IssueRequest{
@@ -2922,6 +2931,30 @@ func effectiveAllowedScopes(policy *domain.CredentialPolicy, identity *domain.Id
 		return identity.AllowedScopes
 	}
 	return nil
+}
+
+// requireGrantableScope closes the gap between intersectScopes' silent
+// narrowing and IssueCredential's "if len(req.Scopes) > 0" claim-omission
+// (credential.go): when a caller explicitly names a scope and every named
+// scope gets intersected away, minting anyway produces a token with no
+// `scopes` claim at all — indistinguishable downstream from a legacy token
+// that predates the scopes feature. Shield's checkScopeCeiling deliberately
+// treats an absent claim as "check not applicable" for that legacy case (see
+// its own comment), so a caller could otherwise escalate past its ceiling
+// simply by naming a scope it does not hold.
+//
+// Mirrors tokenExchange's existing "len(scopes) == 0 -> invalid_scope"
+// safety net (this file, tokenExchange), extended to the three grants that
+// mint a token for the caller's own use rather than delegating to another
+// identity. A caller that asks for nothing (requestedRaw == "") is
+// unaffected: intersectScopes' RFC 6749 §3.3 default (empty request grants
+// the full ceiling) still applies, and so does an identity/client with a
+// genuinely empty ceiling and no explicit ask.
+func requireGrantableScope(requestedRaw string, granted []string) error {
+	if requestedRaw == "" || len(granted) > 0 {
+		return nil
+	}
+	return oauthBadRequest(oautherror.InvalidScope, "requested scopes are not permitted for this identity")
 }
 
 // intersectScopes returns the subset of requested scopes that are in the allowed set.

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -653,12 +653,6 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 		return nil, oauthBadRequest(oautherror.InvalidScope, "client is registered with no scopes and cannot be granted any")
 	}
 
-	// Parse and intersect requested scopes with the client's allowed scopes.
-	scopes := intersectScopes(parseScopeString(req.Scope), client.Scopes)
-	if err := requireGrantableScope(req.Scope, scopes); err != nil {
-		return nil, err
-	}
-
 	// Resolve the identity for this client (external_id == client_id within the tenant).
 	// Tenant comes from the token request — client registration is global.
 	identity, err := s.identitySvc.repo.GetByExternalID(ctx, req.ClientID, req.AccountID, req.ProjectID)
@@ -676,9 +670,32 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 	// the chokepoint can't enforce TTL, scope, delegation-depth, trust-
 	// level, or policy-expiry caps for client_credentials. Mirrors the
 	// pattern used in jwt_bearer / token_exchange / api_key.
+	//
+	// Resolved BEFORE the scope grant is computed (rather than after, as
+	// before) so its AllowedScopes narrows the grant here too — not only
+	// deep inside IssueCredential's EnforcePolicy/dual-read checks, which
+	// hard-reject the whole request instead of narrowing, and would
+	// otherwise let this grant say "grantable" while IssueCredential still
+	// refuses the same request for the same underlying reason.
 	policy, err := s.identitySvc.ResolveCredentialPolicy(ctx, identity)
 	if err != nil {
 		return nil, oauthServerError("failed to resolve identity credential policy", err)
+	}
+
+	// Narrow against the client's own scopes first (checked above: a
+	// client with none can mint nothing), then against the identity's
+	// policy ceiling. Same narrow/intersectScopes selection rule as
+	// apiKeyGrant: decided once from the caller's true original request,
+	// not re-decided per step.
+	rawRequested := parseScopeString(req.Scope)
+	narrow := intersectScopes
+	if len(rawRequested) > 0 {
+		narrow = narrowScopes
+	}
+	scopes := narrow(rawRequested, client.Scopes)
+	scopes = narrow(scopes, effectiveAllowedScopes(policy, identity))
+	if err := requireGrantableScope(req.Scope, scopes); err != nil {
+		return nil, err
 	}
 
 	issue := IssueRequest{
@@ -1459,10 +1476,26 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 	//     ∩ key.policy.allowed_scopes (per-credential restriction)
 	//     ∩ identity.policy.allowed_scopes (authority ceiling)
 	//     ∩ identity.allowed_scopes  (deprecated fallback when policies are wide open)
-	// intersectScopes treats an empty allowed list as "no restriction" so
-	// chaining naturally short-circuits layers that don't restrict.
-	scopes := parseScopeString(req.Scope)
-	scopes = intersectScopes(scopes, sk.Scopes)
+	//
+	// Which composing function narrows each step is decided ONCE, from the
+	// caller's true original request, not re-decided per step: intersectScopes
+	// treats an empty *requested* argument as "caller omitted scope, grant the
+	// full ceiling" (RFC 6749 §3.3's default) — correct for the very first
+	// application against a genuinely omitted request, but wrong if fed an
+	// intermediate result that became empty because an EARLIER ceiling in this
+	// chain actually denied it: the next intersectScopes call would reinterpret
+	// that denial as "nothing was asked" and reset to its own full ceiling,
+	// silently granting scopes an earlier layer explicitly excluded. Once the
+	// request is known to be explicit, every step uses narrowScopes instead,
+	// which has no such reinterpretation and lets a real denial propagate to
+	// the end of the chain instead of being undone by the next ceiling.
+	rawRequested := parseScopeString(req.Scope)
+	narrow := intersectScopes
+	if len(rawRequested) > 0 {
+		narrow = narrowScopes
+	}
+	scopes := rawRequested
+	scopes = narrow(scopes, sk.Scopes)
 	if sk.CredentialPolicyID != "" && s.credentialSvc.policySvc != nil {
 		// Hard fail rather than silently skip the intersection: a
 		// transient DB error during scope resolution must not widen
@@ -1475,11 +1508,11 @@ func (s *OAuthService) apiKeyGrant(ctx context.Context, req TokenRequest) (*doma
 		if err != nil {
 			return nil, oauthServerError("failed to resolve API key credential policy", err)
 		}
-		scopes = intersectScopes(scopes, kp.AllowedScopes)
+		scopes = narrow(scopes, kp.AllowedScopes)
 	}
-	scopes = intersectScopes(scopes, identityPolicyScopes)
+	scopes = narrow(scopes, identityPolicyScopes)
 	if len(identityPolicyScopes) == 0 && identity != nil {
-		scopes = intersectScopes(scopes, identity.AllowedScopes)
+		scopes = narrow(scopes, identity.AllowedScopes)
 	}
 	if err := requireGrantableScope(req.Scope, scopes); err != nil {
 		return nil, err
@@ -1577,8 +1610,24 @@ type IssueAuthCodeRequest struct {
 	// OAuth client's registered Scopes — a code can never authorize a
 	// scope the client itself isn't allowed. Empty means "no
 	// resolver-side narrowing"; the client's full registered scope
-	// surface is encoded.
+	// surface is encoded — UNLESS RequestedScope shows the caller asked
+	// explicitly, in which case empty means a real denial and the code
+	// refuses instead.
 	Scopes []string
+
+	// RequestedScope is the raw, unparsed `scope` value the caller supplied
+	// at /oauth2/authorize, before any resolver-side narrowing folded it
+	// into Scopes above. It exists only to tell apart two states that look
+	// identical once collapsed into Scopes==[]: "the caller never asked for
+	// a scope" (default to the client's full registered surface, RFC 6749
+	// §3.3) and "the caller asked explicitly, and narrowing upstream
+	// already denied it" (refuse — resetting to the client's full surface
+	// here would silently grant scopes the caller was just denied).
+	//
+	// Optional. A caller that leaves it empty (including every existing
+	// caller of this exported function predating this field) gets the
+	// pre-existing behavior: Scopes==[] is always read as "omitted."
+	RequestedScope string
 
 	// Resources is the RFC 8707 resource ceiling the resource owner
 	// consented to, baked into the code's "rsc" claim (CAP-IDN-027).
@@ -1852,15 +1901,23 @@ func (s *OAuthService) IssueAuthCode(ctx context.Context, req IssueAuthCodeReque
 		return "", err
 	}
 
-	// Scope intersection: the issued code can never authorize a scope
-	// the client itself isn't allowed. Empty req.Scopes means
-	// "no resolver-side narrowing" — pass through the client's full
-	// registered surface.
-	scopes := req.Scopes
-	if len(scopes) == 0 {
-		scopes = oauthClient.Scopes
-	} else {
-		scopes = intersectScopes(scopes, oauthClient.Scopes)
+	// Scope intersection: the issued code can never authorize a scope the
+	// client itself isn't allowed. Which meaning req.Scopes==[] carries is
+	// decided by RequestedScope, not re-derived from req.Scopes itself —
+	// req.Scopes alone cannot tell "no resolver-side narrowing happened"
+	// (pass through the client's full surface, RFC 6749 §3.3) apart from "the
+	// caller asked explicitly and narrowing upstream already denied it"
+	// (refuse). Collapsing both into "empty means unrestricted" is exactly
+	// the escalation class the self-mint grants (apiKeyGrant et al.) were
+	// fixed for elsewhere in this file: a denial silently reinterpreted as an
+	// omitted request and reset to a wider ceiling.
+	narrow := intersectScopes
+	if len(parseScopeString(req.RequestedScope)) > 0 {
+		narrow = narrowScopes
+	}
+	scopes := narrow(req.Scopes, oauthClient.Scopes)
+	if err := requireGrantableScope(req.RequestedScope, scopes); err != nil {
+		return "", err
 	}
 
 	// Validate the consented resource ceiling here as well as in the handler
@@ -2944,17 +3001,56 @@ func effectiveAllowedScopes(policy *domain.CredentialPolicy, identity *domain.Id
 // simply by naming a scope it does not hold.
 //
 // Mirrors tokenExchange's existing "len(scopes) == 0 -> invalid_scope"
-// safety net (this file, tokenExchange), extended to the three grants that
-// mint a token for the caller's own use rather than delegating to another
-// identity. A caller that asks for nothing (requestedRaw == "") is
-// unaffected: intersectScopes' RFC 6749 §3.3 default (empty request grants
-// the full ceiling) still applies, and so does an identity/client with a
-// genuinely empty ceiling and no explicit ask.
+// safety net (this file, tokenExchange), extended to the grants that mint a
+// token for the caller's own use rather than delegating to another identity.
+// A caller that asks for nothing is unaffected: intersectScopes' RFC 6749
+// §3.3 default (empty request grants the full ceiling) still applies, and so
+// does an identity/client with a genuinely empty ceiling and no explicit
+// ask.
+//
+// requestedRaw is tested via parseScopeString rather than `== ""` so a
+// whitespace-only value (e.g. "scope=\" \"") is treated identically to an
+// omitted one everywhere a caller's "did they actually ask for something"
+// decision is made — narrowScopes/intersectScopes selection above and this
+// check must agree, or a malformed-but-technically-non-empty scope string
+// gets a different answer depending on which one happens to run.
 func requireGrantableScope(requestedRaw string, granted []string) error {
-	if requestedRaw == "" || len(granted) > 0 {
+	if len(parseScopeString(requestedRaw)) == 0 || len(granted) > 0 {
 		return nil
 	}
 	return oauthBadRequest(oautherror.InvalidScope, "requested scopes are not permitted for this identity")
+}
+
+// narrowScopes filters `granted` — a scope set already known to reflect a
+// real, explicit caller request, never "caller asked for nothing" — against
+// one ceiling. Unlike intersectScopes, an empty `granted` stays empty: it
+// never reinterprets that as an omitted request and falls back to `ceiling`.
+//
+// This is what a chain of ceilings needs and intersectScopes alone cannot
+// provide: composing plain intersectScopes calls treats an empty
+// *intermediate* result — a real denial from an earlier ceiling in the
+// chain — as "nothing was asked" and resets to the next ceiling's full set,
+// silently undoing that denial (see apiKeyGrant, which chains up to four).
+// narrowScopes has no such special case, so a denial anywhere in the chain
+// propagates to the end instead of being reset by the next step.
+//
+// An empty ceiling means "no restriction from this layer," same as
+// intersectScopes.
+func narrowScopes(granted, ceiling []string) []string {
+	if len(ceiling) == 0 {
+		return granted
+	}
+	set := make(map[string]bool, len(ceiling))
+	for _, s := range ceiling {
+		set[s] = true
+	}
+	var kept []string
+	for _, s := range granted {
+		if set[s] {
+			kept = append(kept, s)
+		}
+	}
+	return kept
 }
 
 // intersectScopes returns the subset of requested scopes that are in the allowed set.

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -356,6 +356,9 @@ func runTests(m *testing.M) int {
 	//   test_principal_account → AccountID (required to "apply")
 	//   test_principal_project → ProjectID
 	//   test_principal_user    → UserID
+	//   test_principal_scopes  → Scopes (space-separated; empty means the
+	//                            principal has no scope restriction of its
+	//                            own — see Principal.Scopes)
 	//   test_principal_reject  → "true" returns a non-sentinel error
 	//   (anything else)        → ErrPrincipalNotApplicable
 	//
@@ -373,6 +376,7 @@ func runTests(m *testing.M) int {
 			AccountID: acct,
 			ProjectID: req.Form("test_principal_project"),
 			UserID:    req.Form("test_principal_user"),
+			Scopes:    strings.Fields(req.Form("test_principal_scopes")),
 		}, nil
 	})
 

--- a/tests/integration/scope_escalation_test.go
+++ b/tests/integration/scope_escalation_test.go
@@ -1,0 +1,159 @@
+package integration_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression coverage for the self-mint scope escalation: apiKeyGrant,
+// clientCredentials and jwtBearer used to silently narrow an unauthorized
+// requested scope down to an empty set and mint anyway. IssueCredential
+// omits the `scopes` claim entirely when the granted set is empty
+// (credential.go: `if len(req.Scopes) > 0`), and Shield's checkScopeCeiling
+// deliberately treats an absent claim as "check not applicable" — a
+// backward-compat allowance for tokens minted before the scopes feature
+// existed. The two behaviors compose into an escalation: an identity with
+// allowed_scopes=["tools:read"] that explicitly asked for "tools:execute"
+// got a token Shield would enforce NOTHING against, rather than one it
+// would deny call_tool on.
+//
+// The fix (requireGrantableScope in oauth.go) mirrors tokenExchange's
+// existing "empty result -> invalid_scope" safety net, extended to the
+// three grants that mint a token for the caller's own use.
+
+// TestAPIKeyGrant_UnauthorizedScopeRequestRejected is the exact repro:
+// an identity registered with allowed_scopes=["tools:read"] asks the
+// api_key grant for "tools:execute" and must be refused outright, not
+// handed a token with no scopes claim at all.
+func TestAPIKeyGrant_UnauthorizedScopeRequestRejected(t *testing.T) {
+	externalID := uid("apikey-scope-escalation")
+	resp := post(t, adminPath("/agents/register"), map[string]any{
+		"name":           externalID,
+		"external_id":    externalID,
+		"sub_type":       "tool_agent",
+		"trust_level":    "first_party",
+		"created_by":     "test-user",
+		"allowed_scopes": []string{"tools:read"},
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	reg := decode(t, resp)
+	apiKey, _ := reg["api_key"].(string)
+	require.NotEmpty(t, apiKey)
+
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+		"scope":      "tools:execute",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, tokenResp.StatusCode,
+		"requesting a scope outside allowed_scopes must be rejected, not silently minted with no scopes claim")
+	body := decode(t, tokenResp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestAPIKeyGrant_AuthorizedScopeRequestGranted pins the normal narrowing
+// path: requesting a scope that IS in allowed_scopes still mints, and mints
+// exactly that scope (not the full ceiling). Unaffected by the fix.
+func TestAPIKeyGrant_AuthorizedScopeRequestGranted(t *testing.T) {
+	externalID := uid("apikey-scope-ok")
+	resp := post(t, adminPath("/agents/register"), map[string]any{
+		"name":           externalID,
+		"external_id":    externalID,
+		"sub_type":       "tool_agent",
+		"trust_level":    "first_party",
+		"created_by":     "test-user",
+		"allowed_scopes": []string{"tools:read", "tools:execute"},
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	apiKey, _ := decode(t, resp)["api_key"].(string)
+	require.NotEmpty(t, apiKey)
+
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+		"scope":      "tools:read",
+	}, nil)
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+	token := decode(t, tokenResp)
+	assert.Equal(t, "tools:read", token["scope"], "scope should be capped at requested value")
+}
+
+// TestAPIKeyGrant_NoScopeRequestGetsFullCeiling pins the RFC 6749 §3.3
+// default: omitting scope entirely still grants the full ceiling. The fix
+// only rejects an EXPLICIT request that resolves to nothing — an absent
+// request is untouched.
+func TestAPIKeyGrant_NoScopeRequestGetsFullCeiling(t *testing.T) {
+	externalID := uid("apikey-scope-default")
+	resp := post(t, adminPath("/agents/register"), map[string]any{
+		"name":           externalID,
+		"external_id":    externalID,
+		"sub_type":       "tool_agent",
+		"trust_level":    "first_party",
+		"created_by":     "test-user",
+		"allowed_scopes": []string{"tools:read", "tools:execute"},
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	apiKey, _ := decode(t, resp)["api_key"].(string)
+	require.NotEmpty(t, apiKey)
+
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+	}, nil)
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+	token := decode(t, tokenResp)
+	scope, _ := token["scope"].(string)
+	assert.Contains(t, scope, "tools:read")
+	assert.Contains(t, scope, "tools:execute")
+}
+
+// TestClientCredentials_UnauthorizedScopeRequestRejected is the
+// client_credentials sibling: a client registered with a non-empty but
+// narrower scope set (as opposed to TestOAuthAuthzHardening_
+// ScopelessClientCannotWiden's zero-scope case, which takes a separate
+// explicit-deny branch and never reached intersectScopes) must refuse a
+// request for a scope outside that set.
+func TestClientCredentials_UnauthorizedScopeRequestRejected(t *testing.T) {
+	agentID := uid("cc-scope-escalation")
+	registerIdentity(t, agentID, []string{"data:read"})
+	client := registerOAuthClient(t, agentID, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "data:write",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"requesting a scope outside the client's registered scopes must be rejected")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestJWTBearer_UnauthorizedScopeRequestRejected is the jwt_bearer sibling.
+func TestJWTBearer_UnauthorizedScopeRequestRejected(t *testing.T) {
+	agentKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	agentID := uid("jwtb-scope-escalation")
+	identity := registerIdentity(t, agentID, []string{"data:read"}, ecPublicKeyPEM(t, agentKey))
+	assertion := buildAssertion(t, agentKey, identity.WIMSEURI)
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+		"assertion":  assertion,
+		"scope":      "data:write",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"jwt_bearer requesting a scope outside allowed_scopes must be rejected")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}

--- a/tests/integration/scope_escalation_test.go
+++ b/tests/integration/scope_escalation_test.go
@@ -1,12 +1,15 @@
 package integration_test
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"net/http"
+	"net/url"
 	"testing"
 
+	zeroid "github.com/highflame-ai/zeroid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,4 +159,166 @@ func TestJWTBearer_UnauthorizedScopeRequestRejected(t *testing.T) {
 		"jwt_bearer requesting a scope outside allowed_scopes must be rejected")
 	body := decode(t, resp)
 	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestAPIKeyGrant_ChainedCeilingDenialSurvivesReWidening is the exact repro
+// for the class of bug the first pass of this fix missed: apiKeyGrant chains
+// up to four ceilings (key scopes, key policy, identity policy, legacy
+// identity.allowed_scopes). Composing them with plain intersectScopes let a
+// real denial at an early step be reinterpreted by the NEXT step as "caller
+// asked for nothing" and reset to that step's full (wider) ceiling —
+// resurrecting a scope an earlier layer explicitly excluded, and even
+// granting scopes that were never requested at all.
+//
+// Here: the API key's own scopes=["tools:read"] denies tools:execute at the
+// first step. The identity's credential policy is wider
+// (["tools:read","tools:execute","tools:admin"]). Before the fix, that
+// denial reset at the policy step and the token minted with
+// tools:execute AND tools:admin — the latter never even asked for.
+func TestAPIKeyGrant_ChainedCeilingDenialSurvivesReWidening(t *testing.T) {
+	identityPolicyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("chain-id-cp"),
+		"allowed_grant_types":  []string{"api_key"},
+		"allowed_scopes":       []string{"tools:read", "tools:execute", "tools:admin"},
+		"max_delegation_depth": 1,
+		"max_ttl_seconds":      3600,
+	}, adminHeaders())
+
+	identityID := registerIdentityWithPolicy(t, uid("chain-target"), identityPolicyID, "", nil, adminHeaders())
+
+	headers := adminHeaders()
+	headers["X-User-ID"] = "test-user"
+	keyResp := post(t, adminPath("/api-keys"), map[string]any{
+		"name": "chain-key",
+		// Same policy as the identity (a subset of itself, so key creation's
+		// own subset-invariant check passes trivially) — the point of this
+		// test is the sk.Scopes-vs-policy CHAIN, not the policy check.
+		"credential_policy_id": identityPolicyID,
+		"identity_id":          identityID,
+		"scopes":               []string{"tools:read"}, // the key's OWN, narrower restriction
+	}, headers)
+	require.Equal(t, http.StatusCreated, keyResp.StatusCode)
+	apiKey, _ := decode(t, keyResp)["key"].(string)
+	require.NotEmpty(t, apiKey)
+
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+		"scope":      "tools:execute",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, tokenResp.StatusCode,
+		"a denial at the key-scopes step must survive the identity-policy step, not be reinterpreted as an omitted request and reset to the policy's full scope set")
+	body := decode(t, tokenResp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestClientCredentials_IdentityPolicyNarrowsClientScopes covers the Oracle
+// review comment on this PR: clientCredentials computed its grant from
+// client.Scopes alone, never intersecting the linked identity's credential
+// policy at this layer the way apiKeyGrant/jwtBearer do — so a request could
+// pass this function's own check and only then get a differently-shaped
+// hard rejection deeper inside IssueCredential's EnforcePolicy, for what is
+// conceptually the identical failure the other two grants report as
+// invalid_scope. The client here is registered wider than the identity's
+// policy on purpose.
+func TestClientCredentials_IdentityPolicyNarrowsClientScopes(t *testing.T) {
+	identityPolicyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("cc-policy-cp"),
+		"allowed_grant_types":  []string{"client_credentials"},
+		"allowed_scopes":       []string{"tools:read"},
+		"max_delegation_depth": 1,
+		"max_ttl_seconds":      3600,
+	}, adminHeaders())
+
+	clientID := uid("cc-policy-client")
+	registerIdentityWithPolicy(t, clientID, identityPolicyID, "", nil, adminHeaders())
+	client := registerOAuthClient(t, clientID, []string{"tools:execute", "tools:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		"scope":         "tools:execute",
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"a scope the client is registered for but the linked identity's credential policy excludes must be rejected by this grant, not just by a deeper, differently-shaped chokepoint check")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestAuthorizationCode_UnauthorizedScopeRequestRejected is the fourth grant
+// path the first pass of this fix missed entirely: /oauth2/authorize's
+// principal resolver narrows to a real denial, but IssueAuthCode's old
+// "empty means no resolver-side narrowing" read reinterpreted that denial as
+// an omitted request and substituted the OAuth CLIENT's entire registered
+// scope surface — worse than the other three grants' bug, since it doesn't
+// just omit the scopes claim, it actively widens to scopes (tools:admin
+// here) the caller never asked for and the principal never held.
+func TestAuthorizationCode_UnauthorizedScopeRequestRejected(t *testing.T) {
+	clientID := uid("authz-code-scope-escalation")
+	err := testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:     clientID,
+		Name:         clientID + "-test-client",
+		GrantTypes:   []string{"authorization_code"},
+		Scopes:       []string{"tools:read", "tools:execute", "tools:admin"},
+		RedirectURIs: []string{testRedirectURI},
+	})
+	require.NoError(t, err)
+
+	// The request is expected to fail before a code is ever issued, so
+	// there is no verifier to redeem it with later.
+	_, challenge := buildPKCEPair(t)
+	form := url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {testRedirectURI},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"authz-code-scope-escalation-state"},
+		"scope":                 {"tools:execute"},
+		// Stub PrincipalResolver: the principal itself only holds tools:read,
+		// so tools:execute is a real, explicit denial at the resolver layer —
+		// not an omission.
+		"test_principal_account": {testAccountID},
+		"test_principal_project": {testProjectID},
+		"test_principal_user":    {"user-authz-code-scope-test"},
+		"test_principal_scopes":  {"tools:read"},
+	}
+
+	resp := postAuthorize(t, form)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"a scope the principal was denied must refuse the authorization code outright, not substitute the client's entire registered scope surface")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestAPIKeyGrant_WhitespaceOnlyScopeTreatedAsOmitted pins the fix to
+// requireGrantableScope's raw-string-vs-parsed-emptiness mismatch: a
+// whitespace-only scope parameter now parses to zero tokens (via
+// parseScopeString/strings.Fields) exactly like an omitted one, everywhere
+// that decision is made, so it can no longer produce a false rejection for
+// an identity with no scope ceiling configured.
+func TestAPIKeyGrant_WhitespaceOnlyScopeTreatedAsOmitted(t *testing.T) {
+	externalID := uid("apikey-scope-whitespace")
+	resp := post(t, adminPath("/agents/register"), map[string]any{
+		"name":        externalID,
+		"external_id": externalID,
+		"sub_type":    "tool_agent",
+		"trust_level": "first_party",
+		"created_by":  "test-user",
+		// No allowed_scopes: this identity has no scope ceiling of its own.
+	}, adminHeaders())
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	apiKey, _ := decode(t, resp)["api_key"].(string)
+	require.NotEmpty(t, apiKey)
+
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type": "api_key",
+		"api_key":    apiKey,
+		"scope":      " ",
+	}, nil)
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode,
+		"a whitespace-only scope must be treated the same as an omitted one, not falsely rejected")
 }


### PR DESCRIPTION
## Summary
- `apiKeyGrant`, `clientCredentials`, and `jwtBearer` now refuse with `invalid_scope` when a caller explicitly names a scope and the post-intersection result is empty, instead of silently minting a token with no `scopes` claim at all.
- New helper `requireGrantableScope` mirrors `tokenExchange`'s existing "empty result → invalid_scope" safety net, extended to the three grants that mint a token for the caller's own use.
- An omitted `scope` parameter is unaffected — RFC 6749 §3.3's default (grant the full ceiling) still applies, as does an identity/client with a genuinely empty ceiling and no explicit ask.

## Why
`IssueCredential` only sets the `scopes` claim when it's non-empty (`internal/service/credential.go`), so a token narrowed to zero scopes carries no claim at all — indistinguishable from a legacy token that predates the scopes feature. Downstream, `highflame-shield`'s `checkScopeCeiling` deliberately treats an absent claim as "check not applicable" (a documented backward-compat allowance). The two combine: asking for a scope you don't hold used to produce a token Shield enforces *nothing* against — more permissive than asking for one you do hold.

Closes #340.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] New regression tests (`tests/integration/scope_escalation_test.go`) cover all three grants' refusal, plus two sanity tests pinning the unaffected paths (authorized explicit request, and the no-scope-param default)
- [x] Full suite: `go test ./...` — all packages pass, including existing delegation/subagent scope tests