### PR TITLE
fix: derive client-authentication questions instead of reading client_type (#348)

### DIFF
--- a/domain/client_type_invariant_test.go
+++ b/domain/client_type_invariant_test.go
@@ -1,0 +1,206 @@
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Tests for the client-authentication predicates and the ratchet that keeps the
+// raw `client_type` column out of security decisions (zeroid#348).
+//
+// The invariant `client_type == "public"` used to carry — a public client holds
+// no credential — stopped being true when private_key_jwt landed: such a client
+// holds a real credential while being neither confidential nor secret-bearing.
+// Four separate call sites were patched to compensate, two of them added in the
+// same PR that broke it, and one of those closed a downgrade that implementing
+// private_key_jwt had REOPENED after an earlier fix had already closed it once.
+// The defence was an enumeration, and an enumeration is only as good as the next
+// author's memory.
+
+func TestRequiresClientAuthentication(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		client *OAuthClient
+		want   bool
+		why    string
+	}{
+		"private_key_jwt holds a key": {
+			client: &OAuthClient{TokenEndpointAuthMethod: "private_key_jwt", ClientType: "public"},
+			want:   true,
+			why:    "the whole point: client_type says public, but the client holds a signing key",
+		},
+		"private_key_jwt typed confidential": {
+			client: &OAuthClient{TokenEndpointAuthMethod: "private_key_jwt", ClientType: "confidential"},
+			want:   true,
+			why:    "the DCR-registered shape of the same client must answer identically",
+		},
+		"client_secret_basic": {
+			client: &OAuthClient{TokenEndpointAuthMethod: "client_secret_basic", ClientType: "confidential"},
+			want:   true,
+		},
+		"client_secret_post": {
+			client: &OAuthClient{TokenEndpointAuthMethod: "client_secret_post", ClientType: "confidential"},
+			want:   true,
+		},
+		"none is credential-less": {
+			client: &OAuthClient{TokenEndpointAuthMethod: "none", ClientType: "public"},
+			want:   false,
+			why:    "a public PKCE client proves possession with PKCE, not a credential",
+		},
+		"legacy row, unset method, confidential type": {
+			client: &OAuthClient{ClientType: "confidential"},
+			want:   true,
+			why:    "rows predating the method column must keep behaving as before",
+		},
+		"legacy row, unset method, stored secret": {
+			client: &OAuthClient{ClientSecret: "$2a$10$hash"},
+			want:   true,
+			why:    "a stored secret means it authenticates whatever the type column claims",
+		},
+		"inconsistent row: none + a stored secret": {
+			client: &OAuthClient{TokenEndpointAuthMethod: "none", ClientSecret: "$2a$10$hash"},
+			want:   true,
+			why:    "treating this as credential-less is the unsafe direction — verify the secret",
+		},
+		"legacy row, unset method, no secret": {
+			client: &OAuthClient{ClientType: "public"},
+			want:   false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.client.RequiresClientAuthentication(); got != tc.want {
+				t.Fatalf("got %v, want %v — %s", got, tc.want, tc.why)
+			}
+		})
+	}
+
+	t.Run("a nil client requires nothing", func(t *testing.T) {
+		var c *OAuthClient
+		if c.RequiresClientAuthentication() {
+			t.Fatal("nil must not assert a credential requirement")
+		}
+	})
+}
+
+// The same client must behave identically at every endpoint whichever path
+// registered it — the divergence zeroid#348 was filed for.
+func TestKeyClientBehavesTheSameFromEitherRegistrationPath(t *testing.T) {
+	t.Parallel()
+
+	adminShape := &OAuthClient{TokenEndpointAuthMethod: "private_key_jwt", ClientType: "public"}
+	dcrShape := &OAuthClient{TokenEndpointAuthMethod: "private_key_jwt", ClientType: "confidential"}
+
+	for _, probe := range []struct {
+		name string
+		fn   func(*OAuthClient) bool
+	}{
+		{"RequiresClientAuthentication", (*OAuthClient).RequiresClientAuthentication},
+		{"MayUseInteractiveFlows", (*OAuthClient).MayUseInteractiveFlows},
+		{"UsesPrivateKeyJWT", (*OAuthClient).UsesPrivateKeyJWT},
+	} {
+		if probe.fn(adminShape) != probe.fn(dcrShape) {
+			t.Errorf("%s disagrees between the admin-registered and DCR-registered shape of the same client", probe.name)
+		}
+	}
+}
+
+func TestMayUseInteractiveFlows(t *testing.T) {
+	t.Parallel()
+
+	// Preserved: the inherited pre-CIMD contract still excludes secret-based
+	// confidential clients from the authorize endpoint. Widening that is
+	// deliberately out of scope for zeroid#348 — this test pins it so a future
+	// change to the predicate has to be a deliberate one.
+	secretBased := &OAuthClient{TokenEndpointAuthMethod: "client_secret_basic", ClientType: "confidential"}
+	if secretBased.MayUseInteractiveFlows() {
+		t.Error("a secret-based confidential client must still be refused at /oauth2/authorize")
+	}
+
+	for _, c := range []*OAuthClient{
+		{ClientType: "public", TokenEndpointAuthMethod: "none"},
+		{ClientType: "public", TokenEndpointAuthMethod: "private_key_jwt"},
+		{ClientType: "confidential", TokenEndpointAuthMethod: "private_key_jwt"},
+	} {
+		if !c.MayUseInteractiveFlows() {
+			t.Errorf("client %+v must be able to obtain an authorization code", c)
+		}
+	}
+}
+
+// RATCHET. A bare `ClientType ==` / `!=` comparison outside this package is what
+// zeroid#348 exists to prevent: it reads as "holds no credential", which has not
+// been true since private_key_jwt landed, and the next author who writes one on
+// an auth path writes a silent authentication bypass that looks like correct
+// handling of a public client.
+//
+// Ask the predicates instead. If a genuinely new question needs the raw column,
+// add a named predicate here rather than widening this allowance.
+func TestNoBareClientTypeComparisonsOutsideDomain(t *testing.T) {
+	t.Parallel()
+
+	root := ".."
+	comparison := regexp.MustCompile(`ClientType\s*(==|!=)`)
+
+	var offenders []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // unreadable paths are not this test's business
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "node_modules", "vendor", "cli", "docs":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		// This package is where the predicates live — the comparisons belong here.
+		if filepath.Dir(path) == root+"/domain" || filepath.Dir(path) == "." {
+			return nil
+		}
+		body, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		for i, line := range strings.Split(string(body), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "//") {
+				continue // prose about the column is fine; a branch on it is not
+			}
+			if comparison.MatchString(line) {
+				offenders = append(offenders, filepath.ToSlash(path)+":"+itoa(i+1)+"  "+trimmed)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("bare ClientType comparison(s) outside domain/ — ask a predicate "+
+			"(RequiresClientAuthentication / MayUseInteractiveFlows / UsesPrivateKeyJWT) instead:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/domain/token.go
+++ b/domain/token.go
@@ -152,6 +152,80 @@ type OAuthClient struct {
 	UpdatedAt time.Time `bun:"updated_at"  json:"updated_at"`
 }
 
+// ── Client-authentication predicates ─────────────────────────────────────────
+//
+// `client_type` used to carry a usable implication: a "public" client holds no
+// credential. RFC 7523 §2.2 private_key_jwt broke it (zeroid#206) — such a
+// client holds a real credential, its signing key, while being neither
+// confidential nor secret-bearing. Worse, the value it lands on depends on which
+// path registered it, so it is not even consistently wrong.
+//
+// These predicates exist so that no security decision keys off the raw column
+// again. Each names the question it answers, derives it from the REGISTERED
+// authentication method, and keeps the old column only as a fallback for rows
+// that predate the method being meaningful. Adding a bare `ClientType ==` check
+// on an auth path is what zeroid#348 exists to prevent; a ratchet test enforces
+// it.
+
+// authMethodPrivateKeyJWT is the RFC 7591 token_endpoint_auth_method value for
+// key-based client authentication. Declared here, not in internal/service, so
+// the predicates below can be a property of the type rather than of one package.
+const authMethodPrivateKeyJWT = "private_key_jwt"
+
+// UsesPrivateKeyJWT reports whether this client authenticates with an RFC 7523
+// §2.2 client assertion rather than a shared secret.
+func (c *OAuthClient) UsesPrivateKeyJWT() bool {
+	return c != nil && c.TokenEndpointAuthMethod == authMethodPrivateKeyJWT
+}
+
+// RequiresClientAuthentication reports whether this client MUST prove a
+// credential before a grant proceeds — the question the old
+// `ClientType == "confidential" || ClientSecret != ""` test was reaching for,
+// asked correctly.
+//
+// Derived from the registered method first, because that is the authoritative
+// statement of how the client authenticates. The ClientType/ClientSecret
+// fallback covers rows written before the method column was enforced (it is
+// unset on those), and is belt-and-braces against an inconsistent row carrying a
+// secret with a non-confidential type — which would otherwise skip verification.
+func (c *OAuthClient) RequiresClientAuthentication() bool {
+	if c == nil {
+		return false
+	}
+	switch c.TokenEndpointAuthMethod {
+	case authMethodPrivateKeyJWT, "client_secret_post", "client_secret_basic":
+		return true
+	case "none":
+		// Explicitly credential-less: PKCE is the proof of possession. Fall
+		// through to the fallback anyway — a "none" client that somehow carries
+		// a stored secret is an inconsistent row, and treating it as
+		// credential-less is the unsafe direction.
+	}
+	return c.ClientType == "confidential" || c.ClientSecret != ""
+}
+
+// MayUseInteractiveFlows reports whether this client may obtain an authorization
+// code at /oauth2/authorize.
+//
+// The rule it replaces was `ClientType == "public"`, described in its own
+// comment as the inherited pre-CIMD GetPublicClient contract rather than a
+// reasoned property. That is preserved: a secret-based confidential client still
+// cannot obtain a code here, and widening that is deliberately NOT part of
+// zeroid#348.
+//
+// What changes is that a key-based client qualifies regardless of the
+// client_type its registration path happened to assign. A private_key_jwt client
+// running authorization_code is ordinary OAuth — it authenticates at the token
+// endpoint with its key — and gating it on a column whose value differs between
+// the admin and DCR paths made the same client legal or illegal depending on how
+// it was created.
+func (c *OAuthClient) MayUseInteractiveFlows() bool {
+	if c == nil {
+		return false
+	}
+	return c.ClientType == "public" || c.UsesPrivateKeyJWT()
+}
+
 // ProofToken represents a persisted WIMSE Proof Token (WPT).
 // WPTs are single-use; the nonce column has a DB UNIQUE constraint that provides
 // atomic replay prevention without a separate pre-check query.

--- a/internal/service/backchannel.go
+++ b/internal/service/backchannel.go
@@ -402,7 +402,7 @@ func (s *BackchannelService) CreateAuthRequest(ctx context.Context, in CreateAut
 	if err := requireNonAssertionClientAuth(client); err != nil {
 		return nil, err
 	}
-	if client.ClientType == "confidential" || client.ClientSecret != "" {
+	if client.RequiresClientAuthentication() {
 		if in.ClientSecret == "" {
 			return nil, oauthBadRequest(oautherror.InvalidClient, "client_secret is required for a confidential client")
 		}
@@ -720,7 +720,7 @@ func (s *BackchannelService) Redeem(ctx context.Context, in RedeemInput) (*domai
 		if err := requireNonAssertionClientAuth(client); err != nil {
 			return nil, err
 		}
-		if client.ClientType == "confidential" || client.ClientSecret != "" {
+		if client.RequiresClientAuthentication() {
 			if in.ClientSecret == "" {
 				return nil, oauthBadRequest(oautherror.InvalidClient, "client_secret is required for a confidential client")
 			}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -1818,7 +1818,7 @@ func checkAuthorizeClientPolicy(
 	// and deactivation stays a kill switch. CIMD-synthesized clients are always
 	// active and public (see synthesizeCIMDClient), so this is not a carve-out
 	// they need — it applies to every path.
-	if !client.IsActive || client.ClientType != "public" {
+	if !client.IsActive || !client.MayUseInteractiveFlows() {
 		return false, oauthUnauthorized("unknown or inactive client_id", nil)
 	}
 
@@ -3002,12 +3002,13 @@ func (s *OAuthService) verifyConfidentialClientAuth(ctx context.Context, client 
 	if client.TokenEndpointAuthMethod == clientAuthMethodPrivateKeyJWT {
 		return nil
 	}
-	// A client is confidential if it declares so OR carries a stored secret
-	// hash. The second clause is belt-and-suspenders against an inconsistent
-	// row (secret set but client_type != "confidential"), which would
-	// otherwise skip secret verification and allow an unintended bypass. Same
-	// test the CIBA bc-authorize/redeem paths use.
-	if client.ClientType != "confidential" && client.ClientSecret == "" {
+	// Credential-less (public PKCE) clients pass through — they prove
+	// possession by other means: PKCE on authorization_code, the refresh-token
+	// string itself on refresh_token. The predicate derives this from the
+	// registered method, with the old client_type/secret test surviving inside
+	// it as the fallback for rows predating that column. Same question the CIBA
+	// bc-authorize/redeem paths ask.
+	if !client.RequiresClientAuthentication() {
 		return nil
 	}
 	if clientSecret == "" {

--- a/internal/service/oauth_client.go
+++ b/internal/service/oauth_client.go
@@ -189,6 +189,24 @@ func (s *OAuthClientService) RegisterClient(ctx context.Context, req RegisterCli
 	if err := validateClientAuthMethod(authMethod, req.JWKS, req.JWKSURI, s.allowPrivateJWKSEndpoints); err != nil {
 		return nil, "", err
 	}
+	// A key-based client is CONFIDENTIAL, whichever path registered it
+	// (zeroid#348). client_type was being derived from the separate
+	// `confidential` flag, which for a key client is always false — so the admin
+	// path typed them "public" while DCR hard-coded "confidential", and the same
+	// logical client got a different value depending on how it was created.
+	//
+	// RFC 6749 §2.1 settles which is right: a confidential client is one
+	// "capable of maintaining the confidentiality of their credentials", and a
+	// client holding a private key is exactly that. The read paths no longer key
+	// off this column directly, so it is no longer load-bearing — but leaving it
+	// inconsistent would keep the trap baited for the next reader.
+	//
+	// No migration accompanies this: a census of dev1 and prod at the time of
+	// zeroid#206 found every client registered token_endpoint_auth_method=none,
+	// so no key-based row exists to backfill.
+	if authMethod == clientAuthMethodPrivateKeyJWT {
+		clientType = "confidential"
+	}
 	// A key-based client must NOT also carry a secret. `confidential` and
 	// `token_endpoint_auth_method` are independent inputs, and the block above
 	// mints a secret off the former before the latter is even read — so


### PR DESCRIPTION
Closes #348. Follow-up to #347, which surfaced the problem and deliberately did not fold the fix in.

## The problem

`client_type` used to carry a usable implication: **a `public` client holds no credential.** `private_key_jwt` broke it — such a client holds a real credential, its signing key, while being neither `confidential` nor secret-bearing.

#347 patched four call sites to compensate. Two of those patches were added *in that same PR*, and one of them closed an introspection downgrade that implementing `private_key_jwt` had **reopened** after #346 had already closed it once. That history is the argument: this exact invariant has already produced one regression, so "every branch is covered today" is a weaker guarantee than it sounds. `ClientType == "public"` still *reads* as "holds no credential", so the next branch written on it is a silent authentication bypass that looks like correct handling of a public client.

## The fix

Three named predicates on `domain.OAuthClient`, answering the three questions those sites were actually asking — derived from the **registered authentication method**, not the stored column:

| Predicate | Question | Replaces |
|---|---|---|
| `RequiresClientAuthentication()` | must this client prove a credential? | `ClientType == "confidential" \|\| ClientSecret != ""` (×3) |
| `MayUseInteractiveFlows()` | may it obtain an authorization code? | `ClientType != "public"` |
| `UsesPrivateKeyJWT()` | does it authenticate with an assertion? | — |

Each keeps the old `client_type`/`client_secret` test **inside** it as the fallback for rows written before the method column was enforced, so legacy rows behave exactly as before.

**No behaviour changes for any client that exists today.** The full suite — including the `private_key_jwt` integration coverage from #206 — is green unchanged.

## Two deliberate non-changes, pinned by tests

- A **secret-based confidential client is still refused** at `/oauth2/authorize`. That restriction describes itself in its own comment as the inherited pre-CIMD `GetPublicClient` contract rather than a reasoned property; widening it is not this change's business, and a test now fails if someone does it accidentally.
- What *does* change there: a **key-based client qualifies regardless of registration path**. A `private_key_jwt` client running `authorization_code` is ordinary OAuth, and gating it on a column whose value differed between the admin and DCR paths made the same client legal or illegal depending on how it was created. That was acceptance criterion 2.

## Write side converged

`RegisterClient` now types a key-based client `confidential` whichever flag it was registered with, matching DCR. RFC 6749 §2.1 settles which is right — a confidential client is one "capable of maintaining the confidentiality of their credentials", which a key holder plainly is.

The read paths no longer depend on the column, so this is no longer load-bearing; leaving it inconsistent would just keep the trap baited. **No migration:** the dev1/prod census taken during #206 found every client registered `token_endpoint_auth_method=none`, so there is no key-based row to backfill.

## The ratchet

A test walks the tree and fails on any bare `ClientType ==` / `!=` outside `domain/`, naming file and line. That is acceptance criterion 3, and it is what actually prevents the regression rather than hoping the next author reads the comment.

Verified non-vacuous: I reintroduced the original comparison and confirmed it fires with `../internal/service/oauth.go:3011`, then restored it.

## Acceptance criteria

- [x] No security decision keys off `ClientType` without accounting for `token_endpoint_auth_method`
- [x] A `private_key_jwt` client registered via admin and via DCR behave identically at every endpoint
- [x] A regression test that fails if a new bare `ClientType` branch is introduced

## Verification

`go build`, `go vet`, `gofmt`, and `golangci-lint` v2.13.2 (the version CI pins) all clean. Full suite green including the ~52s integration run against testcontainers Postgres.
