### PR TITLE
fix: an empty narrowed scope set is a denial, not an omitted request

### DIFF
--- a/internal/handler/authorize.go
+++ b/internal/handler/authorize.go
@@ -424,9 +424,14 @@ func (a *API) authorizeHandler(w http.ResponseWriter, r *http.Request) {
 	// The service layer (IssueAuthCode) does the final intersection
 	// against the client's registered scope set. Here we just combine
 	// what the caller asked for with what the resolver pre-narrowed.
+	// Tested with strings.Fields, not req.Scope != "": IssueAuthCode and
+	// requireGrantableScope both decide "did the caller actually ask" by
+	// parsing the scope string, so a whitespace-only scope must look omitted
+	// here too. Branching on != "" narrowed to an empty set here while the
+	// service still read the request as omitted and fell back to the client's
+	// full registered scopes — wider than sending no scope at all.
 	scopes := principal.Scopes
-	if req.Scope != "" {
-		requested := strings.Fields(req.Scope)
+	if requested := strings.Fields(req.Scope); len(requested) > 0 {
 		if len(scopes) > 0 {
 			scopes = intersectStrings(requested, scopes)
 		} else {

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -694,8 +694,18 @@ func (s *OAuthService) clientCredentials(ctx context.Context, req TokenRequest) 
 	}
 	scopes := narrow(rawRequested, client.Scopes)
 	scopes = narrow(scopes, effectiveAllowedScopes(policy, identity))
-	if err := requireGrantableScope(req.Scope, scopes); err != nil {
-		return nil, err
+
+	// Stricter than the shared requireGrantableScope, which permits an empty
+	// grant when the caller named no scope. That is safe only where an empty
+	// set means "nothing was asked"; here it can also mean the client's
+	// registered scopes and the policy ceiling are disjoint — a denial. There
+	// is no identity or delegation fallback on this path (see the zero-scope
+	// check above), so either way nothing is grantable, and issuing would mint
+	// a token with no `scopes` claim: IssueCredential's dual-read and
+	// EnforcePolicy scope checks are both gated on len(Scopes) > 0, and a
+	// claimless token reads downstream as "no scope ceiling to check".
+	if len(scopes) == 0 {
+		return nil, oauthBadRequest(oautherror.InvalidScope, "requested scopes are not permitted for this identity")
 	}
 
 	issue := IssueRequest{

--- a/tests/integration/scope_escalation_test.go
+++ b/tests/integration/scope_escalation_test.go
@@ -322,3 +322,98 @@ func TestAPIKeyGrant_WhitespaceOnlyScopeTreatedAsOmitted(t *testing.T) {
 	require.Equal(t, http.StatusOK, tokenResp.StatusCode,
 		"a whitespace-only scope must be treated the same as an omitted one, not falsely rejected")
 }
+
+// TestClientCredentials_OmittedScopeNarrowedToEmptyRejected covers the gap
+// requireGrantableScope leaves open on this grant: it permits an empty grant
+// whenever the caller named no scope, but on client_credentials an empty set
+// has a second meaning — the client's registered scopes and the identity
+// policy's ceiling are disjoint, i.e. a denial. There is no identity or
+// delegation fallback here, so nothing is grantable either way, and minting
+// would hand back a token with NO scopes claim: exactly the
+// "Shield enforces nothing" escalation this file exists to close, reached
+// via the omitted-scope path instead of the explicit-request one.
+func TestClientCredentials_OmittedScopeNarrowedToEmptyRejected(t *testing.T) {
+	identityPolicyID := createRichCredentialPolicy(t, map[string]any{
+		"name":                 uid("cc-disjoint-cp"),
+		"allowed_grant_types":  []string{"client_credentials"},
+		"allowed_scopes":       []string{"tools:read"},
+		"max_delegation_depth": 1,
+		"max_ttl_seconds":      3600,
+	}, adminHeaders())
+
+	clientID := uid("cc-disjoint-client")
+	registerIdentityWithPolicy(t, clientID, identityPolicyID, "", nil, adminHeaders())
+	// Registered scopes share nothing with the policy ceiling above.
+	client := registerOAuthClient(t, clientID, []string{"data:read"})
+
+	resp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "client_credentials",
+		"account_id":    testAccountID,
+		"project_id":    testProjectID,
+		"client_id":     client.ClientID,
+		"client_secret": client.ClientSecret,
+		// scope deliberately omitted — the narrowing still resolves to nothing.
+	}, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"a client whose registered scopes are disjoint from the identity policy's ceiling must be refused, not handed a token with no scopes claim")
+	body := decode(t, resp)
+	assert.Equal(t, "invalid_scope", body["error"])
+}
+
+// TestAuthorize_WhitespaceOnlyScopeDoesNotWiden pins the handler side of the
+// same raw-string-vs-parsed-emptiness mismatch as
+// TestAPIKeyGrant_WhitespaceOnlyScopeTreatedAsOmitted. /oauth2/authorize used
+// to branch on `req.Scope != ""` while IssueAuthCode and requireGrantableScope
+// both branch on the PARSED scope, so `scope=" "` narrowed the principal away
+// to an empty set here and then read as an omitted request one layer down —
+// substituting the client's entire registered surface. The result was strictly
+// wider than sending no scope at all.
+func TestAuthorize_WhitespaceOnlyScopeDoesNotWiden(t *testing.T) {
+	clientID := uid("authz-code-scope-whitespace")
+	err := testZeroIDServer.EnsureClient(context.Background(), zeroid.OAuthClientConfig{
+		ClientID:     clientID,
+		Name:         clientID + "-test-client",
+		GrantTypes:   []string{"authorization_code"},
+		Scopes:       []string{"tools:read", "tools:admin"},
+		RedirectURIs: []string{testRedirectURI},
+	})
+	require.NoError(t, err)
+
+	verifier, challenge := buildPKCEPair(t)
+	form := url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {testRedirectURI},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"authz-code-scope-whitespace-state"},
+		"scope":                 {" "},
+		// The principal holds tools:read only; tools:admin is the client's
+		// registered scope that must never leak into the grant.
+		"test_principal_account": {testAccountID},
+		"test_principal_project": {testProjectID},
+		"test_principal_user":    {"user-authz-code-whitespace-test"},
+		"test_principal_scopes":  {"tools:read"},
+	}
+
+	resp := postAuthorize(t, form)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusFound, resp.StatusCode,
+		"a whitespace-only scope must be treated as omitted, not as a request that narrows to nothing")
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	code := loc.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	tokenResp := post(t, "/oauth2/token", map[string]any{
+		"grant_type":    "authorization_code",
+		"client_id":     clientID,
+		"code":          code,
+		"code_verifier": verifier,
+		"redirect_uri":  testRedirectURI,
+	}, nil)
+	require.Equal(t, http.StatusOK, tokenResp.StatusCode)
+	scope, _ := decode(t, tokenResp)["scope"].(string)
+	assert.Equal(t, "tools:read", scope,
+		"the grant must stay at the principal's scopes; tools:admin is the client's registered scope and was never held or requested")
+}


### PR DESCRIPTION
Follow-up to #341. Two paths could still mint a token wider than the caller's authority, both because *"the caller asked for nothing"* and *"the caller was denied everything"* are indistinguishable once a scope set is empty.

## `clientCredentials` — `internal/service/oauth.go`

With `scope` omitted, the chain narrows the client's registered scopes against the identity policy's ceiling. Disjoint sets leave an empty grant, which `requireGrantableScope` permits when no scope was named. `IssueCredential` then skips both the dual-read check and `EnforcePolicy`'s scope check (both gated on `len(Scopes) > 0`) and omits the `scopes` claim entirely — and Shield's `checkScopeCeiling` reads an absent claim as "check not applicable".

Client registered `["data:read"]`, linked identity's policy allows `["tools:read"]`, no `scope` on the request: a hard 400 before #341, a token nothing enforces against after. There is no identity or delegation fallback on this grant, so an empty set is unmintable either way — rejected outright now.

## `/oauth2/authorize` — `internal/handler/authorize.go`

The handler decided "did the caller ask" with `req.Scope != ""` while `IssueAuthCode` and `requireGrantableScope` both decide it by parsing the string. With `scope=%20` the handler narrowed the principal away to an empty set, and the service then read the request as omitted and substituted the client's **entire** registered scope surface — strictly wider than sending no scope at all. Now branches on `strings.Fields`, so both layers agree.

## Tests

Two regression tests in `tests/integration/scope_escalation_test.go`, both verified to fail on `main`:

| Test | On `main` | Here |
|---|---|---|
| `TestClientCredentials_OmittedScopeNarrowedToEmptyRejected` | `200` + claimless token | `400 invalid_scope` |
| `TestAuthorize_WhitespaceOnlyScopeDoesNotWiden` | `tools:read tools:admin` | `tools:read` |

Full suite: 1408 passed across 17 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)