### PR TITLE
fix: refuse clients registered for an auth method we cannot enforce

### DIFF
--- a/internal/service/client_auth_method_test.go
+++ b/internal/service/client_auth_method_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/highflame-ai/zeroid/domain"
+	"github.com/highflame-ai/zeroid/internal/oautherror"
+)
+
+// Tests for rejectUnimplementedClientAuth — the guard that stops a client
+// registered for an unenforceable authentication method from being treated as a
+// public client (zeroid#206 scope item 2).
+//
+// The property under test is narrow and worth stating precisely: it is NOT
+// "private_key_jwt is unsupported". Registration accepts private_key_jwt and
+// stores key material, but derives client_type from the separate `confidential`
+// flag — so such a client lands as client_type=public with an empty secret hash,
+// which is exactly the shape the public-client pass-through allows. Without this
+// guard, choosing key-based authentication yields WEAKER authentication than
+// choosing a shared secret, silently.
+func TestRejectUnimplementedClientAuth(t *testing.T) {
+	t.Parallel()
+
+	allowed := []string{"", "none", "client_secret_post", "client_secret_basic"}
+	for _, method := range allowed {
+		t.Run("allows "+orUnset(method), func(t *testing.T) {
+			err := rejectUnimplementedClientAuth(&domain.OAuthClient{TokenEndpointAuthMethod: method})
+			if err != nil {
+				t.Fatalf("method %q must be allowed — this server enforces it: %v", method, err)
+			}
+		})
+	}
+
+	// The empty string deserves its own statement of intent: it means "unset",
+	// which is what a row predating the column carries. Registration never
+	// writes it, so treating it as allowed preserves legacy data rather than
+	// creating a bypass — an unset method with a stored secret still goes
+	// through secret verification, and without one it is a genuine public
+	// client.
+	t.Run("an unset method is legacy data, not a bypass", func(t *testing.T) {
+		if err := rejectUnimplementedClientAuth(&domain.OAuthClient{}); err != nil {
+			t.Fatalf("an unset method must keep behaving as before: %v", err)
+		}
+	})
+
+	refused := map[string]string{
+		"private_key_jwt":             "the live gap — registration accepts it and stores keys, nothing validates them",
+		"client_secret_jwt":           "dropped in OAuth 2.1, will not be implemented",
+		"tls_client_auth":             "deferred pending an mTLS termination story",
+		"self_signed_tls_client_auth": "same family as tls_client_auth",
+		"totally_made_up":             "registration stores the method verbatim, so unknown values are reachable",
+	}
+	for method, why := range refused {
+		t.Run("refuses "+method, func(t *testing.T) {
+			err := rejectUnimplementedClientAuth(&domain.OAuthClient{
+				// The shape registration actually produces for these: public
+				// type, no secret. That is the combination that would otherwise
+				// be waved through.
+				ClientType:              "public",
+				ClientSecret:            "",
+				TokenEndpointAuthMethod: method,
+			})
+			oe := wantOAuthError(t, err, oautherror.InvalidClient)
+			// invalid_client, not invalid_request: the client is well-formed and
+			// known, it simply cannot be authenticated as registered
+			// (RFC 6749 §5.2).
+			if oe.HTTPStatus != 401 {
+				t.Fatalf("expected 401 for %s (%s), got %d", method, why, oe.HTTPStatus)
+			}
+		})
+	}
+
+	t.Run("a nil client is not this guard's business", func(t *testing.T) {
+		// Callers already handle "no client resolved" separately; returning an
+		// auth error here would convert an unrelated state into a 401.
+		if err := rejectUnimplementedClientAuth(nil); err != nil {
+			t.Fatalf("nil client must pass through: %v", err)
+		}
+	})
+}
+
+func orUnset(s string) string {
+	if s == "" {
+		return "(unset)"
+	}
+	return s
+}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -2866,6 +2866,64 @@ func (s *OAuthService) parseWIMSEURI(wimseURI string) (accountID, projectID stri
 	return parts[0], parts[1], nil
 }
 
+// implementedClientAuthMethods are the token-endpoint client authentication
+// methods this server can actually ENFORCE.
+//
+// The empty string is included deliberately: it means "unset", which is what a
+// row predating the column carries. Registration never writes it (it defaults
+// to none or client_secret_basic), so an empty value is legacy data and must
+// keep behaving exactly as it did.
+//
+// private_key_jwt, client_secret_jwt and tls_client_auth are ABSENT because
+// nothing in this codebase validates them. private_key_jwt is the live gap
+// (zeroid#206) — registration accepts it and stores key material today;
+// client_secret_jwt is dropped in OAuth 2.1 and will not be added;
+// tls_client_auth (RFC 8705) is deferred pending an mTLS termination story.
+var implementedClientAuthMethods = map[string]bool{
+	"":                    true,
+	"none":                true,
+	"client_secret_post":  true,
+	"client_secret_basic": true,
+}
+
+// rejectUnimplementedClientAuth refuses a client whose REGISTERED
+// token_endpoint_auth_method this server cannot enforce.
+//
+// This closes a silent downgrade, not a missing feature. Registration accepts
+// `token_endpoint_auth_method: private_key_jwt` and stores the client's key
+// material, but sets client_type from the separate `confidential` flag — so a
+// key-based client lands as client_type=public with an empty secret hash, which
+// is precisely the shape verifyConfidentialClientAuth waves through. The result
+// is that a client registered for key-based authentication authenticates with
+// NOTHING on authorization_code, refresh_token, CIBA redemption, introspection
+// and revocation.
+//
+// The asymmetry is what makes it worth refusing rather than leaving to the
+// eventual implementation: a deployer who chose private_key_jwt specifically to
+// avoid shared secrets ends up with WEAKER authentication than one who chose a
+// secret, with no error on any surface to say so. Failing loudly is strictly
+// better than proceeding unauthenticated, and it cannot regress a working
+// deployment because no such client can be authenticating correctly today —
+// there is no code path that would have checked its key.
+//
+// invalid_client (401) rather than invalid_request: the client is well-formed
+// and known, it simply cannot be authenticated as registered. RFC 6749 §5.2
+// assigns invalid_client to failed or absent client authentication.
+//
+// Interim hardening for zeroid#206 scope item 2, deliberately landed ahead of
+// the RFC 7523 §2.2 client-assertion work it is bundled with there: it has no
+// dependency on that work, and leaving the downgrade open while it is built
+// would be the wrong order.
+func rejectUnimplementedClientAuth(client *domain.OAuthClient) error {
+	if client == nil || implementedClientAuthMethods[client.TokenEndpointAuthMethod] {
+		return nil
+	}
+	return oauthUnauthorized(fmt.Sprintf(
+		"client is registered for token_endpoint_auth_method %q, which this authorization "+
+			"server does not implement; it cannot be authenticated",
+		client.TokenEndpointAuthMethod), nil)
+}
+
 // verifyConfidentialClientAuth enforces RFC 6749 §2.3 / §10.4 client
 // authentication for an already-resolved OAuth client. When the client is
 // CONFIDENTIAL it MUST present and prove its client_secret before any grant
@@ -2881,6 +2939,11 @@ func (s *OAuthService) parseWIMSEURI(wimseURI string) (accountID, projectID stri
 func (s *OAuthService) verifyConfidentialClientAuth(ctx context.Context, client *domain.OAuthClient, clientID, clientSecret string) error {
 	if client == nil {
 		return nil
+	}
+	// Refuse a client registered for an authentication method this server does
+	// not implement, BEFORE the public-client pass-through below.
+	if err := rejectUnimplementedClientAuth(client); err != nil {
+		return err
 	}
 	// A client is confidential if it declares so OR carries a stored secret
 	// hash. The second clause is belt-and-suspenders against an inconsistent
@@ -2956,11 +3019,21 @@ func (s *OAuthService) VerifyPresentedClientAuth(ctx context.Context, clientID, 
 	// safe because redirect_uri binding protects the flow; token INSPECTION
 	// has no equivalent binding, so it stays registry-only.
 	if clientSecret == "" {
-		if _, err := s.oauthClientSvc.GetPublicClient(ctx, clientID); err != nil {
+		publicClient, err := s.oauthClientSvc.GetPublicClient(ctx, clientID)
+		if err != nil {
 			if errors.Is(err, ErrOAuthClientNotFound) {
 				return oauthUnauthorized("client authentication required", nil)
 			}
 			return oauthServerError("client verification failed", err)
+		}
+		// Same downgrade as the grant paths: a client registered for an
+		// unimplementable method lands as public with no secret, so without this
+		// it satisfies the no-secret branch and gets introspection/revocation
+		// with no authentication at all. The secret branch below needs no
+		// equivalent check — such a client has no stored hash, so
+		// VerifyClientSecret fails closed.
+		if err := rejectUnimplementedClientAuth(publicClient); err != nil {
+			return err
 		}
 		return nil
 	}

--- a/tests/integration/client_auth_downgrade_test.go
+++ b/tests/integration/client_auth_downgrade_test.go
@@ -1,0 +1,141 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// End-to-end proof that a client registered for an unenforceable authentication
+// method cannot authenticate at all (zeroid#206 scope item 2).
+//
+// The bug this closes is a SILENT DOWNGRADE, not a missing feature. Registration
+// accepts `token_endpoint_auth_method: private_key_jwt` and stores the client's
+// key material, but derives client_type from the separate `confidential` flag.
+// So the row lands client_type=public with an empty secret hash — precisely the
+// shape verifyConfidentialClientAuth's public-client pass-through allows. Before
+// this fix, such a client authenticated with NOTHING on authorization_code,
+// refresh_token, CIBA redemption, introspection and revocation.
+//
+// The asymmetry is the reason it is worth failing loudly rather than waiting for
+// the RFC 7523 §2.2 implementation: a deployer who chose private_key_jwt
+// specifically to avoid shared secrets got WEAKER authentication than one who
+// chose a secret, with no error anywhere to say so.
+func TestClientAuthDowngrade_UnimplementedMethodCannotAuthenticate(t *testing.T) {
+	clientID := uid("pkjwt-downgrade")
+
+	// Register exactly the shape that produces the downgrade: confidential
+	// false (so no secret is minted) with an explicit key-based auth method.
+	reg := post(t, adminPath("/oauth/clients"), map[string]any{
+		"client_id":                  clientID,
+		"name":                       clientID + "-client",
+		"confidential":               false,
+		"token_endpoint_auth_method": "private_key_jwt",
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"redirect_uris":              []string{testRedirectURI},
+		"scopes":                     []string{"data:read"},
+	}, nil)
+	require.Equal(t, http.StatusCreated, reg.StatusCode,
+		"registration still accepts private_key_jwt — this test asserts what happens at AUTH time, "+
+			"not that registration rejects it (that is scope item 3)")
+	body := decode(t, reg)
+	_ = reg.Body.Close()
+
+	// Pin the downgraded shape itself, so this test keeps meaning something if
+	// registration behaviour changes: no secret was issued, and the client is
+	// public despite having been registered for key-based authentication.
+	assert.Empty(t, body["client_secret"],
+		"no secret is minted for a key-based client — which is exactly why the "+
+			"public-client pass-through used to accept it")
+
+	t.Run("authorization_code exchange with no client authentication is refused", func(t *testing.T) {
+		verifier, challenge := buildPKCEPair(t)
+		code := buildAuthCode(t, clientID, uid("pkjwt-user"), testRedirectURI, challenge,
+			[]string{"data:read"})
+
+		resp := post(t, "/oauth2/token", map[string]any{
+			"grant_type":    "authorization_code",
+			"client_id":     clientID,
+			"code":          code,
+			"code_verifier": verifier,
+			"redirect_uri":  testRedirectURI,
+			// Deliberately NO client_secret and NO client_assertion. Before the
+			// fix this returned 200 with a token.
+		}, nil)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+			"a client registered for private_key_jwt must not be able to redeem a code "+
+				"with no client authentication whatsoever")
+		got := decode(t, resp)
+		assert.Equal(t, "invalid_client", got["error"],
+			"RFC 6749 §5.2 assigns invalid_client to failed or absent client authentication — "+
+				"the client is well-formed and known, it simply cannot authenticate as registered")
+		assert.Contains(t, got["error_description"], "private_key_jwt",
+			"the refusal should name the method so an integrator can act on it")
+	})
+
+	t.Run("introspection with client_id alone is refused", func(t *testing.T) {
+		// The same downgrade reached token INSPECTION: the no-secret branch
+		// resolves the client as public and returned nil. Introspection has no
+		// redirect_uri binding to fall back on, so this half mattered
+		// independently of token issuance.
+		resp := post(t, "/oauth2/token/introspect", map[string]any{
+			"token":     "zid_at_whatever",
+			"client_id": clientID,
+		}, nil)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+			"a key-based client must not satisfy introspection auth by presenting only its client_id")
+		assert.Equal(t, "invalid_client", decode(t, resp)["error"])
+	})
+}
+
+// TestClientAuthDowngrade_ImplementedMethodsAreUnaffected is the control.
+//
+// Without it, the assertions above would pass against a change that simply broke
+// client authentication for everyone. It also pins the compatibility claim made
+// when this landed: every client in dev1 and prod at the time was registered
+// `token_endpoint_auth_method=none`, so the hardening had no blast radius.
+func TestClientAuthDowngrade_ImplementedMethodsAreUnaffected(t *testing.T) {
+	t.Run("a public client (none) still exchanges a code", func(t *testing.T) {
+		verifier, challenge := buildPKCEPair(t)
+		code := buildAuthCode(t, testMCPClientID, uid("pkjwt-control"), testRedirectURI,
+			challenge, []string{"data:read"})
+
+		resp := post(t, "/oauth2/token", map[string]any{
+			"grant_type":    "authorization_code",
+			"client_id":     testMCPClientID,
+			"code":          code,
+			"code_verifier": verifier,
+			"redirect_uri":  testRedirectURI,
+		}, nil)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"an ordinary public PKCE client must be entirely unaffected")
+		assert.NotEmpty(t, decode(t, resp)["access_token"])
+	})
+
+	t.Run("a confidential client with its secret still gets a token", func(t *testing.T) {
+		ext := uid("pkjwt-conf")
+		registerAgent(t, ext)
+		client := registerOAuthClient(t, ext, []string{"data:read"})
+
+		resp := post(t, "/oauth2/token", map[string]any{
+			"grant_type":    "client_credentials",
+			"account_id":    testAccountID,
+			"project_id":    testProjectID,
+			"client_id":     client.ClientID,
+			"client_secret": client.ClientSecret,
+		}, nil)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"client_secret_basic is implemented and must keep working")
+		assert.NotEmpty(t, decode(t, resp)["access_token"])
+	})
+}


### PR DESCRIPTION
Interim hardening for #206 (scope item 2), deliberately split out from the RFC 7523 §2.2 client-assertion work so a token-issuance bypass isn't left open while that gets built.

## The bug, demonstrated before fixing

Against unmodified `main`, with a client registered `confidential: false, token_endpoint_auth_method: private_key_jwt`:

| Request | Before | After |
|---|---|---|
| `authorization_code` exchange with **no client authentication at all** | **200 — token issued** | 401 `invalid_client` |
| Introspection with `client_id` alone, no secret | **200 — accepted** | 401 `invalid_client` |

The integration test in this PR was run against unmodified code first and fails exactly there, so it demonstrates the bypass rather than merely asserting the fix.

## Why it happens

This is **not** "private_key_jwt is unimplemented". Registration *accepts* it and stores key material, but derives `client_type` from the separate `confidential` flag — `clientType` is assigned first, then only `authMethod` is overridden (`internal/service/oauth_client.go:141-155`). So the row lands `client_type=public` with an empty secret hash, which is precisely the shape this pass-through allows:

```go
if client.ClientType != "confidential" && client.ClientSecret == "" {
    return nil   // no authentication required
}
```

And `TokenEndpointAuthMethod` appeared **nowhere in `internal/service` at auth time** — stored, echoed back on read, advertised in the API enum, never consulted.

## Why now, ahead of the rest of #206

The asymmetry is the argument: a deployer who chose `private_key_jwt` *specifically to avoid shared secrets* got **weaker** authentication than one who chose a secret, with nothing on any surface to say so. Failing loudly has no dependency on the client-assertion implementation, and it's a few lines.

## Scope

Both no-secret paths are guarded — `verifyConfidentialClientAuth` (authorization_code, refresh_token, CIBA redemption) and `VerifyPresentedClientAuth` (introspection, revocation). The secret-bearing path needs no equivalent: such a client has no stored hash, so `VerifyClientSecret` already fails closed — which is also why `client_credentials` was never affected.

The **empty** auth method is deliberately allowed. It means "unset", which is what a row predating the column carries; registration never writes it. An unset method with a stored secret still goes through secret verification, and without one it's a genuine public client — so allowing it preserves legacy data rather than opening a hole.

## Compatibility — no blast radius

Checked both environments *before* writing the fix:

```
dev1  — 6 clients, all token_endpoint_auth_method=none, public, no secret
prod  — 5 clients, all token_endpoint_auth_method=none, public, no secret
```

Nothing live authenticates with a method we don't implement, and nothing could have been — there is no code path that would have verified such a client's key. The control test pins that public-PKCE and `client_secret_basic` clients are unaffected, so these assertions can't pass against a change that simply broke client auth for everyone.

## Not in scope

#206 items 1, 3, 4, 5 (client_assertion validation, registration allow-list, metadata advertisement, DCR support) are untouched and still open. **Registration still accepts `private_key_jwt`** — this changes what happens at authentication time, not at registration.

Worth pairing items 1 and #282 when they're picked up: actor assertions being replayable within their TTL is the same defect class, and item 1 needs single-use `jti` anyway.

## Verification

- `golangci-lint v2.13.2` (CI's version): 0 issues
- Full suite: all 9 packages green
- New integration test verified to **fail** on unmodified `main` (200 vs 401 on both surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
